### PR TITLE
[FIX] add missing divider between deployment and crds

### DIFF
--- a/hack/csv-generator.sh
+++ b/hack/csv-generator.sh
@@ -120,6 +120,7 @@ cat ${TMP_FILE}
 rm ${TMP_FILE}
 if [ "$DUMP_CRDS" = "true" ]; then
     for CRD in $( ls ${CRDS_DIR}/ssp*.yaml ); do
+        echo "---"
         cat ${CRD}
     done
 fi


### PR DESCRIPTION
**What this PR does / why we need it**:
add missing divider between deployment and crds

**Release note**:
```NONE

```
Signed-off-by: Karel Simon <ksimon@redhat.com>