### PR TITLE
Functests wait for operator deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ run-functest:
 #functest: generate fmt vet manifests build-functests run-functest
 
 functest: generate fmt vet manifests
-	go test -v -coverprofile cover.out ./tests/...
+	go test -v -coverprofile cover.out -timeout 0 ./tests/...
 
 # Build manager binary
 manager: generate fmt vet

--- a/internal/common/environment.go
+++ b/internal/common/environment.go
@@ -46,7 +46,7 @@ func GetNodeLabellerImages() NodeLabellerImages {
 	const kvmCpuNfdDefaultImage = "quay.io/kubevirt/cpu-nfd-plugin"
 
 	const libvirtDefaultVersion = "v0.21.0"
-	const libvirtDefaultImage = "kubevirt/virt-launcher"
+	const libvirtDefaultImage = "docker.io/kubevirt/virt-launcher"
 
 	return NodeLabellerImages{
 		NodeLabeller: envOrDefault(kubevirtNodeLabellerImage, kubevirtNodeLabellerDefaultImage+":"+kubevirtNodeLabellerDefaultVersion),

--- a/tests/validator_test.go
+++ b/tests/validator_test.go
@@ -142,11 +142,18 @@ var _ = Describe("Template validator", func() {
 			pods := core.PodList{}
 			err := apiClient.List(ctx, &pods, client.InNamespace(testNamespace), client.MatchingLabels(labels))
 			Expect(err).ToNot(HaveOccurred())
-			if len(pods.Items) != 1 {
+			if len(pods.Items) != templateValidatorReplicas {
 				return false
 			}
-			return pods.Items[0].Status.Phase == core.PodRunning
-		}, timeout, 1*time.Second).Should(BeTrue())
+
+			runningCount := 0
+			for _, pod := range pods.Items {
+				if pod.Status.Phase == core.PodRunning {
+					runningCount++
+				}
+			}
+			return runningCount == templateValidatorReplicas
+		}, timeout, time.Second).Should(BeTrue())
 	})
 
 	It("should set Deployed phase and conditions when validator pods are running", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a race condition, when the deployment of the operator is too slow.

```release-note
NONE
```
