### PR TITLE
Validate that namespace for common templates exists

### DIFF
--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -346,7 +346,14 @@ func createOrUpdateSsp(ssp *sspv1beta1.SSP) {
 			return apiClient.Update(ctx, foundSsp)
 		}
 		if errors.IsNotFound(err) {
-			return apiClient.Create(ctx, ssp)
+			newSsp := &sspv1beta1.SSP{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      ssp.Name,
+					Namespace: ssp.Namespace,
+				},
+				Spec: ssp.Spec,
+			}
+			return apiClient.Create(ctx, newSsp)
 		}
 		return err
 	}, timeout, time.Second).ShouldNot(HaveOccurred())


### PR DESCRIPTION
**What this PR does / why we need it**:
Webhook validates that namespace set in `commonTemplates.namespace` exists.

**Release note**:
```release-note
NONE
```
