### PR TITLE
Use controller runtime methods

### DIFF
--- a/controllers/ssp_controller.go
+++ b/controllers/ssp_controller.go
@@ -110,7 +110,7 @@ func initialize(request *common.Request) (bool, error) {
 	changed := false
 
 	if !isBeingDeleted(request.Instance) {
-		if !hasFinalizer(request.Instance, finalizerName) {
+		if !controllerutil.ContainsFinalizer(request.Instance, finalizerName) {
 			controllerutil.AddFinalizer(request.Instance, finalizerName)
 			changed = true
 		}
@@ -124,7 +124,7 @@ func initialize(request *common.Request) (bool, error) {
 }
 
 func cleanup(request *common.Request) error {
-	if !hasFinalizer(request.Instance, finalizerName) {
+	if !controllerutil.ContainsFinalizer(request.Instance, finalizerName) {
 		return nil
 	}
 
@@ -135,15 +135,6 @@ func cleanup(request *common.Request) error {
 
 	controllerutil.RemoveFinalizer(request.Instance, finalizerName)
 	return request.Client.Update(request.Context, request.Instance)
-}
-
-func hasFinalizer(object metav1.Object, finalizer string) bool {
-	for _, f := range object.GetFinalizers() {
-		if finalizer == f {
-			return true
-		}
-	}
-	return false
 }
 
 func (r *SSPReconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/internal/common/resource_test.go
+++ b/internal/common/resource_test.go
@@ -84,7 +84,7 @@ var _ = Describe("Create or update resource", func() {
 		key, err := client.ObjectKeyFromObject(newTestResource(namespace))
 		Expect(err).ToNot(HaveOccurred())
 
-		found := newEmptyResource()
+		found := &v1.Service{}
 		Expect(request.Client.Get(request.Context, key, found)).ToNot(HaveOccurred())
 
 		Expect(found.GetOwnerReferences()).To(HaveLen(1))
@@ -96,7 +96,6 @@ var _ = Describe("Create or update resource", func() {
 	It("should set owner annotations", func() {
 		Expect(CreateOrUpdateClusterResource(&request,
 			newTestResource(""),
-			newEmptyResource(),
 			func(expected, found controllerutil.Object) {
 				found.(*v1.Service).Spec = expected.(*v1.Service).Spec
 			},
@@ -105,7 +104,7 @@ var _ = Describe("Create or update resource", func() {
 		key, err := client.ObjectKeyFromObject(newTestResource(""))
 		Expect(err).ToNot(HaveOccurred())
 
-		found := newEmptyResource()
+		found := &v1.Service{}
 		Expect(request.Client.Get(request.Context, key, found)).ToNot(HaveOccurred())
 
 		Expect(found.GetAnnotations()).To(HaveKeyWithValue(libhandler.TypeAnnotation, "SSP.ssp.kubevirt.io"))
@@ -116,7 +115,6 @@ var _ = Describe("Create or update resource", func() {
 func createOrUpdateTestResource(request *Request) error {
 	return CreateOrUpdateResource(request,
 		newTestResource(namespace),
-		newEmptyResource(),
 		func(expected, found controllerutil.Object) {
 			found.(*v1.Service).Spec = expected.(*v1.Service).Spec
 		},
@@ -152,15 +150,11 @@ func newTestResource(namespace string) *v1.Service {
 	}
 }
 
-func newEmptyResource() *v1.Service {
-	return &v1.Service{}
-}
-
 func expectEqualResourceExists(resource controllerutil.Object, request *Request) {
 	key, err := client.ObjectKeyFromObject(resource)
 	Expect(err).ToNot(HaveOccurred())
 
-	found := newEmptyResource()
+	found := newEmptyResource(resource)
 	Expect(request.Client.Get(request.Context, key, found)).ToNot(HaveOccurred())
 
 	resource.SetResourceVersion(found.GetResourceVersion())

--- a/internal/common/resource_test.go
+++ b/internal/common/resource_test.go
@@ -49,6 +49,10 @@ var _ = Describe("Create or update resource", func() {
 			Scheme:  s,
 			Context: context.Background(),
 			Instance: &ssp.SSP{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "SSP",
+					APIVersion: ssp.GroupVersion.String(),
+				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      name,
 					Namespace: namespace,

--- a/internal/common/resource_test.go
+++ b/internal/common/resource_test.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -77,7 +78,7 @@ var _ = Describe("Create or update resource", func() {
 		Expect(CreateOrUpdateResource(&request,
 			newTestResource(namespace),
 			newEmptyResource(),
-			func(newRes Resource, foundRes Resource) bool {
+			func(newRes controllerutil.Object, foundRes controllerutil.Object) bool {
 				newService := newRes.(*v1.Service)
 				foundService := foundRes.(*v1.Service)
 				foundService.Spec = newService.Spec
@@ -158,7 +159,7 @@ func newEmptyResource() *v1.Service {
 	return &v1.Service{}
 }
 
-func expectEqualResourceExists(resource Resource, request Request) {
+func expectEqualResourceExists(resource controllerutil.Object, request Request) {
 	key, err := client.ObjectKeyFromObject(resource)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/internal/operands/metrics/reconcile.go
+++ b/internal/operands/metrics/reconcile.go
@@ -1,8 +1,6 @@
 package metrics
 
 import (
-	"reflect"
-
 	promv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -22,13 +20,7 @@ func Reconcile(request *common.Request) error {
 	return common.CreateOrUpdateResource(request,
 		newPrometheusRule(request.Namespace),
 		&promv1.PrometheusRule{},
-		func(newRes controllerutil.Object, foundRes controllerutil.Object) bool {
-			newRule := newRes.(*promv1.PrometheusRule)
-			foundRule := foundRes.(*promv1.PrometheusRule)
-			if !reflect.DeepEqual(newRule.Spec, foundRule.Spec) {
-				foundRule.Spec = newRule.Spec
-				return true
-			}
-			return false
+		func(newRes, foundRes controllerutil.Object) {
+			foundRes.(*promv1.PrometheusRule).Spec = newRes.(*promv1.PrometheusRule).Spec
 		})
 }

--- a/internal/operands/metrics/reconcile.go
+++ b/internal/operands/metrics/reconcile.go
@@ -19,7 +19,6 @@ func WatchTypes() []runtime.Object {
 func Reconcile(request *common.Request) error {
 	return common.CreateOrUpdateResource(request,
 		newPrometheusRule(request.Namespace),
-		&promv1.PrometheusRule{},
 		func(newRes, foundRes controllerutil.Object) {
 			foundRes.(*promv1.PrometheusRule).Spec = newRes.(*promv1.PrometheusRule).Spec
 		})

--- a/internal/operands/metrics/reconcile.go
+++ b/internal/operands/metrics/reconcile.go
@@ -7,6 +7,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"kubevirt.io/ssp-operator/internal/common"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 func AddWatchTypesToScheme(s *runtime.Scheme) error {
@@ -21,7 +22,7 @@ func Reconcile(request *common.Request) error {
 	return common.CreateOrUpdateResource(request,
 		newPrometheusRule(request.Namespace),
 		&promv1.PrometheusRule{},
-		func(newRes common.Resource, foundRes common.Resource) bool {
+		func(newRes controllerutil.Object, foundRes controllerutil.Object) bool {
 			newRule := newRes.(*promv1.PrometheusRule)
 			foundRule := foundRes.(*promv1.PrometheusRule)
 			if !reflect.DeepEqual(newRule.Spec, foundRule.Spec) {

--- a/internal/operands/metrics/reconcile_test.go
+++ b/internal/operands/metrics/reconcile_test.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -60,7 +61,7 @@ var _ = Describe("Metrics operand", func() {
 	})
 })
 
-func expectResourceExists(resource common.Resource, request common.Request) {
+func expectResourceExists(resource controllerutil.Object, request common.Request) {
 	key, err := client.ObjectKeyFromObject(resource)
 	Expect(err).ToNot(HaveOccurred())
 	Expect(request.Client.Get(request.Context, key, resource)).ToNot(HaveOccurred())

--- a/internal/operands/metrics/reconcile_test.go
+++ b/internal/operands/metrics/reconcile_test.go
@@ -48,6 +48,10 @@ var _ = Describe("Metrics operand", func() {
 			Scheme:  s,
 			Context: context.Background(),
 			Instance: &ssp.SSP{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "SSP",
+					APIVersion: ssp.GroupVersion.String(),
+				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      name,
 					Namespace: namespace,

--- a/internal/operands/template-validator/reconcile.go
+++ b/internal/operands/template-validator/reconcile.go
@@ -65,7 +65,6 @@ func Cleanup(request *common.Request) error {
 func reconcileClusterRole(request *common.Request) error {
 	return common.CreateOrUpdateClusterResource(request,
 		newClusterRole(request.Namespace),
-		&rbac.ClusterRole{},
 		func(newRes, foundRes controllerutil.Object) {
 			foundRes.(*rbac.ClusterRole).Rules = newRes.(*rbac.ClusterRole).Rules
 		})
@@ -74,14 +73,12 @@ func reconcileClusterRole(request *common.Request) error {
 func reconcileServiceAccount(request *common.Request) error {
 	return common.CreateOrUpdateResource(request,
 		newServiceAccount(request.Namespace),
-		&v1.ServiceAccount{},
 		func(_, _ controllerutil.Object) {})
 }
 
 func reconcileClusterRoleBinding(request *common.Request) error {
 	return common.CreateOrUpdateClusterResource(request,
 		newClusterRoleBinding(request.Namespace),
-		&rbac.ClusterRoleBinding{},
 		func(newRes, foundRes controllerutil.Object) {
 			newBinding := newRes.(*rbac.ClusterRoleBinding)
 			foundBinding := foundRes.(*rbac.ClusterRoleBinding)
@@ -93,7 +90,6 @@ func reconcileClusterRoleBinding(request *common.Request) error {
 func reconcileService(request *common.Request) error {
 	return common.CreateOrUpdateResource(request,
 		newService(request.Namespace),
-		&v1.Service{},
 		func(newRes, foundRes controllerutil.Object) {
 			newService := newRes.(*v1.Service)
 			foundService := foundRes.(*v1.Service)
@@ -112,7 +108,6 @@ func reconcileDeployment(request *common.Request) error {
 	addPlacementFields(deployment, validatorSpec)
 	return common.CreateOrUpdateResource(request,
 		deployment,
-		&apps.Deployment{},
 		func(newRes, foundRes controllerutil.Object) {
 			foundRes.(*apps.Deployment).Spec = newRes.(*apps.Deployment).Spec
 		})
@@ -128,7 +123,6 @@ func addPlacementFields(deployment *apps.Deployment, validatorSpec *ssp.Template
 func reconcileValidatingWebhook(request *common.Request) error {
 	return common.CreateOrUpdateClusterResource(request,
 		newValidatingWebhook(request.Namespace),
-		&admission.ValidatingWebhookConfiguration{},
 		func(newRes, foundRes controllerutil.Object) {
 			newWebhookConf := newRes.(*admission.ValidatingWebhookConfiguration)
 			foundWebhookConf := foundRes.(*admission.ValidatingWebhookConfiguration)

--- a/internal/operands/template-validator/reconcile.go
+++ b/internal/operands/template-validator/reconcile.go
@@ -10,6 +10,7 @@ import (
 	rbac "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	ssp "kubevirt.io/ssp-operator/api/v1alpha1"
 	"kubevirt.io/ssp-operator/internal/common"
@@ -48,7 +49,7 @@ func Reconcile(request *common.Request) error {
 }
 
 func Cleanup(request *common.Request) error {
-	for _, obj := range []common.Resource{
+	for _, obj := range []controllerutil.Object{
 		newClusterRole(request.Namespace),
 		newClusterRoleBinding(request.Namespace),
 		newValidatingWebhook(request.Namespace),
@@ -66,7 +67,7 @@ func reconcileClusterRole(request *common.Request) error {
 	return common.CreateOrUpdateClusterResource(request,
 		newClusterRole(request.Namespace),
 		&rbac.ClusterRole{},
-		func(newRes common.Resource, foundRes common.Resource) bool {
+		func(newRes controllerutil.Object, foundRes controllerutil.Object) bool {
 			newRole := newRes.(*rbac.ClusterRole)
 			foundRole := foundRes.(*rbac.ClusterRole)
 			if !reflect.DeepEqual(newRole.Rules, foundRole.Rules) {
@@ -88,7 +89,7 @@ func reconcileClusterRoleBinding(request *common.Request) error {
 	return common.CreateOrUpdateClusterResource(request,
 		newClusterRoleBinding(request.Namespace),
 		&rbac.ClusterRoleBinding{},
-		func(newRes common.Resource, foundRes common.Resource) bool {
+		func(newRes controllerutil.Object, foundRes controllerutil.Object) bool {
 			newBinding := newRes.(*rbac.ClusterRoleBinding)
 			foundBinding := foundRes.(*rbac.ClusterRoleBinding)
 			if !reflect.DeepEqual(newBinding.RoleRef, foundBinding.RoleRef) ||
@@ -105,7 +106,7 @@ func reconcileService(request *common.Request) error {
 	return common.CreateOrUpdateResource(request,
 		newService(request.Namespace),
 		&v1.Service{},
-		func(newRes common.Resource, foundRes common.Resource) bool {
+		func(newRes controllerutil.Object, foundRes controllerutil.Object) bool {
 			newService := newRes.(*v1.Service)
 			foundService := foundRes.(*v1.Service)
 
@@ -128,7 +129,7 @@ func reconcileDeployment(request *common.Request) error {
 	return common.CreateOrUpdateResource(request,
 		deployment,
 		&apps.Deployment{},
-		func(newRes common.Resource, foundRes common.Resource) bool {
+		func(newRes controllerutil.Object, foundRes controllerutil.Object) bool {
 			newDep := newRes.(*apps.Deployment)
 			foundDep := foundRes.(*apps.Deployment)
 			if !reflect.DeepEqual(newDep.Spec, foundDep.Spec) {
@@ -150,7 +151,7 @@ func reconcileValidatingWebhook(request *common.Request) error {
 	return common.CreateOrUpdateClusterResource(request,
 		newValidatingWebhook(request.Namespace),
 		&admission.ValidatingWebhookConfiguration{},
-		func(newRes common.Resource, foundRes common.Resource) bool {
+		func(newRes controllerutil.Object, foundRes controllerutil.Object) bool {
 			newWebhookConf := newRes.(*admission.ValidatingWebhookConfiguration)
 			foundWebhookConf := foundRes.(*admission.ValidatingWebhookConfiguration)
 

--- a/internal/operands/template-validator/reconcile_test.go
+++ b/internal/operands/template-validator/reconcile_test.go
@@ -48,6 +48,10 @@ var _ = Describe("Template validator operand", func() {
 			Scheme:  s,
 			Context: context.Background(),
 			Instance: &ssp.SSP{
+				TypeMeta: meta.TypeMeta{
+					Kind:       "SSP",
+					APIVersion: ssp.GroupVersion.String(),
+				},
 				ObjectMeta: meta.ObjectMeta{
 					Name:      name,
 					Namespace: namespace,

--- a/internal/operands/template-validator/reconcile_test.go
+++ b/internal/operands/template-validator/reconcile_test.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -120,13 +121,13 @@ var _ = Describe("Template validator operand", func() {
 	})
 })
 
-func expectResourceExists(resource common.Resource, request common.Request) {
+func expectResourceExists(resource controllerutil.Object, request common.Request) {
 	key, err := client.ObjectKeyFromObject(resource)
 	Expect(err).ToNot(HaveOccurred())
 	Expect(request.Client.Get(request.Context, key, resource)).ToNot(HaveOccurred())
 }
 
-func expectResourceNotExists(resource common.Resource, request common.Request) {
+func expectResourceNotExists(resource controllerutil.Object, request common.Request) {
 	key, err := client.ObjectKeyFromObject(resource)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/tests/validator_test.go
+++ b/tests/validator_test.go
@@ -16,9 +16,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	sspv1alpha1 "kubevirt.io/ssp-operator/api/v1alpha1"
-	"kubevirt.io/ssp-operator/internal/common"
 	validator "kubevirt.io/ssp-operator/internal/operands/template-validator"
 )
 
@@ -296,11 +296,11 @@ func updateSsp(updateFunc func(foundSsp *sspv1alpha1.SSP)) {
 type testResource struct {
 	Name       string
 	Namsespace string
-	resource   common.Resource
+	resource   controllerutil.Object
 }
 
-func (r *testResource) NewResource() common.Resource {
-	return r.resource.DeepCopyObject().(common.Resource)
+func (r *testResource) NewResource() controllerutil.Object {
+	return r.resource.DeepCopyObject().(controllerutil.Object)
 }
 
 func (r *testResource) GetKey() client.ObjectKey {


### PR DESCRIPTION
Some of the current code reimplements logic from `controller-runtime` library. This PR uses the library code instead.

When writing the code, I did not notice that similar functions already exist in the library.