### PR TITLE
Temporarily skip build container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,11 @@ build-functests:
 run-functest:
 	./hack/run-functest.sh
 
-functest: generate fmt vet manifests build-functests run-functest
+# TODO - skipping build container for functests until OCP CI is ready
+#functest: generate fmt vet manifests build-functests run-functest
+
+functest: generate fmt vet manifests
+	go test -coverprofile cover.out ./tests/...
 
 # Build manager binary
 manager: generate fmt vet

--- a/README.md
+++ b/README.md
@@ -48,6 +48,6 @@ These are the steps:
 ```shell
 make install         # Install CRDs to the cluster
 make run             # Start the operator locally
-go test ./tests/...  # Execute functional tests
+make functest        # Execute functional tests
 make uninstall       # Remove CRDs from the cluster
 ```

--- a/controllers/ssp_controller.go
+++ b/controllers/ssp_controller.go
@@ -19,7 +19,7 @@ package controllers
 import (
 	"context"
 	"reflect"
-	
+
 	"github.com/go-logr/logr"
 	libhandler "github.com/operator-framework/operator-lib/handler"
 	"k8s.io/apimachinery/pkg/api/errors"

--- a/internal/operands/template-validator/reconcile.go
+++ b/internal/operands/template-validator/reconcile.go
@@ -9,8 +9,8 @@ import (
 	rbac "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	lifecycleapi "kubevirt.io/controller-lifecycle-operator-sdk/pkg/sdk/api"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"kubevirt.io/ssp-operator/internal/common"
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
Temporarily skip building tests in a container until OCP CI is ready.
It will simplify testing CI scripts.

**Release note**:
```release-note
NONE
```
