### PR TITLE
Remove workload, flavor, os labels from templates which have older version

### DIFF
--- a/tests/commonTemplates_test.go
+++ b/tests/commonTemplates_test.go
@@ -339,27 +339,28 @@ var _ = Describe("Common templates", func() {
 				var latestTemplates templatev1.TemplateList
 				err = apiClient.List(ctx, &latestTemplates, &opts)
 				Expect(err).To(BeNil())
+				Expect(len(latestTemplates.Items)).To(BeNumerically(">", 0))
 
 				for _, template := range latestTemplates.Items {
 					for _, label := range template.Labels {
-						if strings.HasPrefix(label, "os.template.kubevirt.io/") {
-							return template.Labels[label] == "true"
+						if strings.HasPrefix(label, "os.template.kubevirt.io/") && template.Labels[label] != "true" {
+							return false
 						}
-						if strings.HasPrefix(label, "flavor.template.kubevirt.io/") {
-							return template.Labels[label] == "true"
+						if strings.HasPrefix(label, "flavor.template.kubevirt.io/") && template.Labels[label] != "true" {
+							return false
 						}
-						if strings.HasPrefix(label, "workload.template.kubevirt.io/") {
-							return template.Labels[label] == "true"
+						if strings.HasPrefix(label, "workload.template.kubevirt.io/") && template.Labels[label] != "true"{
+							return false
 						}
 					}
-					if template.Labels["template.kubevirt.io/type"] == "base" {
-						return true
+					if template.Labels["template.kubevirt.io/type"] != "base" {
+						return false
 					}
-					if template.Labels["template.kubevirt.io/version"] == commonTemplates.Version {
-						return true
+					if template.Labels["template.kubevirt.io/version"] != commonTemplates.Version {
+						return false
 					}
 				}
-				return false
+				return true
 			}).Should(BeTrue())
 		})
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
remove workload, flavor, os labels from templates which have older version
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://bugzilla.redhat.com/show_bug.cgi?id=1859235

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
SSP operator now removes workload, flavor, os labels from templates which have older version
```
