### PR TITLE
Reconcile the exact same resources as the old operator

### DIFF
--- a/tests/validator_test.go
+++ b/tests/validator_test.go
@@ -25,15 +25,15 @@ import (
 var _ = Describe("Template validator", func() {
 	var (
 		clusterRoleRes = &testResource{
-			Name:     validator.ClusterRoleName(testNamespace),
+			Name:     validator.ClusterRoleName,
 			resource: &rbac.ClusterRole{},
 		}
 		clusterRoleBindingRes = &testResource{
-			Name:     validator.ClusterRoleBindingName(testNamespace),
+			Name:     validator.ClusterRoleBindingName,
 			resource: &rbac.ClusterRoleBinding{},
 		}
 		webhookConfigRes = &testResource{
-			Name:     validator.ValidatingWebhookName(testNamespace),
+			Name:     validator.WebhookName,
 			resource: &admission.ValidatingWebhookConfiguration{},
 		}
 		serviceAccountRes = &testResource{


### PR DESCRIPTION
Signed-off-by: Shweta Padubidri <spadubid@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Reconcile the exact same resources as the old operator to provide zero interruption upgrade

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
