### PR TITLE
Make os images tests more aesthetic

### DIFF
--- a/tests/commonTemplates_test.go
+++ b/tests/commonTemplates_test.go
@@ -360,67 +360,78 @@ var _ = Describe("Common templates", func() {
 				Expect(apiClient.Delete(ctx, regularSA)).NotTo(HaveOccurred())
 			})
 
-			It("regular service account should be able to 'get' os-images namespace", func() {
-				sar, err := coreClient.AuthorizationV1().SubjectAccessReviews().Create(ctx, &authv1.SubjectAccessReview{
-					Spec: authv1.SubjectAccessReviewSpec{
-						User:   fmt.Sprintf("system:serviceaccount:%s:%s", strategy.GetNamespace(), regularSA.GetName()),
-						Groups: []string{"system:serviceaccounts"},
+			table.DescribeTable("regular service account namespace RBAC", expectUserCan,
+				table.Entry("should be able to 'get' namespaces",
+					&authv1.SubjectAccessReviewSpec{
+						User:   regularSAFullName,
+						Groups: sasGroup,
 						ResourceAttributes: &authv1.ResourceAttributes{
-							Namespace: commonTemplates.GoldenImagesNSname,
 							Verb:      "get",
+							Namespace: commonTemplates.GoldenImagesNSname,
 							Version:   "v1",
 							Resource:  "namespaces",
 						},
-					},
-				}, metav1.CreateOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				Expect(sar.Status.Allowed).To(BeTrue(), "regular service account cannot 'get' the os images namespace")
-			})
-
-			It("regular service account should be able to 'list' os-images namespace", func() {
-				sar, err := coreClient.AuthorizationV1().SubjectAccessReviews().Create(ctx, &authv1.SubjectAccessReview{
-					Spec: authv1.SubjectAccessReviewSpec{
-						User:   fmt.Sprintf("system:serviceaccount:%s:%s", strategy.GetNamespace(), regularSA.GetName()),
-						Groups: []string{"system:serviceaccounts"},
+					}),
+				table.Entry("should be able to 'list' namespaces",
+					&authv1.SubjectAccessReviewSpec{
+						User:   regularSAFullName,
+						Groups: sasGroup,
 						ResourceAttributes: &authv1.ResourceAttributes{
-							Namespace: commonTemplates.GoldenImagesNSname,
 							Verb:      "list",
-							Version:   "v1",
-							Resource:  "namespaces",
-						},
-					},
-				}, metav1.CreateOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				Expect(sar.Status.Allowed).To(BeTrue(), "regular service account cannot 'list' the os images namespace")
-			})
-
-			It("regular service account should be able to 'watch' os-images namespace", func() {
-				sar, err := coreClient.AuthorizationV1().SubjectAccessReviews().Create(ctx, &authv1.SubjectAccessReview{
-					Spec: authv1.SubjectAccessReviewSpec{
-						User:   fmt.Sprintf("system:serviceaccount:%s:%s", strategy.GetNamespace(), regularSA.GetName()),
-						Groups: []string{"system:serviceaccounts"},
-						ResourceAttributes: &authv1.ResourceAttributes{
 							Namespace: commonTemplates.GoldenImagesNSname,
-							Verb:      "watch",
 							Version:   "v1",
 							Resource:  "namespaces",
 						},
-					},
-				}, metav1.CreateOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				Expect(sar.Status.Allowed).To(BeTrue(), "regular service account cannot 'watch' the os images namespace")
-			})
+					}),
+				table.Entry("should be able to 'watch' namespaces",
+					&authv1.SubjectAccessReviewSpec{
+						User:   regularSAFullName,
+						Groups: sasGroup,
+						ResourceAttributes: &authv1.ResourceAttributes{
+							Verb:      "list",
+							Namespace: commonTemplates.GoldenImagesNSname,
+							Version:   "v1",
+							Resource:  "namespaces",
+						},
+					}))
 
-			table.DescribeTable("regular service account DV RBAC",
-				func(user *string, groups []string, verb, resNamespace, resGroup, resVersion, resKind, resName, resSubresource string) {
-					expectUserCan(*user, groups, verb, resNamespace, resGroup, resVersion, resKind, resName, resSubresource)
-				},
+			table.DescribeTable("regular service account DV RBAC", expectUserCan,
 				table.Entry("should be able to 'get' datavolumes",
-					&regularSAFullName, sasGroup, "get", commonTemplates.GoldenImagesNSname, "cdi.kubevirt.io", "v1beta1", "datavolumes", "", ""),
+					&authv1.SubjectAccessReviewSpec{
+						User:   regularSAFullName,
+						Groups: sasGroup,
+						ResourceAttributes: &authv1.ResourceAttributes{
+							Verb:      "get",
+							Namespace: commonTemplates.GoldenImagesNSname,
+							Group:     "cdi.kubevirt.io",
+							Version:   "v1beta1",
+							Resource:  "datavolumes",
+						},
+					}),
 				table.Entry("should be able to 'list' datavolumes",
-					&regularSAFullName, sasGroup, "list", commonTemplates.GoldenImagesNSname, "cdi.kubevirt.io", "v1beta1", "datavolumes", "", ""),
+					&authv1.SubjectAccessReviewSpec{
+						User:   regularSAFullName,
+						Groups: sasGroup,
+						ResourceAttributes: &authv1.ResourceAttributes{
+							Verb:      "list",
+							Namespace: commonTemplates.GoldenImagesNSname,
+							Group:     "cdi.kubevirt.io",
+							Version:   "v1beta1",
+							Resource:  "datavolumes",
+						},
+					}),
 				table.Entry("should be able to 'watch' datavolumes",
-					&regularSAFullName, sasGroup, "watch", commonTemplates.GoldenImagesNSname, "cdi.kubevirt.io", "v1beta1", "datavolumes", "", ""))
+					&authv1.SubjectAccessReviewSpec{
+						User:   regularSAFullName,
+						Groups: sasGroup,
+						ResourceAttributes: &authv1.ResourceAttributes{
+							Verb:      "watch",
+							Namespace: commonTemplates.GoldenImagesNSname,
+							Group:     "cdi.kubevirt.io",
+							Version:   "v1beta1",
+							Resource:  "datavolumes",
+						},
+					}))
 		})
 	})
 })

