### PR TITLE
Change resource names used by operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ deploy: manifests kustomize
 
 # Generate manifests e.g. CRD, RBAC etc.
 manifests: controller-gen
-	$(CONTROLLER_GEN) crd rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	$(CONTROLLER_GEN) crd rbac:roleName=operator-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 
 # Run go fmt against code
 fmt:

--- a/api/v1beta1/ssp_webhook.go
+++ b/api/v1beta1/ssp_webhook.go
@@ -39,7 +39,7 @@ func (r *SSP) SetupWebhookWithManager(mgr ctrl.Manager) error {
 		Complete()
 }
 
-// +kubebuilder:webhook:verbs=create;update,path=/validate-ssp-kubevirt-io-v1beta1-ssp,mutating=false,failurePolicy=fail,groups=ssp.kubevirt.io,resources=ssps,versions=v1beta1,name=vssp.kb.io,webhookVersions=v1beta1
+// +kubebuilder:webhook:verbs=create;update,path=/validate-ssp-kubevirt-io-v1beta1-ssp,mutating=false,failurePolicy=fail,groups=ssp.kubevirt.io,resources=ssps,versions=v1beta1,name=vssp.kb.io,webhookVersions=v1beta1,sideEffects=None
 
 var _ webhook.Validator = &SSP{}
 

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,18 +1,12 @@
 # Adds namespace to all resources.
 namespace: kubevirt
 
-# Value of this field is prepended to the
-# names of all resources, e.g. a deployment named
-# "wordpress" becomes "alices-wordpress".
-# Note that it should also match with the prefix (text before '-') of the namespace
-# field above.
-namePrefix: ""
-
 # Labels to add to all resources and selectors.
 #commonLabels:
 #  someName: someValue
 
 bases:
+- ../namespace
 - ../crd
 - ../rbac
 - ../manager

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -3,7 +3,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: ssp-operator
+  name: operator
   namespace: kubevirt
 spec:
   template:

--- a/config/default/manager_webhook_patch.yaml
+++ b/config/default/manager_webhook_patch.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: ssp-operator
+  name: operator
   namespace: kubevirt
 spec:
   template:
@@ -20,4 +20,4 @@ spec:
       - name: cert
         secret:
           defaultMode: 420
-          secretName: webhook-server-cert
+          secretName: ssp-webhook-server-cert

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,3 +1,6 @@
+
+namePrefix: ssp-
+
 resources:
 - manager.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -1,12 +1,14 @@
+kind: ServiceAccount
 apiVersion: v1
-kind: Namespace
 metadata:
-  name: kubevirt
+  name: operator
+  labels:
+    control-plane: ssp-operator
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: ssp-operator
+  name: operator
   namespace: kubevirt
   labels:
     control-plane: ssp-operator
@@ -20,6 +22,7 @@ spec:
       labels:
         control-plane: ssp-operator
     spec:
+      serviceAccountName: ssp-operator
       containers:
       - command:
         - /manager

--- a/config/manifests/bases/ssp-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ssp-operator.clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
     categories: Openshift Optional
     containerImage: REPLACE_IMAGE:TAG
     description: Manages KubeVirt addons for Scheduling, Scale, Performance
-    operators.operatorframework.io/builder: operator-sdk-v1.0.0
+    operators.operatorframework.io/builder: operator-sdk-v1.1.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
   name: ssp-operator.vX.Y.Z
   namespace: kubevirt

--- a/config/namespace/kustomization.yaml
+++ b/config/namespace/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- namespace.yaml

--- a/config/namespace/namespace.yaml
+++ b/config/namespace/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kubevirt

--- a/config/rbac/auth_proxy_role_binding.yaml
+++ b/config/rbac/auth_proxy_role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: proxy-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: ssp-operator
   namespace: kubevirt

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -1,3 +1,5 @@
+namePrefix: "ssp-"
+
 resources:
 - role.yaml
 - role_binding.yaml
@@ -6,7 +8,7 @@ resources:
 # Comment the following 4 lines if you want to disable
 # the auth proxy (https://github.com/brancz/kube-rbac-proxy)
 # which protects your /metrics endpoint.
-- auth_proxy_service.yaml
-- auth_proxy_role.yaml
-- auth_proxy_role_binding.yaml
-- auth_proxy_client_clusterrole.yaml
+#- auth_proxy_service.yaml
+#- auth_proxy_role.yaml
+#- auth_proxy_role_binding.yaml
+#- auth_proxy_client_clusterrole.yaml

--- a/config/rbac/leader_election_role_binding.yaml
+++ b/config/rbac/leader_election_role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: ssp-operator
   namespace: kubevirt

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: manager-role
+  name: operator-role
 rules:
 - apiGroups:
   - admissionregistration.k8s.io

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -1,12 +1,12 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: manager-rolebinding
+  name: operator-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: manager-role
+  name: operator-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: ssp-operator
   namespace: kubevirt

--- a/config/samples/ssp_v1beta1_ssp.yaml
+++ b/config/samples/ssp_v1beta1_ssp.yaml
@@ -6,3 +6,5 @@ metadata:
 spec:
   commonTemplates:
     namespace: kubevirt
+  templateValidator:
+    replicas: 2

--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -1,6 +1,21 @@
+
+namePrefix: "ssp-"
+
 resources:
 - manifests.v1beta1.yaml
 - service.yaml
 
 configurations:
 - kustomizeconfig.yaml
+
+patches:
+- target:
+    kind: ValidatingWebhookConfiguration
+    name: validating-webhook-configuration
+  patch: |-
+    - op: replace
+      path: /webhooks/0/clientConfig/service/name
+      value: ssp-webhook-service
+    - op: replace
+      path: /webhooks/0/clientConfig/service/namespace
+      value: kubevirt

