### PR TITLE
Add paused annotation

### DIFF
--- a/api/v1beta1/ssp_types.go
+++ b/api/v1beta1/ssp_types.go
@@ -21,6 +21,10 @@ import (
 	lifecycleapi "kubevirt.io/controller-lifecycle-operator-sdk/pkg/sdk/api"
 )
 
+const (
+	OperatorPausedAnnotation = "kubevirt.io/operator.paused"
+)
+
 type TemplateValidator struct {
 	// Replicas is the number of replicas of the template validator pod
 	//+kubebuilder:validation:Minimum=0
@@ -58,6 +62,9 @@ type SSPSpec struct {
 // SSPStatus defines the observed state of SSP
 type SSPStatus struct {
 	lifecycleapi.Status `json:",inline"`
+
+	// Paused is true when the operator notices paused annotation.
+	Paused bool `json:"paused,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/config/crd/bases/ssp.kubevirt.io_ssps.yaml
+++ b/config/crd/bases/ssp.kubevirt.io_ssps.yaml
@@ -840,6 +840,9 @@ spec:
               operatorVersion:
                 description: The version of the resource as defined by the operator
                 type: string
+              paused:
+                description: Paused is true when the operator notices paused annotation.
+                type: boolean
               phase:
                 description: Phase is the current phase of the deployment
                 type: string

--- a/data/crd/ssp.kubevirt.io_ssps.yaml
+++ b/data/crd/ssp.kubevirt.io_ssps.yaml
@@ -838,6 +838,9 @@ spec:
               operatorVersion:
                 description: The version of the resource as defined by the operator
                 type: string
+              paused:
+                description: Paused is true when the operator notices paused annotation.
+                type: boolean
               phase:
                 description: Phase is the current phase of the deployment
                 type: string

--- a/tests/commonTemplates_test.go
+++ b/tests/commonTemplates_test.go
@@ -44,7 +44,7 @@ var _ = Describe("Common templates", func() {
 			Namespace: commonTemplates.GoldenImagesNSname,
 			Resource:  &rbac.RoleBinding{},
 			UpdateFunc: func(roleBinding *rbac.RoleBinding) {
-				roleBinding.Subjects = []rbac.Subject{}
+				roleBinding.Subjects = nil
 			},
 			EqualsFunc: func(old *rbac.RoleBinding, new *rbac.RoleBinding) bool {
 				return reflect.DeepEqual(old.Subjects, new.Subjects)
@@ -71,7 +71,7 @@ var _ = Describe("Common templates", func() {
 			Namespace: strategy.GetTemplatesNamespace(),
 			Resource:  &templatev1.Template{},
 			UpdateFunc: func(t *templatev1.Template) {
-				t.Parameters = []templatev1.Parameter{}
+				t.Parameters = nil
 			},
 			EqualsFunc: func(old *templatev1.Template, new *templatev1.Template) bool {
 				return reflect.DeepEqual(old.Parameters, new.Parameters)
@@ -196,6 +196,23 @@ var _ = Describe("Common templates", func() {
 			table.Entry("[test_id:5317]view role binding", &viewRoleBinding),
 			table.Entry("[test_id:5087]test template", &testTemplate),
 		)
+
+		Context("with pause", func() {
+			BeforeEach(func() {
+				strategy.SkipSspUpdateTestsIfNeeded()
+			})
+
+			JustAfterEach(func() {
+				unpauseSsp()
+			})
+
+			table.DescribeTable("should restore modified resource with pause", expectRestoreAfterUpdateWithPause,
+				table.Entry("[test_id:5388]view role", &viewRole),
+				table.Entry("[test_id:5389]view role binding", &viewRoleBinding),
+				table.Entry("[test_id:5391]testTemplate in custom NS", &testTemplate),
+				table.Entry("[test_id:5393]edit cluster role", &editClusterRole),
+			)
+		})
 	})
 
 	Context("resource deletion", func() {

--- a/tests/metrics_test.go
+++ b/tests/metrics_test.go
@@ -15,9 +15,16 @@ var _ = Describe("Metrics", func() {
 
 	BeforeEach(func() {
 		prometheusRuleRes = testResource{
-			Name:       metrics.PrometheusRuleName,
-			Namsespace: strategy.GetNamespace(),
-			resource:   &promv1.PrometheusRule{},
+			Name:      metrics.PrometheusRuleName,
+			Namespace: strategy.GetNamespace(),
+			Resource:  &promv1.PrometheusRule{},
+			UpdateFunc: func(rule *promv1.PrometheusRule) {
+				rule.Spec.Groups[0].Name = "changed-name"
+				rule.Spec.Groups[0].Rules = []promv1.Rule{}
+			},
+			EqualsFunc: func(old, new *promv1.PrometheusRule) bool {
+				return reflect.DeepEqual(old.Spec, new.Spec)
+			},
 		}
 
 		waitUntilDeployed()
@@ -32,13 +39,6 @@ var _ = Describe("Metrics", func() {
 	})
 
 	It("[test_id:4666] should restore modified prometheus rule", func() {
-		expectRestoreAfterUpdate(&prometheusRuleRes,
-			func(rule *promv1.PrometheusRule) {
-				rule.Spec.Groups[0].Name = "changed-name"
-				rule.Spec.Groups[0].Rules = []promv1.Rule{}
-			},
-			func(old, new *promv1.PrometheusRule) bool {
-				return reflect.DeepEqual(old.Spec, new.Spec)
-			})
+		expectRestoreAfterUpdate(&prometheusRuleRes)
 	})
 })

--- a/tests/metrics_test.go
+++ b/tests/metrics_test.go
@@ -41,4 +41,18 @@ var _ = Describe("Metrics", func() {
 	It("[test_id:4666] should restore modified prometheus rule", func() {
 		expectRestoreAfterUpdate(&prometheusRuleRes)
 	})
+
+	Context("with pause", func() {
+		BeforeEach(func() {
+			strategy.SkipSspUpdateTestsIfNeeded()
+		})
+
+		JustAfterEach(func() {
+			unpauseSsp()
+		})
+
+		It("[test_id:5397] should recreate modified prometheus rule after pause", func() {
+			expectRestoreAfterUpdateWithPause(&prometheusRuleRes)
+		})
+	})
 })

--- a/tests/nodeLabeller_test.go
+++ b/tests/nodeLabeller_test.go
@@ -41,7 +41,7 @@ var _ = Describe("Node Labeller", func() {
 			Resource:  &rbac.ClusterRoleBinding{},
 			Namespace: "",
 			UpdateFunc: func(roleBinding *rbac.ClusterRoleBinding) {
-				roleBinding.Subjects = []rbac.Subject{}
+				roleBinding.Subjects = nil
 			},
 			EqualsFunc: func(old *rbac.ClusterRoleBinding, new *rbac.ClusterRoleBinding) bool {
 				return reflect.DeepEqual(old.Subjects, new.Subjects)
@@ -132,6 +132,24 @@ var _ = Describe("Node Labeller", func() {
 			table.Entry("[test_id:5201] Config Map", &configMapRes),
 			table.Entry("[test_id:5192] daemonSet", &daemonSetRes),
 		)
+
+		Context("with pause", func() {
+			BeforeEach(func() {
+				strategy.SkipSspUpdateTestsIfNeeded()
+			})
+
+			JustAfterEach(func() {
+				unpauseSsp()
+			})
+
+			table.DescribeTable("should restore modified resource with pause", expectRestoreAfterUpdateWithPause,
+				table.Entry("[test_id:5399] cluster role", &clusterRoleRes),
+				table.Entry("[test_id:5402] cluster role binding", &clusterRoleBindingRes),
+				table.Entry("[test_id:5404] security context constraint", &securityContextConstraintRes),
+				table.Entry("[test_id:5408] configMap", &configMapRes),
+				table.Entry("[test_id:5410] daemonSet", &daemonSetRes),
+			)
+		})
 	})
 
 	It("all pods should be ready when deployed", func() {

--- a/tests/nodeLabeller_test.go
+++ b/tests/nodeLabeller_test.go
@@ -26,34 +26,66 @@ var _ = Describe("Node Labeller", func() {
 
 	BeforeEach(func() {
 		clusterRoleRes = testResource{
-			Name:       nodelabeller.ClusterRoleName,
-			resource:   &rbac.ClusterRole{},
-			Namsespace: "",
+			Name:      nodelabeller.ClusterRoleName,
+			Resource:  &rbac.ClusterRole{},
+			Namespace: "",
+			UpdateFunc: func(role *rbac.ClusterRole) {
+				role.Rules[0].Verbs = []string{"watch"}
+			},
+			EqualsFunc: func(old *rbac.ClusterRole, new *rbac.ClusterRole) bool {
+				return reflect.DeepEqual(old.Rules, new.Rules)
+			},
 		}
 		clusterRoleBindingRes = testResource{
-			Name:       nodelabeller.ClusterRoleBindingName,
-			resource:   &rbac.ClusterRoleBinding{},
-			Namsespace: "",
+			Name:      nodelabeller.ClusterRoleBindingName,
+			Resource:  &rbac.ClusterRoleBinding{},
+			Namespace: "",
+			UpdateFunc: func(roleBinding *rbac.ClusterRoleBinding) {
+				roleBinding.Subjects = []rbac.Subject{}
+			},
+			EqualsFunc: func(old *rbac.ClusterRoleBinding, new *rbac.ClusterRoleBinding) bool {
+				return reflect.DeepEqual(old.Subjects, new.Subjects)
+			},
 		}
 		serviceAccountRes = testResource{
-			Name:       nodelabeller.ServiceAccountName,
-			Namsespace: strategy.GetNamespace(),
-			resource:   &core.ServiceAccount{},
+			Name:      nodelabeller.ServiceAccountName,
+			Namespace: strategy.GetNamespace(),
+			Resource:  &core.ServiceAccount{},
 		}
 		securityContextConstraintRes = testResource{
-			Name:       nodelabeller.SecurityContextName,
-			Namsespace: "",
-			resource:   &secv1.SecurityContextConstraints{},
+			Name:      nodelabeller.SecurityContextName,
+			Namespace: "",
+			Resource:  &secv1.SecurityContextConstraints{},
+			UpdateFunc: func(scc *secv1.SecurityContextConstraints) {
+				scc.Users = []string{"test-user"}
+			},
+			EqualsFunc: func(old *secv1.SecurityContextConstraints, new *secv1.SecurityContextConstraints) bool {
+				return reflect.DeepEqual(old.Users, new.Users)
+			},
 		}
 		configMapRes = testResource{
-			Name:       nodelabeller.ConfigMapName,
-			Namsespace: strategy.GetNamespace(),
-			resource:   &core.ConfigMap{},
+			Name:      nodelabeller.ConfigMapName,
+			Namespace: strategy.GetNamespace(),
+			Resource:  &core.ConfigMap{},
+			UpdateFunc: func(configMap *core.ConfigMap) {
+				configMap.Data = map[string]string{
+					"cpu-plugin-configmap.yaml": "change data",
+				}
+			},
+			EqualsFunc: func(old *core.ConfigMap, new *core.ConfigMap) bool {
+				return reflect.DeepEqual(old.Data, new.Data)
+			},
 		}
 		daemonSetRes = testResource{
-			Name:       nodelabeller.DaemonSetName,
-			Namsespace: strategy.GetNamespace(),
-			resource:   &apps.DaemonSet{},
+			Name:      nodelabeller.DaemonSetName,
+			Namespace: strategy.GetNamespace(),
+			Resource:  &apps.DaemonSet{},
+			UpdateFunc: func(daemonSet *apps.DaemonSet) {
+				daemonSet.Spec.Template.Spec.ServiceAccountName = "test-account"
+			},
+			EqualsFunc: func(old *apps.DaemonSet, new *apps.DaemonSet) bool {
+				return reflect.DeepEqual(old.Spec, new.Spec)
+			},
 		}
 
 		waitUntilDeployed()
@@ -94,47 +126,11 @@ var _ = Describe("Node Labeller", func() {
 
 	Context("resource change", func() {
 		table.DescribeTable("should restore modified resource", expectRestoreAfterUpdate,
-			table.Entry("[test_id:5195] cluster role", &clusterRoleRes,
-				func(role *rbac.ClusterRole) {
-					role.Rules[0].Verbs = []string{"watch"}
-				},
-				func(old *rbac.ClusterRole, new *rbac.ClusterRole) bool {
-					return reflect.DeepEqual(old.Rules, new.Rules)
-				}),
-
-			table.Entry("[test_id:5197] cluster role binding", &clusterRoleBindingRes,
-				func(roleBinding *rbac.ClusterRoleBinding) {
-					roleBinding.Subjects = []rbac.Subject{}
-				},
-				func(old *rbac.ClusterRoleBinding, new *rbac.ClusterRoleBinding) bool {
-					return reflect.DeepEqual(old.Subjects, new.Subjects)
-				}),
-
-			table.Entry("[test_id:5204] security context constraint", &securityContextConstraintRes,
-				func(scc *secv1.SecurityContextConstraints) {
-					scc.Users = []string{"test-user"}
-				},
-				func(old *secv1.SecurityContextConstraints, new *secv1.SecurityContextConstraints) bool {
-					return reflect.DeepEqual(old.Users, new.Users)
-				}),
-
-			table.Entry("[test_id:5201] Config Map", &configMapRes,
-				func(configMap *core.ConfigMap) {
-					configMap.Data = map[string]string{
-						"cpu-plugin-configmap.yaml": "change data",
-					}
-				},
-				func(old *core.ConfigMap, new *core.ConfigMap) bool {
-					return reflect.DeepEqual(old.Data, new.Data)
-				}),
-
-			table.Entry("[test_id:5192] daemonSet", &daemonSetRes,
-				func(daemonSet *apps.DaemonSet) {
-					daemonSet.Spec.Template.Spec.ServiceAccountName = "test-account"
-				},
-				func(old *apps.DaemonSet, new *apps.DaemonSet) bool {
-					return reflect.DeepEqual(old.Spec, new.Spec)
-				}),
+			table.Entry("[test_id:5195] cluster role", &clusterRoleRes),
+			table.Entry("[test_id:5197] cluster role binding", &clusterRoleBindingRes),
+			table.Entry("[test_id:5204] security context constraint", &securityContextConstraintRes),
+			table.Entry("[test_id:5201] Config Map", &configMapRes),
+			table.Entry("[test_id:5192] daemonSet", &daemonSetRes),
 		)
 	})
 

--- a/tests/tests_common_test.go
+++ b/tests/tests_common_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"github.com/onsi/ginkgo"
 	"reflect"
 
 	. "github.com/onsi/gomega"
@@ -15,26 +16,39 @@ import (
 )
 
 type testResource struct {
-	Name       string
-	Namsespace string
-	resource   controllerutil.Object
+	Name      string
+	Namespace string
+	Resource  controllerutil.Object
+
+	UpdateFunc interface{}
+	EqualsFunc interface{}
 }
 
 func (r *testResource) NewResource() controllerutil.Object {
-	return r.resource.DeepCopyObject().(controllerutil.Object)
+	return r.Resource.DeepCopyObject().(controllerutil.Object)
 }
 
 func (r *testResource) GetKey() client.ObjectKey {
 	return client.ObjectKey{
 		Name:      r.Name,
-		Namespace: r.Namsespace,
+		Namespace: r.Namespace,
 	}
+}
+
+func (r *testResource) Update(obj controllerutil.Object) {
+	reflect.ValueOf(r.UpdateFunc).Call([]reflect.Value{reflect.ValueOf(obj)})
+}
+
+func (r *testResource) Equals(a, b controllerutil.Object) bool {
+	result := reflect.ValueOf(r.EqualsFunc).
+		Call([]reflect.Value{reflect.ValueOf(a), reflect.ValueOf(b)})
+	return result[0].Bool()
 }
 
 func expectRecreateAfterDelete(res *testResource) {
 	resource := res.NewResource()
 	resource.SetName(res.Name)
-	resource.SetNamespace(res.Namsespace)
+	resource.SetNamespace(res.Namespace)
 
 	// Watch status of the SSP resource
 	watch, err := StartWatch(sspListerWatcher)
@@ -50,23 +64,26 @@ func expectRecreateAfterDelete(res *testResource) {
 	Expect(err).ToNot(HaveOccurred(), "SSP status should be deployed.")
 
 	err = apiClient.Get(ctx, client.ObjectKey{
-		Name: res.Name, Namespace: res.Namsespace,
+		Name: res.Name, Namespace: res.Namespace,
 	}, resource)
 	Expect(err).ToNot(HaveOccurred())
 }
 
-func expectRestoreAfterUpdate(res *testResource, updateFunc interface{}, equalsFunc interface{}) {
-	key := res.GetKey()
+func expectRestoreAfterUpdate(res *testResource) {
+	if res.UpdateFunc == nil || res.EqualsFunc == nil {
+		ginkgo.Fail("Update or Equals functions are not defined.")
+	}
+
 	original := res.NewResource()
-	Expect(apiClient.Get(ctx, key, original)).ToNot(HaveOccurred())
+	Expect(apiClient.Get(ctx, res.GetKey(), original)).ToNot(HaveOccurred())
 
 	// Watch status of the SSP resource
 	watch, err := StartWatch(sspListerWatcher)
 	Expect(err).ToNot(HaveOccurred())
 	defer watch.Stop()
 
-	changed := original.DeepCopyObject()
-	reflect.ValueOf(updateFunc).Call([]reflect.Value{reflect.ValueOf(changed)})
+	changed := original.DeepCopyObject().(controllerutil.Object)
+	res.Update(changed)
 	Expect(apiClient.Update(ctx, changed)).ToNot(HaveOccurred())
 
 	err = WatchChangesUntil(watch, isStatusDeploying, shortTimeout)
@@ -75,13 +92,9 @@ func expectRestoreAfterUpdate(res *testResource, updateFunc interface{}, equalsF
 	err = WatchChangesUntil(watch, isStatusDeployed, timeout)
 	Expect(err).ToNot(HaveOccurred(), "SSP status should be deployed.")
 
-	newRes := res.NewResource()
-	Expect(apiClient.Get(ctx, key, newRes)).ToNot(HaveOccurred())
-	result := reflect.ValueOf(equalsFunc).Call([]reflect.Value{
-		reflect.ValueOf(original),
-		reflect.ValueOf(newRes),
-	})
-	Expect(result[0].Interface().(bool)).To(BeTrue())
+	found := res.NewResource()
+	Expect(apiClient.Get(ctx, res.GetKey(), found)).ToNot(HaveOccurred())
+	Expect(res.Equals(original, found)).To(BeTrue())
 }
 
 func hasOwnerAnnotations(annotations map[string]string) bool {

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -323,14 +323,6 @@ func getBoolEnv(envName string) bool {
 	return val
 }
 
-func updateSsp(updateFunc func(foundSsp *sspv1beta1.SSP)) {
-	Eventually(func() error {
-		foundSsp := getSsp()
-		updateFunc(foundSsp)
-		return apiClient.Update(ctx, foundSsp)
-	}, timeout, time.Second).ShouldNot(HaveOccurred())
-}
-
 func createOrUpdateSsp(ssp *sspv1beta1.SSP) {
 	key := client.ObjectKey{
 		Name:      ssp.Name,

--- a/tests/validator_test.go
+++ b/tests/validator_test.go
@@ -48,7 +48,7 @@ var _ = Describe("Template validator", func() {
 			Name:     validator.ClusterRoleBindingName,
 			Resource: &rbac.ClusterRoleBinding{},
 			UpdateFunc: func(roleBinding *rbac.ClusterRoleBinding) {
-				roleBinding.Subjects = []rbac.Subject{}
+				roleBinding.Subjects = nil
 			},
 			EqualsFunc: func(old *rbac.ClusterRoleBinding, new *rbac.ClusterRoleBinding) bool {
 				return reflect.DeepEqual(old.RoleRef, new.RoleRef) &&
@@ -59,7 +59,7 @@ var _ = Describe("Template validator", func() {
 			Name:     validator.WebhookName,
 			Resource: &admission.ValidatingWebhookConfiguration{},
 			UpdateFunc: func(webhook *admission.ValidatingWebhookConfiguration) {
-				webhook.Webhooks[0].Rules = []admission.RuleWithOperations{}
+				webhook.Webhooks[0].Rules = nil
 			},
 			EqualsFunc: func(old *admission.ValidatingWebhookConfiguration, new *admission.ValidatingWebhookConfiguration) bool {
 				return reflect.DeepEqual(old.Webhooks, new.Webhooks)
@@ -138,6 +138,24 @@ var _ = Describe("Template validator", func() {
 			table.Entry("[test_id:4923] service", &serviceRes),
 			table.Entry("[test_id:4925] deployment", &deploymentRes),
 		)
+
+		Context("with pause", func() {
+			BeforeEach(func() {
+				strategy.SkipSspUpdateTestsIfNeeded()
+			})
+
+			JustAfterEach(func() {
+				unpauseSsp()
+			})
+
+			table.DescribeTable("should restore modified resource with pause", expectRestoreAfterUpdateWithPause,
+				table.Entry("[test_id:5534] cluster role", &clusterRoleRes),
+				table.Entry("[test_id:5535] cluster role binding", &clusterRoleBindingRes),
+				table.Entry("[test_id:5536] validating webhook configuration", &webhookConfigRes),
+				table.Entry("[test_id:5538] service", &serviceRes),
+				table.Entry("[test_id:5539] deployment", &deploymentRes),
+			)
+		})
 	})
 
 	It("[test_id:4913] should successfully start template-validator pod", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
When debugging the deployment, it can be useful to pause the operator.

The reconciliation can be paused by adding annotation:
`"kubevirt.io/operator.paused": "true"`


```release-note
NONE
```
