### PR TITLE
[Bugfix] Give regular users permissions to view os images DataVolumes

### DIFF
--- a/internal/operands/common-templates/resource.go
+++ b/internal/operands/common-templates/resource.go
@@ -65,6 +65,11 @@ func newViewRole(namespace string) *rbac.Role {
 			},
 			{
 				APIGroups: []string{"cdi.kubevirt.io"},
+				Resources: []string{"datavolumes"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
+			{
+				APIGroups: []string{"cdi.kubevirt.io"},
 				Resources: []string{"datavolumes/source"},
 				Verbs:     []string{"create"},
 			},


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows regular users to view DataVolumes in the os-images namespace, main usecase is to follow the upload status of the image

**Which issue(s) this PR fixes** 
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1913717

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
