### PR TITLE
Makefile uses 'oc' or 'kubectl' depending on which one is available

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,12 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
+ifeq (, $(shell which oc))
+OC = kubectl
+else
+OC = oc
+endif
+
 all: manager
 
 # Run tests
@@ -52,16 +58,16 @@ run: generate fmt vet manifests
 
 # Install CRDs into a cluster
 install: manifests kustomize
-	$(KUSTOMIZE) build config/crd | kubectl apply -f -
+	$(KUSTOMIZE) build config/crd | $(OC) apply -f -
 
 # Uninstall CRDs from a cluster
 uninstall: manifests kustomize
-	$(KUSTOMIZE) build config/crd | kubectl delete -f -
+	$(KUSTOMIZE) build config/crd | $(OC) delete -f -
 
 # Deploy controller in the configured Kubernetes cluster in ~/.kube/config
 deploy: manifests kustomize
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
-	$(KUSTOMIZE) build config/default | kubectl apply -f -
+	$(KUSTOMIZE) build config/default | $(OC) apply -f -
 
 # Generate manifests e.g. CRD, RBAC etc.
 manifests: controller-gen


### PR DESCRIPTION
**What this PR does / why we need it**:
Openshift CI containers may not include 'kubectl' binary, so the makefile uses 'oc' instead.

```release-note
NONE
```
