### PR TITLE
Remove workload, flavor, os labels from templates which have older version

### DIFF
--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
 	sspv1beta1 "kubevirt.io/ssp-operator/api/v1beta1"
+	commonTemplates "kubevirt.io/ssp-operator/internal/operands/common-templates"
 )
 
 const (
@@ -88,6 +89,19 @@ func (s *newSspStrategy) Init() {
 	Eventually(func() error {
 		return apiClient.Create(ctx, newSsp)
 	}, timeout, time.Second).ShouldNot(HaveOccurred())
+
+	Eventually(func() error {
+		return apiClient.Create(ctx, getTestTemplate("3", strategy.GetTemplatesNamespace(), commonTemplates.Version))
+	}, timeout, time.Second).ShouldNot(HaveOccurred())
+
+	Eventually(func() error {
+		return apiClient.Create(ctx, getTestTemplate("1", strategy.GetTemplatesNamespace(), "v0.0.1"))
+	}, timeout, time.Second).ShouldNot(HaveOccurred())
+
+	Eventually(func() error {
+		return apiClient.Create(ctx, getTestTemplate("2", strategy.GetTemplatesNamespace(), "v0.0.1"))
+	}, timeout, time.Second).ShouldNot(HaveOccurred())
+
 	s.ssp = newSsp
 }
 
@@ -171,6 +185,18 @@ func (s *existingSspStrategy) Init() {
 	updateSsp(func(foundSsp *sspv1beta1.SSP) {
 		foundSsp.Spec.TemplateValidator.Replicas = &newReplicasCount
 	})
+
+	Eventually(func() error {
+		return apiClient.Create(ctx, getTestTemplate("1", strategy.GetTemplatesNamespace(), "v0.0.1"))
+	}, timeout, time.Second).ShouldNot(HaveOccurred())
+
+	Eventually(func() error {
+		return apiClient.Create(ctx, getTestTemplate("2", strategy.GetTemplatesNamespace(), "v0.0.1"))
+	}, timeout, time.Second).ShouldNot(HaveOccurred())
+
+	Eventually(func() error {
+		return apiClient.Create(ctx, getTestTemplate("3", strategy.GetTemplatesNamespace(), commonTemplates.Version))
+	}, timeout, time.Second).ShouldNot(HaveOccurred())
 
 	Consistently(func() int32 {
 		return *getSsp().Spec.TemplateValidator.Replicas


### PR DESCRIPTION
**What this PR does / why we need it**:
remove workload, flavor, os labels from templates which have older version

With labels removed, old templates will no longer be visible in UI.
**Which issue(s) this PR fixes**:
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1859235

**Release note**:
```
SSP operator now removes workload, flavor, os labels from templates which have older version
```
