### PR TITLE
Fix csv-generator test

### DIFF
--- a/tests/e2e-test-csv-generator.sh
+++ b/tests/e2e-test-csv-generator.sh
@@ -3,7 +3,12 @@
 olm_output=$(docker run --rm --entrypoint=/csv-generator quay.io/kubevirt/ssp-operator:latest \
 --csv-version=9.9.9 --namespace=namespace-test --operator-version=8.8.8  --validator-image=validator-test --dump-crds \
 --kvm-info-image=kvm-test --virt-launcher-image=virt-launcher-test --node-labeller-image=node-labeller-test \
---cpu-plugin-image=cpu-plugin-test --operator-image=operator-test) 
+--cpu-plugin-image=cpu-plugin-test --operator-image=operator-test)
+
+if [ $(echo $olm_output | grep 'ClusterServiceVersion' | wc -l) -eq 0 ]; then
+    echo "no csv data returned from csv-generator"
+    exit 1
+fi
 
 if [ $(echo $olm_output | grep 'name: ssp-operator.v9.9.9'| wc -l) -eq 0 ]; then
     echo "output doesn't contain correct csv-version"
@@ -46,10 +51,15 @@ if [ $(echo $olm_output | grep 'group: ssp.kubevirt.io'| wc -l) -eq 0 ]; then
 fi
 
 #test the case without --dump-crds flag
-olm_output=$(docker run --rm --entrypoint=/usr/bin/csv-generator quay.io/kubevirt/ssp-operator:latest \
---csv-version=test --namespace=namespace-test  --validator-image=validator-test \
+olm_output=$(docker run --rm --entrypoint=/csv-generator quay.io/kubevirt/ssp-operator:latest \
+--csv-version=9.9.9 --namespace=namespace-test --operator-version=8.8.8 --validator-image=validator-test \
 --kvm-info-image=kvm-test --virt-launcher-image=virt-launcher-test --node-labeller-image=node-labeller-test \
---cpu-plugin-image=cpu-plugin-test --operator-image=operator-test) 
+--cpu-plugin-image=cpu-plugin-test --operator-image=operator-test)
+
+if [ $(echo $olm_output | grep 'ClusterServiceVersion' | wc -l) -eq 0 ]; then
+    echo "no csv data returned from csv-generator"
+    exit 1
+fi
 
 if [ $(echo $olm_output | grep 'group: ssp.kubevirt.io'| wc -l) -eq 1 ]; then
     echo "output contains CRD definition"


### PR DESCRIPTION
**What this PR does / why we need it**:
csv-generator test now points to the right binary path inside the container and will fail CI if errors occurred
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
