### PR TITLE
Add observedGeneration to the SSP status

### DIFF
--- a/api/v1beta1/ssp_types.go
+++ b/api/v1beta1/ssp_types.go
@@ -65,6 +65,9 @@ type SSPStatus struct {
 
 	// Paused is true when the operator notices paused annotation.
 	Paused bool `json:"paused,omitempty"`
+
+	// ObservedGeneration is the latest generation observed by the operator.
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/config/crd/bases/ssp.kubevirt.io_ssps.yaml
+++ b/config/crd/bases/ssp.kubevirt.io_ssps.yaml
@@ -834,6 +834,10 @@ spec:
                   - type
                   type: object
                 type: array
+              observedGeneration:
+                description: ObservedGeneration is the latest generation observed by the operator.
+                format: int64
+                type: integer
               observedVersion:
                 description: The observed version of the resource
                 type: string

--- a/controllers/ssp_controller.go
+++ b/controllers/ssp_controller.go
@@ -142,6 +142,7 @@ func (r *SSPReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		}
 		reqLogger.Info(fmt.Sprintf("Pausing SSP operator on resource: %v/%v", instance.Namespace, instance.Name))
 		instance.Status.Paused = true
+		instance.Status.ObservedGeneration = instance.Generation
 		err := r.Status().Update(ctx, instance)
 		return ctrl.Result{}, err
 	}
@@ -211,12 +212,14 @@ func initialize(request *common.Request) error {
 	}
 
 	request.Instance.Status.Phase = lifecycleapi.PhaseDeploying
+	request.Instance.Status.ObservedGeneration = request.Instance.Generation
 	return request.Client.Status().Update(request.Context, request.Instance)
 }
 
 func cleanup(request *common.Request) error {
 	if controllerutil.ContainsFinalizer(request.Instance, finalizerName) {
 		request.Instance.Status.Phase = lifecycleapi.PhaseDeleting
+		request.Instance.Status.ObservedGeneration = request.Instance.Generation
 		err := request.Client.Status().Update(request.Context, request.Instance)
 		if err != nil {
 			return err
@@ -235,6 +238,7 @@ func cleanup(request *common.Request) error {
 	}
 
 	request.Instance.Status.Phase = lifecycleapi.PhaseDeleted
+	request.Instance.Status.ObservedGeneration = request.Instance.Generation
 	err := request.Client.Status().Update(request.Context, request.Instance)
 	if errors.IsConflict(err) || errors.IsNotFound(err) {
 		// These errors are ignored. They can happen if the CR was removed
@@ -321,6 +325,7 @@ func preUpdateStatus(request *common.Request) error {
 
 	sspStatus := &request.Instance.Status
 	sspStatus.Phase = lifecycleapi.PhaseDeploying
+	sspStatus.ObservedGeneration = request.Instance.Generation
 	sspStatus.OperatorVersion = operatorVersion
 	sspStatus.TargetVersion = operatorVersion
 
@@ -452,6 +457,7 @@ func updateStatus(request *common.Request, statuses []common.ResourceStatus) err
 		})
 	}
 
+	sspStatus.ObservedGeneration = request.Instance.Generation
 	if len(notAvailable) == 0 && len(progressing) == 0 && len(degraded) == 0 {
 		sspStatus.Phase = lifecycleapi.PhaseDeployed
 		sspStatus.ObservedVersion = getOperatorVersion()

--- a/data/crd/ssp.kubevirt.io_ssps.yaml
+++ b/data/crd/ssp.kubevirt.io_ssps.yaml
@@ -832,6 +832,10 @@ spec:
                   - type
                   type: object
                 type: array
+              observedGeneration:
+                description: ObservedGeneration is the latest generation observed by the operator.
+                format: int64
+                type: integer
               observedVersion:
                 description: The observed version of the resource
                 type: string

--- a/tests/misc_test.go
+++ b/tests/misc_test.go
@@ -1,0 +1,75 @@
+package tests
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	lifecycleapi "kubevirt.io/controller-lifecycle-operator-sdk/pkg/sdk/api"
+
+	sspv1beta1 "kubevirt.io/ssp-operator/api/v1beta1"
+)
+
+var _ = Describe("Observed generation", func() {
+	BeforeEach(func() {
+		strategy.SkipSspUpdateTestsIfNeeded()
+	})
+
+	AfterEach(func() {
+		strategy.RevertToOriginalSspCr()
+		waitUntilDeployed()
+	})
+
+	It("after deployment observedGeneration equals generation", func() {
+		ssp := getSsp()
+		Expect(ssp.Status.ObservedGeneration).To(Equal(ssp.Generation))
+	})
+
+	It("should update observed generation after CR update", func() {
+		watch, err := StartWatch(sspListerWatcher)
+		Expect(err).ToNot(HaveOccurred())
+		defer watch.Stop()
+
+		var newValidatorReplicas int32 = 0
+		updateSsp(func(foundSsp *sspv1beta1.SSP) {
+			foundSsp.Spec.TemplateValidator.Replicas = &newValidatorReplicas
+		})
+
+		// Watch changes until above change
+		err = WatchChangesUntil(watch, func(updatedSsp *sspv1beta1.SSP) bool {
+			return *updatedSsp.Spec.TemplateValidator.Replicas == newValidatorReplicas &&
+				updatedSsp.Generation > updatedSsp.Status.ObservedGeneration
+		}, shortTimeout)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Watch changes until SSP operator updates ObservedGeneration
+		err = WatchChangesUntil(watch, func(updatedSsp *sspv1beta1.SSP) bool {
+			return *updatedSsp.Spec.TemplateValidator.Replicas == newValidatorReplicas &&
+				updatedSsp.Generation == updatedSsp.Status.ObservedGeneration
+		}, shortTimeout)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("should update observed generation when removing CR", func() {
+		watch, err := StartWatch(sspListerWatcher)
+		Expect(err).ToNot(HaveOccurred())
+		defer watch.Stop()
+
+		ssp := getSsp()
+		Expect(apiClient.Delete(ctx, ssp)).ToNot(HaveOccurred())
+
+		// Check for deletion timestamp before the SSP operator notices change
+		err = WatchChangesUntil(watch, func(updatedSsp *sspv1beta1.SSP) bool {
+			return updatedSsp.DeletionTimestamp != nil &&
+				updatedSsp.Generation > updatedSsp.Status.ObservedGeneration
+		}, shortTimeout)
+		Expect(err).ToNot(HaveOccurred())
+
+		// SSP operator enters Deleting phase
+		err = WatchChangesUntil(watch, func(updatedSsp *sspv1beta1.SSP) bool {
+			return updatedSsp.DeletionTimestamp != nil &&
+				updatedSsp.Status.Phase == lifecycleapi.PhaseDeleting &&
+				updatedSsp.Generation == updatedSsp.Status.ObservedGeneration
+		}, shortTimeout)
+		Expect(err).ToNot(HaveOccurred())
+	})
+})


### PR DESCRIPTION
**What this PR does / why we need it**:
The `observedGeneration` field can be used to check if the operator has seen latest changes to the SSP resource.

**Release note**:
```release-note
Added 'status.observed_generation' field.
```
