### PR TITLE
Add validations to the API and webhook

### DIFF
--- a/api/v1alpha1/ssp_types.go
+++ b/api/v1alpha1/ssp_types.go
@@ -23,6 +23,7 @@ import (
 
 type TemplateValidator struct {
 	// Replicas is the number of replicas of the template validator pod
+	//+kubebuilder:validation:Minimum=0
 	Replicas int32 `json:"replicas"`
 
 	// Placement describes the node scheduling configuration
@@ -31,6 +32,8 @@ type TemplateValidator struct {
 
 type CommonTemplates struct {
 	// Namespace is the k8s namespace where CommonTemplates should be installed
+	//+kubebuilder:validation:MaxLength=63
+	//+kubebuilder:validation:Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
 	Namespace string `json:"namespace"`
 }
 
@@ -41,9 +44,6 @@ type NodeLabeller struct {
 
 // SSPSpec defines the desired state of SSP
 type SSPSpec struct {
-	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
-	// Important: Run "make" to regenerate code after modifying this file
-
 	// TemplateValidator is configuration of the template validator operand
 	TemplateValidator TemplateValidator `json:"templateValidator"`
 
@@ -56,9 +56,6 @@ type SSPSpec struct {
 
 // SSPStatus defines the observed state of SSP
 type SSPStatus struct {
-	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
-	// Important: Run "make" to regenerate code after modifying this file
-
 	lifecycleapi.Status `json:",inline"`
 }
 

--- a/api/v1alpha1/ssp_webhook.go
+++ b/api/v1alpha1/ssp_webhook.go
@@ -62,15 +62,18 @@ func (r *SSP) ValidateCreate() error {
 func (r *SSP) ValidateUpdate(old runtime.Object) error {
 	ssplog.Info("validate update", "name", r.Name)
 
-	// TODO(user): fill in your validation logic upon object update.
+	oldSsp := old.(*SSP)
+	if r.Spec.CommonTemplates.Namespace != oldSsp.Spec.CommonTemplates.Namespace {
+		return fmt.Errorf("commonTemplates.namespace cannot be changed. Attempting to change from: %v to %v",
+			oldSsp.Spec.CommonTemplates.Namespace,
+			r.Spec.CommonTemplates.Namespace)
+	}
+
 	return nil
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type
 func (r *SSP) ValidateDelete() error {
-	ssplog.Info("validate delete", "name", r.Name)
-
-	// TODO(user): fill in your validation logic upon object deletion.
 	return nil
 }
 

--- a/api/v1alpha1/ssp_webhook_test.go
+++ b/api/v1alpha1/ssp_webhook_test.go
@@ -78,6 +78,27 @@ var _ = Describe("SSP Validation", func() {
 			})
 		})
 	})
+
+	It("should not allow update of commonTemplates.namespace", func() {
+		oldSsp := &SSP{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-ssp",
+				Namespace: "test-ns",
+			},
+			Spec: SSPSpec{
+				CommonTemplates: CommonTemplates{
+					Namespace: "old-ns",
+				},
+			},
+		}
+
+		newSsp := oldSsp.DeepCopy()
+		newSsp.Spec.CommonTemplates.Namespace = "new-ns"
+
+		err := newSsp.ValidateUpdate(oldSsp)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("commonTemplates.namespace cannot be changed."))
+	})
 })
 
 func TestAPI(t *testing.T) {

--- a/config/crd/bases/ssp.kubevirt.io_ssps.yaml
+++ b/config/crd/bases/ssp.kubevirt.io_ssps.yaml
@@ -43,6 +43,8 @@ spec:
                 namespace:
                   description: Namespace is the k8s namespace where CommonTemplates
                     should be installed
+                  maxLength: 63
+                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                   type: string
               required:
               - namespace
@@ -1433,6 +1435,7 @@ spec:
                   description: Replicas is the number of replicas of the template
                     validator pod
                   format: int32
+                  minimum: 0
                   type: integer
               required:
               - replicas


### PR DESCRIPTION
**What this PR does / why we need it**:
Added validations to the API and webhook

In API:
- `templateValidator.replicas` cannot be negative
- `commonTemplates.namespace` must be valid namespace

In webhook:
- `commonTemplates.namespace` cannot be updated on existing CR

```release-note
NONE
```
