### PR TITLE
[Bugfix] Make kubevirt-os-images visible to regular users

### DIFF
--- a/internal/operands/common-templates/resource.go
+++ b/internal/operands/common-templates/resource.go
@@ -68,6 +68,11 @@ func newViewRole(namespace string) *rbac.Role {
 				Resources: []string{"datavolumes/source"},
 				Verbs:     []string{"create"},
 			},
+			{
+				APIGroups: []string{""},
+				Resources: []string{"namespaces"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
 		},
 	}
 }

--- a/tests/commonTemplates_test.go
+++ b/tests/commonTemplates_test.go
@@ -2,17 +2,20 @@ package tests
 
 import (
 	"fmt"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/selection"
 	"reflect"
 	"strings"
+
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
 
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	templatev1 "github.com/openshift/api/template/v1"
+	authv1 "k8s.io/api/authorization/v1"
 	core "k8s.io/api/core/v1"
 	rbac "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -329,6 +332,81 @@ var _ = Describe("Common templates", func() {
 				Expect(template.Labels["template.kubevirt.io/version"]).To(Equal(commonTemplates.Version))
 
 			}
+		})
+	})
+
+	Context("rbac", func() {
+		Context("os-images", func() {
+			var (
+				regularSA *core.ServiceAccount
+			)
+
+			BeforeEach(func() {
+				regularSA = &core.ServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "regular-sa",
+						Namespace: strategy.GetNamespace(),
+					},
+				}
+
+				Expect(apiClient.Create(ctx, regularSA)).ToNot(HaveOccurred(), "creation of regular service account failed")
+				Expect(apiClient.Get(ctx, getResourceKey(regularSA), regularSA)).ToNot(HaveOccurred())
+			})
+
+			AfterEach(func() {
+				Expect(apiClient.Delete(ctx, regularSA)).NotTo(HaveOccurred())
+			})
+
+			It("regular service account should be able to 'get' os-images namespace", func() {
+				sar, err := coreClient.AuthorizationV1().SubjectAccessReviews().Create(ctx, &authv1.SubjectAccessReview{
+					Spec: authv1.SubjectAccessReviewSpec{
+						User:   fmt.Sprintf("system:serviceaccount:%s:%s", strategy.GetNamespace(), regularSA.GetName()),
+						Groups: []string{"system:serviceaccounts"},
+						ResourceAttributes: &authv1.ResourceAttributes{
+							Namespace: commonTemplates.GoldenImagesNSname,
+							Verb:      "get",
+							Version:   "v1",
+							Resource:  "namespaces",
+						},
+					},
+				}, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(sar.Status.Allowed).To(BeTrue(), "regular service account cannot 'get' the os images namespace")
+			})
+
+			It("regular service account should be able to 'list' os-images namespace", func() {
+				sar, err := coreClient.AuthorizationV1().SubjectAccessReviews().Create(ctx, &authv1.SubjectAccessReview{
+					Spec: authv1.SubjectAccessReviewSpec{
+						User:   fmt.Sprintf("system:serviceaccount:%s:%s", strategy.GetNamespace(), regularSA.GetName()),
+						Groups: []string{"system:serviceaccounts"},
+						ResourceAttributes: &authv1.ResourceAttributes{
+							Namespace: commonTemplates.GoldenImagesNSname,
+							Verb:      "list",
+							Version:   "v1",
+							Resource:  "namespaces",
+						},
+					},
+				}, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(sar.Status.Allowed).To(BeTrue(), "regular service account cannot 'list' the os images namespace")
+			})
+
+			It("regular service account should be able to 'watch' os-images namespace", func() {
+				sar, err := coreClient.AuthorizationV1().SubjectAccessReviews().Create(ctx, &authv1.SubjectAccessReview{
+					Spec: authv1.SubjectAccessReviewSpec{
+						User:   fmt.Sprintf("system:serviceaccount:%s:%s", strategy.GetNamespace(), regularSA.GetName()),
+						Groups: []string{"system:serviceaccounts"},
+						ResourceAttributes: &authv1.ResourceAttributes{
+							Namespace: commonTemplates.GoldenImagesNSname,
+							Verb:      "watch",
+							Version:   "v1",
+							Resource:  "namespaces",
+						},
+					},
+				}, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(sar.Status.Allowed).To(BeTrue(), "regular service account cannot 'watch' the os images namespace")
+			})
 		})
 	})
 })

--- a/tests/tests_common_test.go
+++ b/tests/tests_common_test.go
@@ -197,3 +197,10 @@ func isStatusDeployed(obj *v1beta1.SSP) bool {
 		progressing.Status == core.ConditionFalse &&
 		degraded.Status == core.ConditionFalse
 }
+
+func getResourceKey(obj controllerutil.Object) client.ObjectKey {
+	return client.ObjectKey{
+		Namespace: obj.GetNamespace(),
+		Name:      obj.GetName(),
+	}
+}

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
@@ -225,6 +226,7 @@ func (s *existingSspStrategy) sspModificationDisabled() bool {
 
 var (
 	apiClient          client.Client
+	coreClient         *kubernetes.Clientset
 	ctx                context.Context
 	strategy           TestSuiteStrategy
 	sspListerWatcher   cache.ListerWatcher
@@ -267,6 +269,8 @@ func setupApiClient() {
 	cfg, err := config.GetConfig()
 	Expect(err).ToNot(HaveOccurred())
 	apiClient, err = client.New(cfg, client.Options{})
+	Expect(err).ToNot(HaveOccurred())
+	coreClient, err = kubernetes.NewForConfig(cfg)
 	Expect(err).ToNot(HaveOccurred())
 
 	ctx = context.Background()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Makes the `kubevirt-os-images` namespace visible for regular users with `oc projects`.
This enables UI users to clone images from this namespace

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1893278

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
kubevirt-os-images namespace is now visible to all users
```
