### PR TITLE
Add RBAC tests for OS Images

### DIFF
--- a/tests/tests_common_test.go
+++ b/tests/tests_common_test.go
@@ -220,3 +220,16 @@ func expectUserCan(sars *authv1.SubjectAccessReviewSpec) {
 			sars.ResourceAttributes.Subresource, sars.ResourceAttributes.Name, sars.ResourceAttributes.Group,
 			sars.ResourceAttributes.Version, sars.ResourceAttributes.Namespace))
 }
+
+func expectUserCannot(sars *authv1.SubjectAccessReviewSpec) {
+	sar, err := coreClient.AuthorizationV1().SubjectAccessReviews().Create(ctx, &authv1.SubjectAccessReview{
+		Spec: *sars,
+	}, metav1.CreateOptions{})
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+	// Cannot assert Status.Denied here because it is optional and can be flaky even if Allowed is false
+	ExpectWithOffset(1, sar.Status.Allowed).To(BeFalse(),
+		fmt.Sprintf("user [%s] with groups %v should not be able to [%s] resource: [%s], subresource: [%s], name: [%s] in group [%s/%s] in namespace [%s]",
+			sars.User, sars.Groups, sars.ResourceAttributes.Verb, sars.ResourceAttributes.Resource,
+			sars.ResourceAttributes.Subresource, sars.ResourceAttributes.Name, sars.ResourceAttributes.Group,
+			sars.ResourceAttributes.Version, sars.ResourceAttributes.Namespace))
+}


### PR DESCRIPTION
Signed-off-by: Vatsal Parekh <vparekh@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Add RBAC tests for OS Images from the old operator functests https://github.com/kubevirt/kubevirt-ssp-operator/blob/master/functests/12-test-os-imaes-namespace_rbac.sh
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add RBAC tests for OS Images
```
