### PR TITLE
Run functional tests with existing SSP CR

### DIFF
--- a/tests/metrics_test.go
+++ b/tests/metrics_test.go
@@ -11,13 +11,15 @@ import (
 )
 
 var _ = Describe("Metrics", func() {
-	var prometheusRuleRes = &testResource{
-		Name:       metrics.PrometheusRuleName,
-		Namsespace: testNamespace,
-		resource:   &promv1.PrometheusRule{},
-	}
+	var prometheusRuleRes testResource
 
 	BeforeEach(func() {
+		prometheusRuleRes = testResource{
+			Name:       metrics.PrometheusRuleName,
+			Namsespace: strategy.GetNamespace(),
+			resource:   &promv1.PrometheusRule{},
+		}
+
 		waitUntilDeployed()
 	})
 
@@ -26,11 +28,11 @@ var _ = Describe("Metrics", func() {
 	})
 
 	It("should recreate deleted prometheus rule", func() {
-		expectRecreateAfterDelete(prometheusRuleRes)
+		expectRecreateAfterDelete(&prometheusRuleRes)
 	})
 
 	It("[test_id:4666] should restore modified prometheus rule", func() {
-		expectRestoreAfterUpdate(prometheusRuleRes,
+		expectRestoreAfterUpdate(&prometheusRuleRes,
 			func(rule *promv1.PrometheusRule) {
 				rule.Spec.Groups[0].Name = "changed-name"
 				rule.Spec.Groups[0].Rules = []promv1.Rule{}

--- a/tests/tests_common_test.go
+++ b/tests/tests_common_test.go
@@ -86,7 +86,7 @@ func expectRestoreAfterUpdate(res *testResource, updateFunc interface{}, equalsF
 
 func hasOwnerAnnotations(annotations map[string]string) bool {
 	const typeName = "SSP.ssp.kubevirt.io"
-	namespacedName := ssp.Namespace + "/" + ssp.Name
+	namespacedName := strategy.GetNamespace() + "/" + strategy.GetName()
 
 	if annotations == nil {
 		return false

--- a/tests/webhook_test.go
+++ b/tests/webhook_test.go
@@ -1,11 +1,9 @@
 package tests
 
 import (
+	"fmt"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	sspv1alpha1 "kubevirt.io/ssp-operator/api/v1alpha1"
 )
 
 var _ = Describe("Validation webhook", func() {
@@ -15,7 +13,8 @@ var _ = Describe("Validation webhook", func() {
 
 	Context("creation", func() {
 		It("[test_id:5242] should fail to create a second SSP CR", func() {
-			ssp2 := ssp.DeepCopy()
+			foundSsp := getSsp()
+			ssp2 := foundSsp.DeepCopy()
 			ssp2.Name = "test-ssp2"
 
 			err := apiClient.Create(ctx, ssp2)
@@ -23,24 +22,29 @@ var _ = Describe("Validation webhook", func() {
 				apiClient.Delete(ctx, ssp2)
 				Fail("Second SSP resource created.")
 			}
-			Expect(err.Error()).To(ContainSubstring("creation failed, an SSP CR already exists in namespace ssp-operator-functests: test-s"))
+			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf(
+				"creation failed, an SSP CR already exists in namespace %v: %v",
+				foundSsp.Namespace,
+				foundSsp.Name,
+			)))
 		})
 	})
 
 	Context("update", func() {
+		BeforeEach(func() {
+			strategy.SkipSspUpdateTestsIfNeeded()
+		})
+
+		AfterEach(func() {
+			strategy.RevertToOriginalSspCr()
+		})
+
 		It("should fail to update commonTemplates.namespace", func() {
-			key := client.ObjectKey{Name: ssp.Name, Namespace: ssp.Namespace}
-			foundSsp := &sspv1alpha1.SSP{}
-			Expect(apiClient.Get(ctx, key, foundSsp)).ToNot(HaveOccurred())
-
-			foundSsp.Spec.CommonTemplates.Namespace = commonTemplatesTestNS + "-updated"
+			foundSsp := getSsp()
+			originalNs := foundSsp.Spec.CommonTemplates.Namespace
+			foundSsp.Spec.CommonTemplates.Namespace = originalNs + "-updated"
 			err := apiClient.Update(ctx, foundSsp)
-			if err == nil {
-				foundSsp.Spec.CommonTemplates.Namespace = commonTemplatesTestNS
-				Expect(apiClient.Update(ctx, foundSsp)).ToNot(HaveOccurred())
-				Fail("update succeeded")
-			}
-
+			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("commonTemplates.namespace cannot be changed."))
 		})
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:
Added an option to run functional tests with an existing SSP CR.

This patch adds these environment variables:
- `TEST_EXISTING_CR_NAME` - Name of the SSP CR
- `TEST_EXISTING_CR_NAMESPACE` - Namespace of the SSP CR
- `SKIP_UPDATE_SSP_TESTS` - If `true`, tests that modify the SSP CR are skipped. This is useful if another controller watches the CR and reverts any changes

If `TEST_EXISTING_CR_NAME` is not defined, the tests create a new SSP CR.

```release-note
NONE
```
