### PR TITLE
Fixed operator version assignment

### DIFF
--- a/controllers/ssp_controller.go
+++ b/controllers/ssp_controller.go
@@ -163,7 +163,7 @@ func (r *SSPReconciler) clearCache() {
 
 func getOperatorVersion() string {
 	opVer := os.Getenv("OPERATOR_VERSION")
-	if opVer != "" {
+	if opVer == "" {
 		return defaultOperatorVersion
 	}
 	return opVer


### PR DESCRIPTION
Fixed a condition that caused operator verison to default to 'devel' when it was actually provided

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