--- a/config/webhook/manifests.v1beta1.yaml
+++ b/config/webhook/manifests.v1beta1.yaml
@@ -24,3 +24,4 @@ webhooks:
     - UPDATE
     resources:
     - ssps
+  sideEffects: None

--- a/config/webhook/service.yaml
+++ b/config/webhook/service.yaml
@@ -5,7 +5,7 @@ metadata:
   name: webhook-service
   namespace: kubevirt
   annotations:
-    service.beta.openshift.io/serving-cert-secret-name: webhook-server-cert
+    service.beta.openshift.io/serving-cert-secret-name: ssp-webhook-server-cert
 spec:
   ports:
     - port: 443

--- a/data/olm-catalog/ssp-operator.clusterserviceversion.yaml
+++ b/data/olm-catalog/ssp-operator.clusterserviceversion.yaml
@@ -1,4 +1,4 @@
-apiVersion: operators.coreos.com/v1beta1
+apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   annotations:
@@ -26,7 +26,7 @@ metadata:
     categories: Openshift Optional
     containerImage: REPLACE_IMAGE:TAG
     description: Manages KubeVirt addons for Scheduling, Scale, Performance
-    operators.operatorframework.io/builder: operator-sdk-v1.0.0
+    operators.operatorframework.io/builder: operator-sdk-v1.1.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
   name: ssp-operator.v0.0.1
   namespace: kubevirt
@@ -60,6 +60,12 @@ spec:
           - patch
           - update
           - watch
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - list
         - apiGroups:
           - apps
           resources:
@@ -230,6 +236,54 @@ spec:
         - apiGroups:
           - ssp.kubevirt.io
           resources:
+          - kubevirtcommontemplatesbundles
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ssp.kubevirt.io
+          resources:
+          - kubevirtmetricsaggregations
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ssp.kubevirt.io
+          resources:
+          - kubevirtnodelabellerbundles
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ssp.kubevirt.io
+          resources:
+          - kubevirttemplatevalidators
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ssp.kubevirt.io
+          resources:
           - ssps
           verbs:
           - create
@@ -279,32 +333,20 @@ spec:
           - create
         serviceAccountName: default
       deployments:
-      - name: ssp-operator-update-controller-manager
+      - name: ssp-operator
         spec:
           replicas: 1
           selector:
             matchLabels:
-              control-plane: controller-manager
+              control-plane: ssp-operator
           strategy: {}
           template:
             metadata:
               labels:
-                control-plane: controller-manager
+                control-plane: ssp-operator
             spec:
               containers:
               - args:
-                - --secure-listen-address=0.0.0.0:8443
-                - --upstream=http://127.0.0.1:8080/
-                - --logtostderr=true
-                - --v=10
-                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
-                name: kube-rbac-proxy
-                ports:
-                - containerPort: 8443
-                  name: https
-                resources: {}
-              - args:
-                - --metrics-addr=127.0.0.1:8080
                 - --enable-leader-election
                 command:
                 - /manager
@@ -400,8 +442,9 @@ spec:
       operated-by: ssp-operator
   version: 0.0.1
   webhookdefinitions:
-  - admissionReviewVersions: null
-    deploymentName: ssp-operator-update-webhook
+  - admissionReviewVersions:
+    - v1beta1
+    deploymentName: ssp-operator
     failurePolicy: Fail
     generateName: vssp.kb.io
     rules:
@@ -414,6 +457,6 @@ spec:
       - UPDATE
       resources:
       - ssps
-    sideEffects: null
+    sideEffects: None
     type: ValidatingAdmissionWebhook
     webhookPath: /validate-ssp-kubevirt-io-v1beta1-ssp

--- a/data/olm-catalog/ssp-operator.clusterserviceversion.yaml
+++ b/data/olm-catalog/ssp-operator.clusterserviceversion.yaml
@@ -9,15 +9,14 @@ metadata:
           "kind": "SSP",
           "metadata": {
             "name": "ssp-sample",
-            "namespace": "test-kubevirt"
+            "namespace": "kubevirt"
           },
           "spec": {
-            "nodeLabeller": {
-              "placement": {}
+            "commonTemplates": {
+              "namespace": "kubevirt"
             },
             "templateValidator": {
-              "placement": {},
-              "replicas": 1
+              "replicas": 2
             }
           }
         }
@@ -319,19 +318,7 @@ spec:
           - patch
           - update
           - watch
-        - apiGroups:
-          - authentication.k8s.io
-          resources:
-          - tokenreviews
-          verbs:
-          - create
-        - apiGroups:
-          - authorization.k8s.io
-          resources:
-          - subjectaccessreviews
-          verbs:
-          - create
-        serviceAccountName: default
+        serviceAccountName: ssp-operator
       deployments:
       - name: ssp-operator
         spec:
@@ -368,12 +355,13 @@ spec:
                 - mountPath: /tmp/k8s-webhook-server/serving-certs
                   name: cert
                   readOnly: true
+              serviceAccountName: ssp-operator
               terminationGracePeriodSeconds: 10
               volumes:
               - name: cert
                 secret:
                   defaultMode: 420
-                  secretName: webhook-server-cert
+                  secretName: ssp-webhook-server-cert
       permissions:
       - rules:
         - apiGroups:
@@ -403,7 +391,7 @@ spec:
           verbs:
           - create
           - patch
-        serviceAccountName: default
+        serviceAccountName: ssp-operator
     strategy: deployment
   installModes:
   - supported: true


### PR DESCRIPTION
**What this PR does / why we need it**:
The default names generated by operator-sdk may collide with other operators created using the SDK

**Release note**:
```release-note
NONE
```

This PR uses code from PR: #51 