### PR TITLE
Remove owner references for older templates with and Update api call instead of a Patch

### DIFF
--- a/internal/common/resource.go
+++ b/internal/common/resource.go
@@ -5,11 +5,8 @@ import (
 	"reflect"
 
 	"github.com/go-logr/logr"
-	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
 
 	libhandler "github.com/operator-framework/operator-lib/handler"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
@@ -96,38 +93,8 @@ func createOrUpdate(request *Request, resource controllerutil.Object, isClusterR
 
 func setOwner(request *Request, resource controllerutil.Object, isClusterRes bool) error {
 	if isClusterRes {
-		err := libhandler.SetOwnerAnnotations(request.Instance, resource)
-		if err != nil {
-			return err
-		}
-
-		// Removing ownerReferences for objects prior to creation
 		resource.SetOwnerReferences(nil)
-
-		// Removing ownerReferences for existing objects
-		existingRes := newEmptyResource(resource)
-		key, err := client.ObjectKeyFromObject(resource)
-		if err != nil {
-			return err
-		}
-
-		err = request.Client.Get(request.Context, key, existingRes)
-		if err != nil && !errors.IsNotFound(err) {
-			return err
-		} else if err == nil {
-			if len(existingRes.GetOwnerReferences()) > 0 {
-				request.Logger.Info(fmt.Sprintf("Patching %s to remove ownerReferences", key))
-				patch := client.RawPatch(types.JSONPatchType,
-					[]byte(`[{"op": "replace", "path": "/metadata/ownerReferences", "value": []}, {"op": "remove", "path": "/metadata/ownerReferences"}]`))
-				err = request.Client.Patch(request.Context, existingRes, patch)
-
-				if err != nil {
-					return err
-				}
-			}
-		}
-
-		return nil
+		return libhandler.SetOwnerAnnotations(request.Instance, resource)
 	} else {
 		delete(resource.GetAnnotations(), libhandler.NamespacedNameAnnotation)
 		delete(resource.GetAnnotations(), libhandler.TypeAnnotation)


### PR DESCRIPTION
On a previos change I presented (#72), I mistakingly used `Patch` which was over complicated

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
