### PR TITLE
Fix webhook tests that create resources with irrelevant metadata

### DIFF
--- a/tests/webhook_test.go
+++ b/tests/webhook_test.go
@@ -2,8 +2,10 @@ package tests
 
 import (
 	"fmt"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -19,7 +21,10 @@ var _ = Describe("Validation webhook", func() {
 		It("[test_id:5242] should fail to create a second SSP CR", func() {
 			foundSsp := getSsp()
 			ssp2 := foundSsp.DeepCopy()
-			ssp2.Name = "test-ssp2"
+			ssp2.ObjectMeta = v1.ObjectMeta{
+				Name:      "test-ssp2",
+				Namespace: foundSsp.GetNamespace(),
+			}
 
 			err := apiClient.Create(ctx, ssp2)
 			if err == nil {
@@ -48,6 +53,10 @@ var _ = Describe("Validation webhook", func() {
 				Expect(apiClient.Delete(ctx, foundSsp)).ToNot(HaveOccurred())
 				waitForDeletion(client.ObjectKey{Name: foundSsp.GetName(), Namespace: foundSsp.GetNamespace()}, &ssp.SSP{})
 
+				foundSsp.ObjectMeta = v1.ObjectMeta{
+					Name:      foundSsp.GetName(),
+					Namespace: foundSsp.GetNamespace(),
+				}
 				foundSsp.Spec.CommonTemplates.Namespace = "nonexisting-templates-namespace"
 
 				err := apiClient.Create(ctx, foundSsp)


### PR DESCRIPTION
**What this PR does / why we need it**:
Webhook tests were failing due to attempts to create SSP resources with metadata.resourceVersion defined.
This commit makes sure no existing object metadata is leftover on creation

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
