### PR TITLE
Remove unit tests from TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,6 @@ services:
   - docker
 jobs:
   include:
-  - stage: Unit tests
-    name: Unit tests
-    script: make unittest
-
   - stage: Test csv-generator
     name: Test csv-generator
     script: make container-build && ./tests/e2e-test-csv-generator.sh


### PR DESCRIPTION
**What this PR does / why we need it**:
The unit tests are currently run by OCP CI

**Release note**:
```release-note
NONE
```
