### PR TITLE
Add status phase and conditions

### DIFF
--- a/controllers/ssp_controller.go
+++ b/controllers/ssp_controller.go
@@ -18,13 +18,18 @@ package controllers
 
 import (
 	"context"
+	"fmt"
+	"reflect"
+
 	"github.com/go-logr/logr"
+	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
 	libhandler "github.com/operator-framework/operator-lib/handler"
+	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"reflect"
+	lifecycleapi "kubevirt.io/controller-lifecycle-operator-sdk/pkg/sdk/api"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -96,8 +101,8 @@ func (r *SSPReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		ResourceVersionCache: r.SubresourceCache,
 	}
 
-	updated, err := initialize(sspRequest)
-	if updated || err != nil {
+	if !isInitialized(sspRequest.Instance) {
+		err := initialize(sspRequest)
 		// No need to requeue here, because
 		// the update will trigger reconciliation again
 		return ctrl.Result{}, err
@@ -112,13 +117,13 @@ func (r *SSPReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		return ctrl.Result{}, nil
 	}
 
-	for _, operand := range sspOperands {
-		if err := operand.Reconcile(sspRequest); err != nil {
-			return ctrl.Result{}, err
-		}
+	statuses, err := reconcileOperands(sspRequest)
+	if err != nil {
+		return ctrl.Result{}, err
 	}
 
-	return ctrl.Result{}, nil
+	err = updateStatus(sspRequest, statuses)
+	return ctrl.Result{}, err
 }
 
 func (r *SSPReconciler) clearCacheIfNeeded(sspObj *ssp.SSP) {
@@ -137,37 +142,169 @@ func isBeingDeleted(object metav1.Object) bool {
 	return !object.GetDeletionTimestamp().IsZero()
 }
 
-func initialize(request *common.Request) (bool, error) {
-	changed := false
+func isInitialized(ssp *ssp.SSP) bool {
+	return isBeingDeleted(ssp) || ssp.Status.Phase != lifecycleapi.PhaseEmpty
+}
 
-	if !isBeingDeleted(request.Instance) {
-		if !controllerutil.ContainsFinalizer(request.Instance, finalizerName) {
-			controllerutil.AddFinalizer(request.Instance, finalizerName)
-			changed = true
-		}
+func initialize(request *common.Request) error {
+	controllerutil.AddFinalizer(request.Instance, finalizerName)
+	err := request.Client.Update(request.Context, request.Instance)
+	if err != nil {
+		return err
 	}
 
-	var err error
-	if changed {
-		err = request.Client.Update(request.Context, request.Instance)
-	}
-	return changed, err
+	request.Instance.Status.Phase = lifecycleapi.PhaseDeploying
+	return request.Client.Status().Update(request.Context, request.Instance)
 }
 
 func cleanup(request *common.Request) error {
-	if !controllerutil.ContainsFinalizer(request.Instance, finalizerName) {
-		return nil
-	}
-
-	for _, operand := range sspOperands {
-		err := operand.Cleanup(request)
+	if controllerutil.ContainsFinalizer(request.Instance, finalizerName) {
+		request.Instance.Status.Phase = lifecycleapi.PhaseDeleting
+		err := request.Client.Status().Update(request.Context, request.Instance)
+		if err != nil {
+			return err
+		}
+		for _, operand := range sspOperands {
+			err = operand.Cleanup(request)
+			if err != nil {
+				return err
+			}
+		}
+		controllerutil.RemoveFinalizer(request.Instance, finalizerName)
+		err = request.Client.Update(request.Context, request.Instance)
 		if err != nil {
 			return err
 		}
 	}
 
-	controllerutil.RemoveFinalizer(request.Instance, finalizerName)
-	return request.Client.Update(request.Context, request.Instance)
+	request.Instance.Status.Phase = lifecycleapi.PhaseDeleted
+	err := request.Client.Status().Update(request.Context, request.Instance)
+	if errors.IsConflict(err) || errors.IsNotFound(err) {
+		// These errors are ignored. They can happen if the CR was removed
+		// before the status update call is executed.
+		return nil
+	}
+	return err
+}
+
+func reconcileOperands(sspRequest *common.Request) ([]common.ResourceStatus, error) {
+	allStatuses := make([]common.ResourceStatus, 0, len(sspOperands))
+	for _, operand := range sspOperands {
+		statuses, err := operand.Reconcile(sspRequest)
+		if err != nil {
+			return nil, err
+		}
+		allStatuses = append(allStatuses, statuses...)
+	}
+	return allStatuses, nil
+}
+
+func updateStatus(request *common.Request, statuses []common.ResourceStatus) error {
+	notAvailable := make([]common.ResourceStatus, 0, len(statuses))
+	progressing := make([]common.ResourceStatus, 0, len(statuses))
+	degraded := make([]common.ResourceStatus, 0, len(statuses))
+	for _, status := range statuses {
+		if status.NotAvailable != nil {
+			notAvailable = append(notAvailable, status)
+		}
+		if status.Progressing != nil {
+			progressing = append(progressing, status)
+		}
+		if status.Degraded != nil {
+			degraded = append(degraded, status)
+		}
+	}
+
+	sspStatus := &request.Instance.Status
+	switch len(notAvailable) {
+	case 0:
+		conditionsv1.SetStatusCondition(&sspStatus.Conditions, conditionsv1.Condition{
+			Type:    conditionsv1.ConditionAvailable,
+			Status:  v1.ConditionTrue,
+			Reason:  "available",
+			Message: "All SSP resources are available",
+		})
+	case 1:
+		status := notAvailable[0]
+		conditionsv1.SetStatusCondition(&sspStatus.Conditions, conditionsv1.Condition{
+			Type:    conditionsv1.ConditionAvailable,
+			Status:  v1.ConditionFalse,
+			Reason:  "available",
+			Message: prefixResourceTypeAndName(*status.NotAvailable, status.Resource),
+		})
+	default:
+		conditionsv1.SetStatusCondition(&sspStatus.Conditions, conditionsv1.Condition{
+			Type:    conditionsv1.ConditionAvailable,
+			Status:  v1.ConditionFalse,
+			Reason:  "available",
+			Message: fmt.Sprintf("%d SSP resources are not available", len(notAvailable)),
+		})
+	}
+
+	switch len(progressing) {
+	case 0:
+		conditionsv1.SetStatusCondition(&sspStatus.Conditions, conditionsv1.Condition{
+			Type:    conditionsv1.ConditionProgressing,
+			Status:  v1.ConditionFalse,
+			Reason:  "progressing",
+			Message: "No SSP resources are progressing",
+		})
+	case 1:
+		status := progressing[0]
+		conditionsv1.SetStatusCondition(&sspStatus.Conditions, conditionsv1.Condition{
+			Type:    conditionsv1.ConditionProgressing,
+			Status:  v1.ConditionTrue,
+			Reason:  "progressing",
+			Message: prefixResourceTypeAndName(*status.Progressing, status.Resource),
+		})
+	default:
+		conditionsv1.SetStatusCondition(&sspStatus.Conditions, conditionsv1.Condition{
+			Type:    conditionsv1.ConditionProgressing,
+			Status:  v1.ConditionTrue,
+			Reason:  "progressing",
+			Message: fmt.Sprintf("%d SSP resources are progressing", len(progressing)),
+		})
+	}
+
+	switch len(degraded) {
+	case 0:
+		conditionsv1.SetStatusCondition(&sspStatus.Conditions, conditionsv1.Condition{
+			Type:    conditionsv1.ConditionDegraded,
+			Status:  v1.ConditionFalse,
+			Reason:  "degraded",
+			Message: "No SSP resources are degraded",
+		})
+	case 1:
+		status := degraded[0]
+		conditionsv1.SetStatusCondition(&sspStatus.Conditions, conditionsv1.Condition{
+			Type:    conditionsv1.ConditionDegraded,
+			Status:  v1.ConditionTrue,
+			Reason:  "degraded",
+			Message: prefixResourceTypeAndName(*status.Degraded, status.Resource),
+		})
+	default:
+		conditionsv1.SetStatusCondition(&sspStatus.Conditions, conditionsv1.Condition{
+			Type:    conditionsv1.ConditionDegraded,
+			Status:  v1.ConditionTrue,
+			Reason:  "degraded",
+			Message: fmt.Sprintf("%d SSP resources are degraded", len(degraded)),
+		})
+	}
+
+	if len(notAvailable) == 0 && len(progressing) == 0 && len(degraded) == 0 {
+		sspStatus.Phase = lifecycleapi.PhaseDeployed
+	} else {
+		sspStatus.Phase = lifecycleapi.PhaseDeploying
+	}
+	return request.Client.Status().Update(request.Context, request.Instance)
+}
+
+func prefixResourceTypeAndName(message string, resource controllerutil.Object) string {
+	return fmt.Sprintf("%s %s/%s: %s",
+		resource.GetObjectKind().GroupVersionKind().Kind,
+		resource.GetNamespace(),
+		resource.GetName(),
+		message)
 }
 
 func (r *SSPReconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/onsi/ginkgo v1.12.1
 	github.com/onsi/gomega v1.10.1
 	github.com/openshift/api v0.0.0-20200917102736-0a191b5b9bb0 // release-4.5
+	github.com/openshift/custom-resource-status v0.0.0-20200602122900-c002fd1547ca
 	github.com/operator-framework/operator-lib v0.1.0
 	k8s.io/api v0.18.6
 	k8s.io/apimachinery v0.18.6

--- a/internal/common/cache.go
+++ b/internal/common/cache.go
@@ -1,0 +1,41 @@
+package common
+
+import "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+type versionCacheKey struct {
+	Kind      string
+	Name      string
+	Namespace string
+}
+
+type VersionCache map[versionCacheKey]string
+
+func (v VersionCache) Contains(obj controllerutil.Object) bool {
+	resVersion := obj.GetResourceVersion()
+	if resVersion == "" {
+		return false
+	}
+	cachedVersion, ok := v[cacheKeyFromObj(obj)]
+	return ok && resVersion == cachedVersion
+}
+
+func (v VersionCache) Add(obj controllerutil.Object) {
+	kind := obj.GetObjectKind().GroupVersionKind().Kind
+	if kind == "" {
+		// Do not cache objects without kind
+		return
+	}
+	v[cacheKeyFromObj(obj)] = obj.GetResourceVersion()
+}
+
+func (v VersionCache) RemoveObj(obj controllerutil.Object) {
+	delete(v, cacheKeyFromObj(obj))
+}
+
+func cacheKeyFromObj(obj controllerutil.Object) versionCacheKey {
+	return versionCacheKey{
+		Kind:      obj.GetObjectKind().GroupVersionKind().Kind,
+		Name:      obj.GetName(),
+		Namespace: obj.GetNamespace(),
+	}
+}

--- a/internal/common/request.go
+++ b/internal/common/request.go
@@ -13,9 +13,10 @@ import (
 
 type Request struct {
 	reconcile.Request
-	Client   client.Client
-	Scheme   *runtime.Scheme
-	Context  context.Context
-	Instance *ssp.SSP
-	Logger   logr.Logger
+	Client               client.Client
+	Scheme               *runtime.Scheme
+	Context              context.Context
+	Instance             *ssp.SSP
+	Logger               logr.Logger
+	ResourceVersionCache VersionCache
 }

--- a/internal/common/resource.go
+++ b/internal/common/resource.go
@@ -2,32 +2,66 @@ package common
 
 import (
 	"fmt"
-	"github.com/go-logr/logr"
 	"reflect"
+
+	"github.com/go-logr/logr"
 
 	libhandler "github.com/operator-framework/operator-lib/handler"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
+type StatusMessage = *string
+
+type ResourceStatus struct {
+	Resource     controllerutil.Object
+	Progressing  StatusMessage
+	NotAvailable StatusMessage
+	Degraded     StatusMessage
+}
+
+type ReconcileFunc = func(*Request) (ResourceStatus, error)
+
+func CollectResourceStatus(request *Request, funcs ...ReconcileFunc) ([]ResourceStatus, error) {
+	res := make([]ResourceStatus, 0, len(funcs))
+	for _, f := range funcs {
+		status, err := f(request)
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, status)
+	}
+	return res, nil
+}
+
 type ResourceUpdateFunc = func(expected, found controllerutil.Object)
+type ResourceStatusFunc = func(resource controllerutil.Object) ResourceStatus
 
-func CreateOrUpdateResource(request *Request, resource controllerutil.Object, updateResource ResourceUpdateFunc) error {
-	err := controllerutil.SetControllerReference(request.Instance, resource, request.Scheme)
-	if err != nil {
-		return err
-	}
-	return createOrUpdate(request, resource, updateResource)
+func CreateOrUpdateResource(request *Request, resource controllerutil.Object, updateResource ResourceUpdateFunc) (ResourceStatus, error) {
+	return createOrUpdate(request, resource, false, updateResource, statusOk)
 }
 
-func CreateOrUpdateClusterResource(request *Request, resource controllerutil.Object, updateResource ResourceUpdateFunc) error {
-	err := libhandler.SetOwnerAnnotations(request.Instance, resource)
-	if err != nil {
-		return err
-	}
-	return createOrUpdate(request, resource, updateResource)
+func CreateOrUpdateResourceWithStatus(request *Request, resource controllerutil.Object, updateResource ResourceUpdateFunc, statusFunc ResourceStatusFunc) (ResourceStatus, error) {
+	return createOrUpdate(request, resource, false, updateResource, statusFunc)
 }
 
-func createOrUpdate(request *Request, resource controllerutil.Object, updateResource ResourceUpdateFunc) error {
+func CreateOrUpdateClusterResource(request *Request, resource controllerutil.Object, updateResource ResourceUpdateFunc) (ResourceStatus, error) {
+	return createOrUpdate(request, resource, true, updateResource, statusOk)
+}
+
+func CreateOrUpdateClusterResourceWithStatus(request *Request, resource controllerutil.Object, updateResource ResourceUpdateFunc, statusFunc ResourceStatusFunc) (ResourceStatus, error) {
+	return createOrUpdate(request, resource, true, updateResource, statusFunc)
+}
+
+func statusOk(_ controllerutil.Object) ResourceStatus {
+	return ResourceStatus{}
+}
+
+func createOrUpdate(request *Request, resource controllerutil.Object, isClusterRes bool, updateResource ResourceUpdateFunc, statusFunc ResourceStatusFunc) (ResourceStatus, error) {
+	err := setOwner(request, resource, isClusterRes)
+	if err != nil {
+		return ResourceStatus{}, err
+	}
+
 	found := newEmptyResource(resource)
 	found.SetName(resource.GetName())
 	found.SetNamespace(resource.GetNamespace())
@@ -46,12 +80,20 @@ func createOrUpdate(request *Request, resource controllerutil.Object, updateReso
 		return nil
 	})
 	if err != nil {
-		return err
+		return ResourceStatus{}, err
 	}
 
 	request.ResourceVersionCache.Add(found)
 	logOperation(res, found, request.Logger)
-	return nil
+	return operationStatus(res, found, statusFunc), nil
+}
+
+func setOwner(request *Request, resource controllerutil.Object, isClusterRes bool) error {
+	if isClusterRes {
+		return libhandler.SetOwnerAnnotations(request.Instance, resource)
+	} else {
+		return controllerutil.SetControllerReference(request.Instance, resource, request.Scheme)
+	}
 }
 
 func newEmptyResource(resource controllerutil.Object) controllerutil.Object {
@@ -92,5 +134,30 @@ func logOperation(result controllerutil.OperationResult, resource controllerutil
 		logger.Info(fmt.Sprintf("Updated %s resource: %s",
 			resource.GetObjectKind().GroupVersionKind().Kind,
 			resource.GetName()))
+	}
+}
+
+func operationStatus(result controllerutil.OperationResult, resource controllerutil.Object, statusFunc ResourceStatusFunc) ResourceStatus {
+	switch result {
+	case controllerutil.OperationResultCreated:
+		msg := "Creating resource."
+		return ResourceStatus{
+			Resource:     resource,
+			Progressing:  &msg,
+			NotAvailable: &msg,
+			Degraded:     &msg,
+		}
+	case controllerutil.OperationResultUpdated:
+		msg := "Updating resource."
+		return ResourceStatus{
+			Resource:     resource,
+			Progressing:  &msg,
+			NotAvailable: &msg,
+			Degraded:     &msg,
+		}
+	default:
+		status := statusFunc(resource)
+		status.Resource = resource
+		return status
 	}
 }

--- a/internal/common/resource.go
+++ b/internal/common/resource.go
@@ -32,6 +32,10 @@ func createOrUpdate(request *Request, resource controllerutil.Object, updateReso
 	found.SetName(resource.GetName())
 	found.SetNamespace(resource.GetNamespace())
 	res, err := controllerutil.CreateOrUpdate(request.Context, request.Client, found, func() error {
+		if request.ResourceVersionCache.Contains(found) {
+			return nil
+		}
+
 		// We expect users will not add any other owner references,
 		// if that is not correct, this code needs to be changed.
 		found.SetOwnerReferences(resource.GetOwnerReferences())
@@ -45,6 +49,7 @@ func createOrUpdate(request *Request, resource controllerutil.Object, updateReso
 		return err
 	}
 
+	request.ResourceVersionCache.Add(found)
 	logOperation(res, found, request.Logger)
 	return nil
 }

--- a/internal/operands/common-templates/reconcile_test.go
+++ b/internal/operands/common-templates/reconcile_test.go
@@ -72,11 +72,13 @@ var _ = Describe("Common-Templates operand", func() {
 	})
 
 	It("should create golden-images namespace", func() {
-		Expect(operand.Reconcile(&request)).ToNot(HaveOccurred())
+		_, err := operand.Reconcile(&request)
+		Expect(err).ToNot(HaveOccurred())
 		expectResourceExists(newGoldenImagesNS(GoldenImagesNSname), request)
 	})
 	It("should create common-template resources", func() {
-		Expect(operand.Reconcile(&request)).ToNot(HaveOccurred())
+		_, err := operand.Reconcile(&request)
+		Expect(err).ToNot(HaveOccurred())
 		Expect(templatesBundle).ToNot(BeNil())
 		for _, template := range templatesBundle {
 			template.Namespace = namespace
@@ -84,15 +86,18 @@ var _ = Describe("Common-Templates operand", func() {
 		}
 	})
 	It("should create view role", func() {
-		Expect(operand.Reconcile(&request)).ToNot(HaveOccurred())
+		_, err := operand.Reconcile(&request)
+		Expect(err).ToNot(HaveOccurred())
 		expectResourceExists(newViewRole(GoldenImagesNSname), request)
 	})
 	It("should create view role binding", func() {
-		Expect(operand.Reconcile(&request)).ToNot(HaveOccurred())
+		_, err := operand.Reconcile(&request)
+		Expect(err).ToNot(HaveOccurred())
 		expectResourceExists(newViewRoleBinding(GoldenImagesNSname), request)
 	})
 	It("should create view role binding", func() {
-		Expect(operand.Reconcile(&request)).ToNot(HaveOccurred())
+		_, err := operand.Reconcile(&request)
+		Expect(err).ToNot(HaveOccurred())
 		expectResourceExists(newEditRole(), request)
 	})
 })

--- a/internal/operands/metrics/reconcile.go
+++ b/internal/operands/metrics/reconcile.go
@@ -23,12 +23,10 @@ func (m *metrics) WatchClusterTypes() []runtime.Object {
 	return nil
 }
 
-func (m *metrics) Reconcile(request *common.Request) error {
-	return common.CreateOrUpdateResource(request,
-		newPrometheusRule(request.Namespace),
-		func(newRes, foundRes controllerutil.Object) {
-			foundRes.(*promv1.PrometheusRule).Spec = newRes.(*promv1.PrometheusRule).Spec
-		})
+func (m *metrics) Reconcile(request *common.Request) ([]common.ResourceStatus, error) {
+	return common.CollectResourceStatus(request,
+		reconcilePrometheusRule,
+	)
 }
 
 func (m *metrics) Cleanup(*common.Request) error {
@@ -39,4 +37,12 @@ var _ operands.Operand = &metrics{}
 
 func GetOperand() operands.Operand {
 	return &metrics{}
+}
+
+func reconcilePrometheusRule(request *common.Request) (common.ResourceStatus, error) {
+	return common.CreateOrUpdateResource(request,
+		newPrometheusRule(request.Namespace),
+		func(newRes, foundRes controllerutil.Object) {
+			foundRes.(*promv1.PrometheusRule).Spec = newRes.(*promv1.PrometheusRule).Spec
+		})
 }

--- a/internal/operands/metrics/reconcile_test.go
+++ b/internal/operands/metrics/reconcile_test.go
@@ -62,7 +62,8 @@ var _ = Describe("Metrics operand", func() {
 			ResourceVersionCache: common.VersionCache{},
 		}
 
-		Expect(operand.Reconcile(&request)).ToNot(HaveOccurred())
+		_, err := operand.Reconcile(&request)
+		Expect(err).ToNot(HaveOccurred())
 		expectResourceExists(newPrometheusRule(namespace), request)
 	})
 })

--- a/internal/operands/metrics/reconcile_test.go
+++ b/internal/operands/metrics/reconcile_test.go
@@ -58,7 +58,8 @@ var _ = Describe("Metrics operand", func() {
 					Namespace: namespace,
 				},
 			},
-			Logger: log,
+			Logger:               log,
+			ResourceVersionCache: common.VersionCache{},
 		}
 
 		Expect(operand.Reconcile(&request)).ToNot(HaveOccurred())

--- a/internal/operands/node-labeller/reconcile_test.go
+++ b/internal/operands/node-labeller/reconcile_test.go
@@ -65,7 +65,8 @@ var _ = Describe("Node Labeller operand", func() {
 	})
 
 	It("should create node labeller resources", func() {
-		Expect(operand.Reconcile(&request)).ToNot(HaveOccurred())
+		_, err := operand.Reconcile(&request)
+		Expect(err).ToNot(HaveOccurred())
 
 		expectResourceExists(newClusterRole(), request)
 		expectResourceExists(newServiceAccount(namespace), request)
@@ -76,7 +77,8 @@ var _ = Describe("Node Labeller operand", func() {
 	})
 
 	It("should remove cluster resources on cleanup", func() {
-		Expect(operand.Reconcile(&request)).ToNot(HaveOccurred())
+		_, err := operand.Reconcile(&request)
+		Expect(err).ToNot(HaveOccurred())
 
 		expectResourceExists(newClusterRole(), request)
 		expectResourceExists(newClusterRoleBinding(namespace), request)

--- a/internal/operands/operand.go
+++ b/internal/operands/operand.go
@@ -18,7 +18,7 @@ type Operand interface {
 	WatchClusterTypes() []runtime.Object
 
 	// Reconcile creates and updates resources.
-	Reconcile(*common.Request) error
+	Reconcile(*common.Request) ([]common.ResourceStatus, error)
 
 	// Cleanup removes any created cluster resources.
 	// They don't use owner references, so the garbage collector will not remove them.

--- a/internal/operands/template-validator/reconcile_test.go
+++ b/internal/operands/template-validator/reconcile_test.go
@@ -60,7 +60,8 @@ var _ = Describe("Template validator operand", func() {
 					Namespace: namespace,
 				},
 			},
-			Logger: log,
+			Logger:               log,
+			ResourceVersionCache: common.VersionCache{},
 		}
 	})
 

--- a/internal/operands/template-validator/reconcile_test.go
+++ b/internal/operands/template-validator/reconcile_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	admission "k8s.io/api/admissionregistration/v1"
+	apps "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -28,6 +29,7 @@ var _ = Describe("Template validator operand", func() {
 	const (
 		namespace = "kubevirt"
 		name      = "test-ssp"
+		replicas  = 2
 	)
 
 	var (
@@ -59,6 +61,11 @@ var _ = Describe("Template validator operand", func() {
 					Name:      name,
 					Namespace: namespace,
 				},
+				Spec: ssp.SSPSpec{
+					TemplateValidator: ssp.TemplateValidator{
+						Replicas: replicas,
+					},
+				},
 			},
 			Logger:               log,
 			ResourceVersionCache: common.VersionCache{},
@@ -66,18 +73,20 @@ var _ = Describe("Template validator operand", func() {
 	})
 
 	It("should create validator resources", func() {
-		Expect(operand.Reconcile(&request)).ToNot(HaveOccurred())
+		_, err := operand.Reconcile(&request)
+		Expect(err).ToNot(HaveOccurred())
 
 		expectResourceExists(newClusterRole(namespace), request)
 		expectResourceExists(newServiceAccount(namespace), request)
 		expectResourceExists(newClusterRoleBinding(namespace), request)
 		expectResourceExists(newService(namespace), request)
-		expectResourceExists(newDeployment(namespace, 2, "test-img"), request)
+		expectResourceExists(newDeployment(namespace, replicas, "test-img"), request)
 		expectResourceExists(newValidatingWebhook(namespace), request)
 	})
 
 	It("should not update webhook CA bundle", func() {
-		Expect(operand.Reconcile(&request)).ToNot(HaveOccurred())
+		_, err := operand.Reconcile(&request)
+		Expect(err).ToNot(HaveOccurred())
 
 		key, err := client.ObjectKeyFromObject(newValidatingWebhook(namespace))
 		Expect(err).ToNot(HaveOccurred())
@@ -88,7 +97,8 @@ var _ = Describe("Template validator operand", func() {
 		webhook.Webhooks[0].ClientConfig.CABundle = []byte(testCaBundle)
 		Expect(request.Client.Update(request.Context, webhook)).ToNot(HaveOccurred())
 
-		Expect(operand.Reconcile(&request)).ToNot(HaveOccurred())
+		_, err = operand.Reconcile(&request)
+		Expect(err).ToNot(HaveOccurred())
 
 		updatedWebhook := &admission.ValidatingWebhookConfiguration{}
 		Expect(request.Client.Get(request.Context, key, updatedWebhook)).ToNot(HaveOccurred())
@@ -96,7 +106,8 @@ var _ = Describe("Template validator operand", func() {
 	})
 
 	It("should not update service cluster IP", func() {
-		Expect(operand.Reconcile(&request)).ToNot(HaveOccurred())
+		_, err := operand.Reconcile(&request)
+		Expect(err).ToNot(HaveOccurred())
 
 		key, err := client.ObjectKeyFromObject(newService(namespace))
 		Expect(err).ToNot(HaveOccurred())
@@ -107,7 +118,8 @@ var _ = Describe("Template validator operand", func() {
 		service.Spec.ClusterIP = testClusterIp
 		Expect(request.Client.Update(request.Context, service)).ToNot(HaveOccurred())
 
-		Expect(operand.Reconcile(&request)).ToNot(HaveOccurred())
+		_, err = operand.Reconcile(&request)
+		Expect(err).ToNot(HaveOccurred())
 
 		updatedService := &core.Service{}
 		Expect(request.Client.Get(request.Context, key, updatedService)).ToNot(HaveOccurred())
@@ -115,7 +127,8 @@ var _ = Describe("Template validator operand", func() {
 	})
 
 	It("should remove cluster resources on cleanup", func() {
-		Expect(operand.Reconcile(&request)).ToNot(HaveOccurred())
+		_, err := operand.Reconcile(&request)
+		Expect(err).ToNot(HaveOccurred())
 
 		expectResourceExists(newClusterRole(namespace), request)
 		expectResourceExists(newClusterRoleBinding(namespace), request)
@@ -126,6 +139,54 @@ var _ = Describe("Template validator operand", func() {
 		expectResourceNotExists(newClusterRole(namespace), request)
 		expectResourceNotExists(newClusterRoleBinding(namespace), request)
 		expectResourceNotExists(newValidatingWebhook(namespace), request)
+	})
+
+	It("should report status", func() {
+		statuses, err := operand.Reconcile(&request)
+		Expect(err).ToNot(HaveOccurred())
+
+		// All resources should be progressing
+		for _, status := range statuses {
+			Expect(status.NotAvailable).ToNot(BeNil())
+			Expect(status.Progressing).ToNot(BeNil())
+			Expect(status.Degraded).ToNot(BeNil())
+		}
+
+		statuses, err = operand.Reconcile(&request)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Only deployment should be progressing
+		for _, status := range statuses {
+			if _, ok := status.Resource.(*apps.Deployment); ok {
+				Expect(status.NotAvailable).ToNot(BeNil())
+				Expect(status.Progressing).ToNot(BeNil())
+				Expect(status.Degraded).ToNot(BeNil())
+			} else {
+				Expect(status.NotAvailable).To(BeNil())
+				Expect(status.Progressing).To(BeNil())
+				Expect(status.Degraded).To(BeNil())
+			}
+		}
+
+		key, err := client.ObjectKeyFromObject(newDeployment(namespace, replicas, "test-img"))
+		deployment := &apps.Deployment{}
+		Expect(request.Client.Get(request.Context, key, deployment)).ToNot(HaveOccurred())
+
+		deployment.Status.Replicas = replicas
+		deployment.Status.ReadyReplicas = replicas
+		deployment.Status.AvailableReplicas = replicas
+		deployment.Status.UpdatedReplicas = replicas
+		Expect(request.Client.Update(request.Context, deployment)).ToNot(HaveOccurred())
+
+		statuses, err = operand.Reconcile(&request)
+		Expect(err).ToNot(HaveOccurred())
+
+		// All resources should be available
+		for _, status := range statuses {
+			Expect(status.NotAvailable).To(BeNil())
+			Expect(status.Progressing).To(BeNil())
+			Expect(status.Degraded).To(BeNil())
+		}
 	})
 })
 

--- a/tests/commonTemplates_test.go
+++ b/tests/commonTemplates_test.go
@@ -42,6 +42,10 @@ var _ = Describe("Common templates", func() {
 		}
 	)
 
+	BeforeEach(func() {
+		waitUntilDeployed()
+	})
+
 	Context("resource creation", func() {
 		table.DescribeTable("created cluster resource", func(res *testResource) {
 			resource := res.NewResource()

--- a/tests/commonTemplates_test.go
+++ b/tests/commonTemplates_test.go
@@ -1,51 +1,51 @@
 package tests
 
 import (
+	"reflect"
+
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	templatev1 "github.com/openshift/api/template/v1"
 	core "k8s.io/api/core/v1"
 	rbac "k8s.io/api/rbac/v1"
-	commonTemplates "kubevirt.io/ssp-operator/internal/operands/common-templates"
-	"reflect"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"time"
-)
 
-var (
-	viewRole = &testResource{
-		Name:       commonTemplates.ViewRoleName,
-		Namsespace: commonTemplates.GoldenImagesNSname,
-		resource:   &rbac.Role{},
-	}
-	viewRoleBinding = &testResource{
-		Name:       commonTemplates.ViewRoleName,
-		Namsespace: commonTemplates.GoldenImagesNSname,
-		resource:   &rbac.RoleBinding{},
-	}
-	editClusterRole = &testResource{
-		Name:       commonTemplates.EditClusterRoleName,
-		resource:   &rbac.ClusterRole{},
-		Namsespace: "",
-	}
-	goldenImageNS = &testResource{
-		Name:       commonTemplates.GoldenImagesNSname,
-		resource:   &core.Namespace{},
-		Namsespace: "",
-	}
-	testTemplate = &testResource{
-		Name:       "centos6-server-large-v0.11.3",
-		Namsespace: commonTemplatesTestNS,
-		resource:   &templatev1.Template{},
-	}
+	commonTemplates "kubevirt.io/ssp-operator/internal/operands/common-templates"
 )
 
 var _ = Describe("Common templates", func() {
+	var (
+		viewRole = &testResource{
+			Name:       commonTemplates.ViewRoleName,
+			Namsespace: commonTemplates.GoldenImagesNSname,
+			resource:   &rbac.Role{},
+		}
+		viewRoleBinding = &testResource{
+			Name:       commonTemplates.ViewRoleName,
+			Namsespace: commonTemplates.GoldenImagesNSname,
+			resource:   &rbac.RoleBinding{},
+		}
+		editClusterRole = &testResource{
+			Name:       commonTemplates.EditClusterRoleName,
+			resource:   &rbac.ClusterRole{},
+			Namsespace: "",
+		}
+		goldenImageNS = &testResource{
+			Name:       commonTemplates.GoldenImagesNSname,
+			resource:   &core.Namespace{},
+			Namsespace: "",
+		}
+		testTemplate = &testResource{
+			Name:       "centos6-server-large-v0.11.3",
+			Namsespace: commonTemplatesTestNS,
+			resource:   &templatev1.Template{},
+		}
+	)
+
 	Context("resource creation", func() {
 		table.DescribeTable("created cluster resource", func(res *testResource) {
 			resource := res.NewResource()
-			err := apiClient.Get(ctx, client.ObjectKey{Name: res.Name}, resource)
+			err := apiClient.Get(ctx, res.GetKey(), resource)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(hasOwnerAnnotations(resource.GetAnnotations())).To(BeTrue())
 		},
@@ -54,9 +54,7 @@ var _ = Describe("Common templates", func() {
 		)
 
 		table.DescribeTable("created namespaced resource", func(res *testResource) {
-			err := apiClient.Get(ctx, client.ObjectKey{
-				Name: res.Name, Namespace: res.Namsespace,
-			}, res.NewResource())
+			err := apiClient.Get(ctx, res.GetKey(), res.NewResource())
 			Expect(err).ToNot(HaveOccurred())
 		},
 			table.Entry("[test_id:4777]view role", viewRole),
@@ -64,37 +62,13 @@ var _ = Describe("Common templates", func() {
 		)
 
 		It("[test_id:5086]Create common-template in custom NS", func() {
-			err := apiClient.Get(ctx, client.ObjectKey{
-				Name: testTemplate.Name, Namespace: commonTemplatesTestNS,
-			}, testTemplate.NewResource())
+			err := apiClient.Get(ctx, testTemplate.GetKey(), testTemplate.NewResource())
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})
 
 	Context("resource change", func() {
-		table.DescribeTable("should restore modified resource", func(
-			res *testResource,
-			updateFunc interface{},
-			equalsFunc interface{},
-		) {
-			key := res.GetKey()
-			original := res.NewResource()
-			Expect(apiClient.Get(ctx, key, original)).ToNot(HaveOccurred())
-
-			changed := original.DeepCopyObject()
-			reflect.ValueOf(updateFunc).Call([]reflect.Value{reflect.ValueOf(changed)})
-			Expect(apiClient.Update(ctx, changed)).ToNot(HaveOccurred())
-
-			newRes := res.NewResource()
-			Eventually(func() bool {
-				Expect(apiClient.Get(ctx, key, newRes)).ToNot(HaveOccurred())
-				res := reflect.ValueOf(equalsFunc).Call([]reflect.Value{
-					reflect.ValueOf(original),
-					reflect.ValueOf(newRes),
-				})
-				return res[0].Interface().(bool)
-			}, timeout, time.Second).Should(BeTrue())
-		},
+		table.DescribeTable("should restore modified resource", expectRestoreAfterUpdate,
 			table.Entry("edit cluster role", editClusterRole,
 				func(role *rbac.ClusterRole) {
 					role.Rules[0].Verbs = []string{"watch"}
@@ -130,18 +104,7 @@ var _ = Describe("Common templates", func() {
 	})
 
 	Context("resource deletion", func() {
-		table.DescribeTable("recreate after delete", func(res *testResource) {
-			resource := res.NewResource()
-			resource.SetName(res.Name)
-			resource.SetNamespace(res.Namsespace)
-			Expect(apiClient.Delete(ctx, resource)).ToNot(HaveOccurred())
-
-			Eventually(func() error {
-				return apiClient.Get(ctx, client.ObjectKey{
-					Name: res.Name, Namespace: res.Namsespace,
-				}, resource)
-			}, timeout, time.Second).ShouldNot(HaveOccurred())
-		},
+		table.DescribeTable("recreate after delete", expectRecreateAfterDelete,
 			table.Entry("[test_id:4773]view role", viewRole),
 			table.Entry("[test_id:4842]view role binding", viewRoleBinding),
 			table.Entry("[test_id:5088]testTemplate in custom NS", testTemplate),

--- a/tests/metrics_test.go
+++ b/tests/metrics_test.go
@@ -2,54 +2,37 @@ package tests
 
 import (
 	"reflect"
-	"time"
 
 	promv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"kubevirt.io/ssp-operator/internal/operands/metrics"
 )
 
 var _ = Describe("Metrics", func() {
-	var (
-		ruleKey = client.ObjectKey{
-			Name:      metrics.PrometheusRuleName,
-			Namespace: testNamespace,
-		}
-	)
+	var prometheusRuleRes = &testResource{
+		Name:       metrics.PrometheusRuleName,
+		Namsespace: testNamespace,
+		resource:   &promv1.PrometheusRule{},
+	}
 
 	It("[test_id:4665] should create prometheus rule", func() {
-		Expect(apiClient.Get(ctx, ruleKey, &promv1.PrometheusRule{})).ToNot(HaveOccurred())
+		Expect(apiClient.Get(ctx, prometheusRuleRes.GetKey(), &promv1.PrometheusRule{})).ToNot(HaveOccurred())
 	})
 
 	It("should recreate deleted prometheus rule", func() {
-		err := apiClient.DeleteAllOf(ctx, &promv1.PrometheusRule{},
-			client.InNamespace(testNamespace),
-			client.HasLabels{"kubevirt.io"})
-		Expect(err).ToNot(HaveOccurred())
-
-		Eventually(func() error {
-			return apiClient.Get(ctx, ruleKey, &promv1.PrometheusRule{})
-		}, timeout, time.Second).ShouldNot(HaveOccurred())
+		expectRecreateAfterDelete(prometheusRuleRes)
 	})
 
 	It("[test_id:4666] should restore modified prometheus rule", func() {
-		originalRule := promv1.PrometheusRule{}
-		err := apiClient.Get(ctx, ruleKey, &originalRule)
-		Expect(err).ToNot(HaveOccurred())
-
-		ruleCopy := originalRule.DeepCopy()
-		ruleCopy.Spec.Groups[0].Name = "changed-name"
-		ruleCopy.Spec.Groups[0].Rules = []promv1.Rule{}
-		Expect(apiClient.Update(ctx, ruleCopy)).ToNot(HaveOccurred())
-
-		Eventually(func() bool {
-			newRule := promv1.PrometheusRule{}
-			err := apiClient.Get(ctx, ruleKey, &newRule)
-			Expect(err).ToNot(HaveOccurred())
-			return reflect.DeepEqual(newRule.Spec, originalRule.Spec)
-		}, timeout, time.Second).Should(BeTrue())
+		expectRestoreAfterUpdate(prometheusRuleRes,
+			func(rule *promv1.PrometheusRule) {
+				rule.Spec.Groups[0].Name = "changed-name"
+				rule.Spec.Groups[0].Rules = []promv1.Rule{}
+			},
+			func(old, new *promv1.PrometheusRule) bool {
+				return reflect.DeepEqual(old.Spec, new.Spec)
+			})
 	})
 })

--- a/tests/metrics_test.go
+++ b/tests/metrics_test.go
@@ -17,6 +17,10 @@ var _ = Describe("Metrics", func() {
 		resource:   &promv1.PrometheusRule{},
 	}
 
+	BeforeEach(func() {
+		waitUntilDeployed()
+	})
+
 	It("[test_id:4665] should create prometheus rule", func() {
 		Expect(apiClient.Get(ctx, prometheusRuleRes.GetKey(), &promv1.PrometheusRule{})).ToNot(HaveOccurred())
 	})

--- a/tests/nodeLabeller_test.go
+++ b/tests/nodeLabeller_test.go
@@ -1,6 +1,8 @@
 package tests
 
 import (
+	"reflect"
+
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
@@ -8,117 +10,80 @@ import (
 	apps "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
 	rbac "k8s.io/api/rbac/v1"
-	nodelabeller "kubevirt.io/ssp-operator/internal/operands/node-labeller"
-	"reflect"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"time"
-)
 
-var (
-	nlClusterRoleRes = &testResource{
-		Name:       nodelabeller.ClusterRoleName,
-		resource:   &rbac.ClusterRole{},
-		Namsespace: "",
-	}
-	nlClusterRoleBindingRes = &testResource{
-		Name:       nodelabeller.ClusterRoleBindingName,
-		resource:   &rbac.ClusterRoleBinding{},
-		Namsespace: "",
-	}
-	nlServiceAccountRes = &testResource{
-		Name:       nodelabeller.ServiceAccountName,
-		Namsespace: testNamespace,
-		resource:   &core.ServiceAccount{},
-	}
-	securityContextConstraintRes = &testResource{
-		Name:       nodelabeller.SecurityContextName,
-		Namsespace: "",
-		resource:   &secv1.SecurityContextConstraints{},
-	}
-	configMapRes = &testResource{
-		Name:       nodelabeller.ConfigMapName,
-		Namsespace: testNamespace,
-		resource:   &core.ConfigMap{},
-	}
-	daemonSetRes = &testResource{
-		Name:       nodelabeller.DaemonSetName,
-		Namsespace: testNamespace,
-		resource:   &apps.DaemonSet{},
-	}
+	nodelabeller "kubevirt.io/ssp-operator/internal/operands/node-labeller"
 )
 
 var _ = Describe("Node Labeller", func() {
+	var (
+		clusterRoleRes = &testResource{
+			Name:       nodelabeller.ClusterRoleName,
+			resource:   &rbac.ClusterRole{},
+			Namsespace: "",
+		}
+		clusterRoleBindingRes = &testResource{
+			Name:       nodelabeller.ClusterRoleBindingName,
+			resource:   &rbac.ClusterRoleBinding{},
+			Namsespace: "",
+		}
+		serviceAccountRes = &testResource{
+			Name:       nodelabeller.ServiceAccountName,
+			Namsespace: testNamespace,
+			resource:   &core.ServiceAccount{},
+		}
+		securityContextConstraintRes = &testResource{
+			Name:       nodelabeller.SecurityContextName,
+			Namsespace: "",
+			resource:   &secv1.SecurityContextConstraints{},
+		}
+		configMapRes = &testResource{
+			Name:       nodelabeller.ConfigMapName,
+			Namsespace: testNamespace,
+			resource:   &core.ConfigMap{},
+		}
+		daemonSetRes = &testResource{
+			Name:       nodelabeller.DaemonSetName,
+			Namsespace: testNamespace,
+			resource:   &apps.DaemonSet{},
+		}
+	)
+
 	Context("resource creation", func() {
 		table.DescribeTable("created cluster resource", func(res *testResource) {
 			resource := res.NewResource()
-			err := apiClient.Get(ctx, client.ObjectKey{Name: res.Name}, resource)
+			err := apiClient.Get(ctx, res.GetKey(), resource)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(hasOwnerAnnotations(resource.GetAnnotations())).To(BeTrue())
 		},
-			table.Entry("[test_id:5193] cluster role", nlClusterRoleRes),
-			table.Entry("[test_id:5196] cluster role binding", nlClusterRoleBindingRes),
+			table.Entry("[test_id:5193] cluster role", clusterRoleRes),
+			table.Entry("[test_id:5196] cluster role binding", clusterRoleBindingRes),
 			table.Entry("[test_id:5202] security context constraint", securityContextConstraintRes),
 		)
 
 		table.DescribeTable("created namespaced resource", func(res *testResource) {
-			err := apiClient.Get(ctx, client.ObjectKey{
-				Name: res.Name, Namespace: testNamespace,
-			}, res.NewResource())
+			err := apiClient.Get(ctx, res.GetKey(), res.NewResource())
 			Expect(err).ToNot(HaveOccurred())
 		},
-			table.Entry("[test_id:5205] service account", nlServiceAccountRes),
+			table.Entry("[test_id:5205] service account", serviceAccountRes),
 			table.Entry("[test_id:5199] configMap", configMapRes),
 			table.Entry("[test_id:5190] daemonSet", daemonSetRes),
 		)
 	})
 
 	Context("resource deletion", func() {
-		table.DescribeTable("recreate after delete", func(res *testResource) {
-			resource := res.NewResource()
-			resource.SetName(res.Name)
-			resource.SetNamespace(res.Namsespace)
-			Expect(apiClient.Delete(ctx, resource)).ToNot(HaveOccurred())
-
-			Eventually(func() error {
-				return apiClient.Get(ctx, client.ObjectKey{
-					Name: res.Name, Namespace: res.Namsespace,
-				}, resource)
-			}, timeout, time.Second).ShouldNot(HaveOccurred())
-		},
-			table.Entry("[test_id:5194] cluster role", nlClusterRoleRes),
-			table.Entry("[test_id:5198] cluster role binding", nlClusterRoleBindingRes),
+		table.DescribeTable("recreate after delete", expectRecreateAfterDelete,
+			table.Entry("[test_id:5194] cluster role", clusterRoleRes),
+			table.Entry("[test_id:5198] cluster role binding", clusterRoleBindingRes),
 			table.Entry("[test_id:5203] security context constraint", securityContextConstraintRes),
-			table.Entry("[test_id:5206] service account", nlServiceAccountRes),
+			table.Entry("[test_id:5206] service account", serviceAccountRes),
 			table.Entry("[test_id:5200] configMap", configMapRes),
 			table.Entry("[test_id:5191] daemonSet", daemonSetRes),
 		)
 	})
 
 	Context("resource change", func() {
-		table.DescribeTable("should restore modified resource", func(
-			res *testResource,
-			updateFunc interface{},
-			equalsFunc interface{},
-		) {
-			key := res.GetKey()
-			original := res.NewResource()
-			Expect(apiClient.Get(ctx, key, original)).ToNot(HaveOccurred())
-
-			changed := original.DeepCopyObject()
-			reflect.ValueOf(updateFunc).Call([]reflect.Value{reflect.ValueOf(changed)})
-			Expect(apiClient.Update(ctx, changed)).ToNot(HaveOccurred())
-
-			newRes := res.NewResource()
-			Eventually(func() bool {
-				Expect(apiClient.Get(ctx, key, newRes)).ToNot(HaveOccurred())
-				res := reflect.ValueOf(equalsFunc).Call([]reflect.Value{
-					reflect.ValueOf(original),
-					reflect.ValueOf(newRes),
-				})
-				return res[0].Interface().(bool)
-			}, timeout, time.Second).Should(BeTrue())
-		},
-			table.Entry("[test_id:5195] cluster role", nlClusterRoleRes,
+		table.DescribeTable("should restore modified resource", expectRestoreAfterUpdate,
+			table.Entry("[test_id:5195] cluster role", clusterRoleRes,
 				func(role *rbac.ClusterRole) {
 					role.Rules[0].Verbs = []string{"watch"}
 				},
@@ -126,7 +91,7 @@ var _ = Describe("Node Labeller", func() {
 					return reflect.DeepEqual(old.Rules, new.Rules)
 				}),
 
-			table.Entry("[test_id:5197] cluster role binding", nlClusterRoleBindingRes,
+			table.Entry("[test_id:5197] cluster role binding", clusterRoleBindingRes,
 				func(roleBinding *rbac.ClusterRoleBinding) {
 					roleBinding.Subjects = []rbac.Subject{}
 				},

--- a/tests/tests_common_test.go
+++ b/tests/tests_common_test.go
@@ -2,12 +2,16 @@ package tests
 
 import (
 	"reflect"
-	"time"
 
 	. "github.com/onsi/gomega"
+	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
 	"github.com/operator-framework/operator-lib/handler"
+	core "k8s.io/api/core/v1"
+	"kubevirt.io/controller-lifecycle-operator-sdk/pkg/sdk/api"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"kubevirt.io/ssp-operator/api/v1alpha1"
 )
 
 type testResource struct {
@@ -31,13 +35,24 @@ func expectRecreateAfterDelete(res *testResource) {
 	resource := res.NewResource()
 	resource.SetName(res.Name)
 	resource.SetNamespace(res.Namsespace)
+
+	// Watch status of the SSP resource
+	watch, err := StartWatch(sspListerWatcher)
+	Expect(err).ToNot(HaveOccurred())
+	defer watch.Stop()
+
 	Expect(apiClient.Delete(ctx, resource)).ToNot(HaveOccurred())
 
-	Eventually(func() error {
-		return apiClient.Get(ctx, client.ObjectKey{
-			Name: res.Name, Namespace: res.Namsespace,
-		}, resource)
-	}, timeout, time.Second).ShouldNot(HaveOccurred())
+	err = WatchChangesUntil(watch, isStatusDeploying, timeout)
+	Expect(err).ToNot(HaveOccurred(), "SSP status should be deploying.")
+
+	err = WatchChangesUntil(watch, isStatusDeployed, timeout)
+	Expect(err).ToNot(HaveOccurred(), "SSP status should be deployed.")
+
+	err = apiClient.Get(ctx, client.ObjectKey{
+		Name: res.Name, Namespace: res.Namsespace,
+	}, resource)
+	Expect(err).ToNot(HaveOccurred())
 }
 
 func expectRestoreAfterUpdate(res *testResource, updateFunc interface{}, equalsFunc interface{}) {
@@ -45,19 +60,28 @@ func expectRestoreAfterUpdate(res *testResource, updateFunc interface{}, equalsF
 	original := res.NewResource()
 	Expect(apiClient.Get(ctx, key, original)).ToNot(HaveOccurred())
 
+	// Watch status of the SSP resource
+	watch, err := StartWatch(sspListerWatcher)
+	Expect(err).ToNot(HaveOccurred())
+	defer watch.Stop()
+
 	changed := original.DeepCopyObject()
 	reflect.ValueOf(updateFunc).Call([]reflect.Value{reflect.ValueOf(changed)})
 	Expect(apiClient.Update(ctx, changed)).ToNot(HaveOccurred())
 
+	err = WatchChangesUntil(watch, isStatusDeploying, timeout)
+	Expect(err).ToNot(HaveOccurred(), "SSP status should be deploying.")
+
+	err = WatchChangesUntil(watch, isStatusDeployed, timeout)
+	Expect(err).ToNot(HaveOccurred(), "SSP status should be deployed.")
+
 	newRes := res.NewResource()
-	Eventually(func() bool {
-		Expect(apiClient.Get(ctx, key, newRes)).ToNot(HaveOccurred())
-		res := reflect.ValueOf(equalsFunc).Call([]reflect.Value{
-			reflect.ValueOf(original),
-			reflect.ValueOf(newRes),
-		})
-		return res[0].Interface().(bool)
-	}, timeout, time.Second).Should(BeTrue())
+	Expect(apiClient.Get(ctx, key, newRes)).ToNot(HaveOccurred())
+	result := reflect.ValueOf(equalsFunc).Call([]reflect.Value{
+		reflect.ValueOf(original),
+		reflect.ValueOf(newRes),
+	})
+	Expect(result[0].Interface().(bool)).To(BeTrue())
 }
 
 func hasOwnerAnnotations(annotations map[string]string) bool {
@@ -70,4 +94,26 @@ func hasOwnerAnnotations(annotations map[string]string) bool {
 
 	return annotations[handler.TypeAnnotation] == typeName &&
 		annotations[handler.NamespacedNameAnnotation] == namespacedName
+}
+
+func isStatusDeploying(obj *v1alpha1.SSP) bool {
+	available := conditionsv1.FindStatusCondition(obj.Status.Conditions, conditionsv1.ConditionAvailable)
+	progressing := conditionsv1.FindStatusCondition(obj.Status.Conditions, conditionsv1.ConditionProgressing)
+	degraded := conditionsv1.FindStatusCondition(obj.Status.Conditions, conditionsv1.ConditionDegraded)
+
+	return obj.Status.Phase == api.PhaseDeploying &&
+		available.Status == core.ConditionFalse &&
+		progressing.Status == core.ConditionTrue &&
+		degraded.Status == core.ConditionTrue
+}
+
+func isStatusDeployed(obj *v1alpha1.SSP) bool {
+	available := conditionsv1.FindStatusCondition(obj.Status.Conditions, conditionsv1.ConditionAvailable)
+	progressing := conditionsv1.FindStatusCondition(obj.Status.Conditions, conditionsv1.ConditionProgressing)
+	degraded := conditionsv1.FindStatusCondition(obj.Status.Conditions, conditionsv1.ConditionDegraded)
+
+	return obj.Status.Phase == api.PhaseDeployed &&
+		available.Status == core.ConditionTrue &&
+		progressing.Status == core.ConditionFalse &&
+		degraded.Status == core.ConditionFalse
 }

--- a/tests/tests_common_test.go
+++ b/tests/tests_common_test.go
@@ -1,0 +1,73 @@
+package tests
+
+import (
+	"reflect"
+	"time"
+
+	. "github.com/onsi/gomega"
+	"github.com/operator-framework/operator-lib/handler"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+type testResource struct {
+	Name       string
+	Namsespace string
+	resource   controllerutil.Object
+}
+
+func (r *testResource) NewResource() controllerutil.Object {
+	return r.resource.DeepCopyObject().(controllerutil.Object)
+}
+
+func (r *testResource) GetKey() client.ObjectKey {
+	return client.ObjectKey{
+		Name:      r.Name,
+		Namespace: r.Namsespace,
+	}
+}
+
+func expectRecreateAfterDelete(res *testResource) {
+	resource := res.NewResource()
+	resource.SetName(res.Name)
+	resource.SetNamespace(res.Namsespace)
+	Expect(apiClient.Delete(ctx, resource)).ToNot(HaveOccurred())
+
+	Eventually(func() error {
+		return apiClient.Get(ctx, client.ObjectKey{
+			Name: res.Name, Namespace: res.Namsespace,
+		}, resource)
+	}, timeout, time.Second).ShouldNot(HaveOccurred())
+}
+
+func expectRestoreAfterUpdate(res *testResource, updateFunc interface{}, equalsFunc interface{}) {
+	key := res.GetKey()
+	original := res.NewResource()
+	Expect(apiClient.Get(ctx, key, original)).ToNot(HaveOccurred())
+
+	changed := original.DeepCopyObject()
+	reflect.ValueOf(updateFunc).Call([]reflect.Value{reflect.ValueOf(changed)})
+	Expect(apiClient.Update(ctx, changed)).ToNot(HaveOccurred())
+
+	newRes := res.NewResource()
+	Eventually(func() bool {
+		Expect(apiClient.Get(ctx, key, newRes)).ToNot(HaveOccurred())
+		res := reflect.ValueOf(equalsFunc).Call([]reflect.Value{
+			reflect.ValueOf(original),
+			reflect.ValueOf(newRes),
+		})
+		return res[0].Interface().(bool)
+	}, timeout, time.Second).Should(BeTrue())
+}
+
+func hasOwnerAnnotations(annotations map[string]string) bool {
+	const typeName = "SSP.ssp.kubevirt.io"
+	namespacedName := ssp.Namespace + "/" + ssp.Name
+
+	if annotations == nil {
+		return false
+	}
+
+	return annotations[handler.TypeAnnotation] == typeName &&
+		annotations[handler.NamespacedNameAnnotation] == namespacedName
+}

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -2,14 +2,14 @@ package tests
 
 import (
 	"context"
-	secv1 "github.com/openshift/api/security/v1"
-	templatev1 "github.com/openshift/api/template/v1"
 	"testing"
 	"time"
 
 	promv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	secv1 "github.com/openshift/api/security/v1"
+	templatev1 "github.com/openshift/api/template/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/tests/watcher.go
+++ b/tests/watcher.go
@@ -1,0 +1,146 @@
+package tests
+
+import (
+	"errors"
+	"fmt"
+	"k8s.io/client-go/tools/cache"
+	"sync/atomic"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+
+	sspv1alpha1 "kubevirt.io/ssp-operator/api/v1alpha1"
+)
+
+type SspWatch interface {
+	Stop()
+	Updates() <-chan *sspv1alpha1.SSP
+	Error() error
+}
+
+func StartWatch(listerWatcher cache.ListerWatcher) (SspWatch, error) {
+	listObj, err := listerWatcher.List(v1.ListOptions{ResourceVersion: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	list, err := meta.ListAccessor(listObj)
+	if err != nil {
+		return nil, err
+	}
+
+	watch := &sspWatch{
+		listerWatcher: listerWatcher,
+		stopCh:        make(chan struct{}),
+		updateCh:      make(chan *sspv1alpha1.SSP),
+		lastVersion:   list.GetResourceVersion(),
+	}
+	go watch.startWatch()
+	return watch, nil
+}
+
+type sspWatch struct {
+	listerWatcher cache.ListerWatcher
+	stopCh        chan struct{}
+	updateCh      chan *sspv1alpha1.SSP
+	atomicError   atomic.Value
+	lastVersion   string
+}
+
+func (s *sspWatch) Stop() {
+	close(s.stopCh)
+}
+
+func (s *sspWatch) Updates() <-chan *sspv1alpha1.SSP {
+	return s.updateCh
+}
+
+func (s *sspWatch) Error() error {
+	return s.atomicError.Load().(error)
+}
+
+const watchTimeout = 1 * time.Minute
+
+func (s *sspWatch) startWatch() {
+	defer func() {
+		close(s.updateCh)
+	}()
+
+	for {
+		timeoutSec := int64(watchTimeout.Seconds())
+		options := v1.ListOptions{
+			ResourceVersion: s.lastVersion,
+			TimeoutSeconds:  &timeoutSec,
+		}
+
+		w, err := s.listerWatcher.Watch(options)
+		if err != nil {
+			s.atomicError.Store(err)
+			return
+		}
+
+		err = s.handleWatch(w)
+		if err != nil {
+			if err != errorStopWatch {
+				s.atomicError.Store(err)
+			}
+			return
+		}
+	}
+}
+
+var errorStopWatch = errors.New("watch stopped")
+
+func (s *sspWatch) handleWatch(w watch.Interface) error {
+	defer w.Stop()
+	for {
+		select {
+		case <-s.stopCh:
+			return errorStopWatch
+		case event, ok := <-w.ResultChan():
+			if !ok {
+				return nil
+			}
+			if event.Type == watch.Error {
+				err := apierrors.FromObject(event.Object)
+				return err
+			}
+			sspObj, ok := event.Object.(*sspv1alpha1.SSP)
+			if !ok {
+				panic("Watch should receive SSP type.")
+			}
+
+			if event.Type == watch.Added || event.Type == watch.Modified {
+				select {
+				case <-s.stopCh:
+					return errorStopWatch
+				case s.updateCh <- sspObj:
+					break
+				}
+			}
+			s.lastVersion = sspObj.GetResourceVersion()
+		}
+	}
+}
+
+var ErrorTimeout = fmt.Errorf("timed out")
+
+func WatchChangesUntil(watch SspWatch, predicate func(updatedSsp *sspv1alpha1.SSP) bool, timeout time.Duration) error {
+	timeoutCh := time.After(timeout)
+	for {
+		select {
+		case obj, ok := <-watch.Updates():
+			if !ok {
+				return watch.Error()
+			}
+			if predicate(obj) {
+				return nil
+			}
+		case <-timeoutCh:
+			return ErrorTimeout
+		}
+	}
+}

--- a/tests/webhook_test.go
+++ b/tests/webhook_test.go
@@ -9,6 +9,10 @@ import (
 )
 
 var _ = Describe("Validation webhook", func() {
+	BeforeEach(func() {
+		waitUntilDeployed()
+	})
+
 	Context("creation", func() {
 		It("[test_id:5242] should fail to create a second SSP CR", func() {
 			ssp2 := &sspv1alpha1.SSP{


### PR DESCRIPTION
**What this PR does / why we need it**:
Added `status` field to the SSP CR.
`status.phase` can be used to check if the SSP operator finished deployment of all dependent resources.
`status.conditions` give more information about the status.

**Release note**:
```release-note
Added status to the SSP resource.
```