--- a/tests/tests_common_test.go
+++ b/tests/tests_common_test.go
@@ -209,24 +209,14 @@ func getResourceKey(obj controllerutil.Object) client.ObjectKey {
 	}
 }
 
-func expectUserCan(user string, groups []string, verb, resNamespace, resGroup, resVersion, resKind, resName, resSubresource string) {
+func expectUserCan(sars *authv1.SubjectAccessReviewSpec) {
 	sar, err := coreClient.AuthorizationV1().SubjectAccessReviews().Create(ctx, &authv1.SubjectAccessReview{
-		Spec: authv1.SubjectAccessReviewSpec{
-			User:   user,
-			Groups: groups,
-			ResourceAttributes: &authv1.ResourceAttributes{
-				Namespace:   resNamespace,
-				Verb:        verb,
-				Group:       resGroup,
-				Version:     resVersion,
-				Resource:    resKind,
-				Subresource: resSubresource,
-				Name:        resName,
-			},
-		},
+		Spec: *sars,
 	}, metav1.CreateOptions{})
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 	ExpectWithOffset(1, sar.Status.Allowed).To(BeTrue(),
 		fmt.Sprintf("user [%s] with groups %v cannot [%s] resource: [%s], subresource: [%s], name: [%s] in group [%s/%s] in namespace [%s]",
-			user, groups, verb, resKind, resSubresource, resName, resGroup, resVersion, resNamespace))
+			sars.User, sars.Groups, sars.ResourceAttributes.Verb, sars.ResourceAttributes.Resource,
+			sars.ResourceAttributes.Subresource, sars.ResourceAttributes.Name, sars.ResourceAttributes.Group,
+			sars.ResourceAttributes.Version, sars.ResourceAttributes.Namespace))
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Reuse code in the os-images namespace permission tests, this is based on #83 , so it should only be merged after it

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
