### PR TITLE
Break infinite reconciliation loop

### DIFF
--- a/internal/common/request.go
+++ b/internal/common/request.go
@@ -13,10 +13,10 @@ import (
 
 type Request struct {
 	reconcile.Request
-	Client               client.Client
-	Scheme               *runtime.Scheme
-	Context              context.Context
-	Instance             *ssp.SSP
-	Logger               logr.Logger
-	ResourceVersionCache VersionCache
+	Client       client.Client
+	Scheme       *runtime.Scheme
+	Context      context.Context
+	Instance     *ssp.SSP
+	Logger       logr.Logger
+	VersionCache VersionCache
 }

--- a/internal/operands/common-templates/reconcile.go
+++ b/internal/operands/common-templates/reconcile.go
@@ -90,10 +90,8 @@ func (c *commonTemplates) Cleanup(request *common.Request) error {
 
 func reconcileGoldenImagesNS(request *common.Request) (common.ResourceStatus, error) {
 	return common.CreateOrUpdateClusterResource(request, newGoldenImagesNS(GoldenImagesNSname),
-		func(newRes, foundRes controllerutil.Object) {
-			newNS := newRes.(*core.Namespace)
-			foundNS := foundRes.(*core.Namespace)
-			foundNS.Spec = newNS.Spec
+		func(_, _ controllerutil.Object) {
+			// Namespace spec only contains finalizers, which can be modified
 		})
 }
 func reconcileViewRole(request *common.Request) (common.ResourceStatus, error) {

--- a/internal/operands/metrics/reconcile_test.go
+++ b/internal/operands/metrics/reconcile_test.go
@@ -57,8 +57,8 @@ var _ = Describe("Metrics operand", func() {
 					Namespace: namespace,
 				},
 			},
-			Logger:               log,
-			ResourceVersionCache: common.VersionCache{},
+			Logger:       log,
+			VersionCache: common.VersionCache{},
 		}
 
 		_, err := operand.Reconcile(&request)

--- a/internal/operands/template-validator/reconcile.go
+++ b/internal/operands/template-validator/reconcile.go
@@ -131,14 +131,14 @@ func reconcileDeployment(request *common.Request) (common.ResourceStatus, error)
 		func(res controllerutil.Object) common.ResourceStatus {
 			dep := res.(*apps.Deployment)
 			status := common.ResourceStatus{}
-			if dep.Status.Replicas > 0 && dep.Status.AvailableReplicas == 0 {
+			if *validatorSpec.Replicas > 0 && dep.Status.AvailableReplicas == 0 {
 				msg := fmt.Sprintf("No validator pods are running. Expected: %d", dep.Status.Replicas)
 				status.NotAvailable = &msg
 			}
-			if dep.Status.UnavailableReplicas != 0 {
+			if dep.Status.AvailableReplicas != *validatorSpec.Replicas {
 				msg := fmt.Sprintf(
 					"Not all template validator pods are running. Expected: %d, running: %d",
-					dep.Status.Replicas,
+					*validatorSpec.Replicas,
 					dep.Status.AvailableReplicas,
 				)
 				status.Progressing = &msg

--- a/internal/operands/template-validator/reconcile_test.go
+++ b/internal/operands/template-validator/reconcile_test.go
@@ -67,8 +67,8 @@ var _ = Describe("Template validator operand", func() {
 					},
 				},
 			},
-			Logger:               log,
-			ResourceVersionCache: common.VersionCache{},
+			Logger:       log,
+			VersionCache: common.VersionCache{},
 		}
 	})
 
@@ -145,13 +145,6 @@ var _ = Describe("Template validator operand", func() {
 		statuses, err := operand.Reconcile(&request)
 		Expect(err).ToNot(HaveOccurred())
 
-		// All resources should be progressing
-		for _, status := range statuses {
-			Expect(status.NotAvailable).ToNot(BeNil())
-			Expect(status.Progressing).ToNot(BeNil())
-			Expect(status.Degraded).ToNot(BeNil())
-		}
-
 		// Set status for deployment
 		key, _ := client.ObjectKeyFromObject(newDeployment(namespace, replicas, "test-img"))
 		updateDeployment(key, &request, func(deployment *apps.Deployment) {
@@ -203,6 +196,7 @@ func updateDeployment(key client.ObjectKey, request *common.Request, updateFunc 
 	Expect(request.Client.Get(request.Context, key, deployment)).ToNot(HaveOccurred())
 	updateFunc(deployment)
 	Expect(request.Client.Update(request.Context, deployment)).ToNot(HaveOccurred())
+	Expect(request.Client.Status().Update(request.Context, deployment)).ToNot(HaveOccurred())
 }
 
 func TestValidator(t *testing.T) {

--- a/tests/tests_common_test.go
+++ b/tests/tests_common_test.go
@@ -43,7 +43,7 @@ func expectRecreateAfterDelete(res *testResource) {
 
 	Expect(apiClient.Delete(ctx, resource)).ToNot(HaveOccurred())
 
-	err = WatchChangesUntil(watch, isStatusDeploying, timeout)
+	err = WatchChangesUntil(watch, isStatusDeploying, shortTimeout)
 	Expect(err).ToNot(HaveOccurred(), "SSP status should be deploying.")
 
 	err = WatchChangesUntil(watch, isStatusDeployed, timeout)
@@ -69,7 +69,7 @@ func expectRestoreAfterUpdate(res *testResource, updateFunc interface{}, equalsF
 	reflect.ValueOf(updateFunc).Call([]reflect.Value{reflect.ValueOf(changed)})
 	Expect(apiClient.Update(ctx, changed)).ToNot(HaveOccurred())
 
-	err = WatchChangesUntil(watch, isStatusDeploying, timeout)
+	err = WatchChangesUntil(watch, isStatusDeploying, shortTimeout)
 	Expect(err).ToNot(HaveOccurred(), "SSP status should be deploying.")
 
 	err = WatchChangesUntil(watch, isStatusDeployed, timeout)

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -37,7 +37,8 @@ const (
 	envSkipUpdateSspTests    = "SKIP_UPDATE_SSP_TESTS"
 	envSkipCleanupAfterTests = "SKIP_CLEANUP_AFTER_TESTS"
 
-	timeout = 10 * time.Minute
+	shortTimeout = 1 * time.Minute
+	timeout      = 10 * time.Minute
 )
 
 type TestSuiteStrategy interface {

--- a/tests/validator_test.go
+++ b/tests/validator_test.go
@@ -175,7 +175,7 @@ var _ = Describe("Template validator", func() {
 
 		deployment := &apps.Deployment{}
 		Expect(apiClient.Get(ctx, deploymentRes.GetKey(), deployment)).ToNot(HaveOccurred())
-		Expect(deployment.Status.ReadyReplicas).To(Equal(int32(strategy.GetValidatorReplicas())))
+		Expect(deployment.Status.AvailableReplicas).To(Equal(int32(strategy.GetValidatorReplicas())))
 	})
 
 	Context("with SSP resource modification", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
Since Openshift `4.6` and Kubernetes `v1.19.0`, a status change on SSP CR causes reconciliation.
This patch adds a predicate to ignore the status change, otherwise the operator would never stop with reconciliation.

**Release note**:
```release-note
NONE
```
