### PR TITLE
Add app.kubernetes.io labels to resources provisioned by ssp-operator

### DIFF
--- a/automation/ssp-cr-template.yaml
+++ b/automation/ssp-cr-template.yaml
@@ -5,6 +5,9 @@ kind: SSP
 metadata:
   name: %%_SSP_NAME_%%
   namespace: %%_SSP_NAMESPACE_%%
+  labels:
+    app.kubernetes.io/part-of: "kubevirt-test"
+    app.kubernetes.io/version: "v0.0.0"
 spec:
   commonTemplates:
     namespace: %%_COMMON_TEMPLATES_NAMESPACE_%%

--- a/controllers/ssp_controller.go
+++ b/controllers/ssp_controller.go
@@ -289,14 +289,16 @@ func listExistingCRDKinds(sspRequest *common.Request) []string {
 	crds.SetAPIVersion("apiextensions.k8s.io/v1")
 	err := sspRequest.Client.List(sspRequest.Context, crds)
 	foundKinds := make([]string, 0, len(kvsspCRDs))
-	if err == nil {
-		for _, item := range crds.Items {
-			name := item.GetName()
-			for crd, kind := range kvsspCRDs {
-				if crd == name {
-					foundKinds = append(foundKinds, kind)
-					break
-				}
+	if err != nil {
+		return nil
+	}
+
+	for _, item := range crds.Items {
+		name := item.GetName()
+		for crd, kind := range kvsspCRDs {
+			if crd == name {
+				foundKinds = append(foundKinds, kind)
+				break
 			}
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/operator-framework/api v0.3.25
 	github.com/operator-framework/operator-lib v0.2.0
 	github.com/spf13/cobra v1.0.0
+	gomodules.xyz/jsonpatch/v2 v2.0.1
 	gopkg.in/yaml.v2 v2.3.0
 	k8s.io/api v0.19.3
 	k8s.io/apiextensions-apiserver v0.19.3

--- a/internal/common/labels.go
+++ b/internal/common/labels.go
@@ -1,0 +1,60 @@
+package common
+
+import "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+const (
+	AppKubernetesNameLabel      = "app.kubernetes.io/name"
+	AppKubernetesPartOfLabel    = "app.kubernetes.io/part-of"
+	AppKubernetesVersionLabel   = "app.kubernetes.io/version"
+	AppKubernetesManagedByLabel = "app.kubernetes.io/managed-by"
+	AppKubernetesComponentLabel = "app.kubernetes.io/component"
+)
+
+type AppComponent string
+
+func (a AppComponent) String() string {
+	return string(a)
+}
+
+const (
+	AppComponentMonitoring AppComponent = "monitoring"
+	AppComponentSchedule   AppComponent = "schedule"
+	AppComponentTemplating AppComponent = "templating"
+)
+
+// AddAppLabels to the provided obj
+// Name will translate into the AppKubernetesNameLabel
+// Component will translate into the AppKubernetesComponentLabel
+// Instance wide labels will be taken from the request if available
+func AddAppLabels(request *Request, name string, component AppComponent, obj controllerutil.Object) controllerutil.Object {
+	labels := getOrCreateLabels(obj)
+	addInstanceLabels(request, labels)
+
+	labels[AppKubernetesNameLabel] = name
+	labels[AppKubernetesComponentLabel] = component.String()
+	labels[AppKubernetesManagedByLabel] = "ssp-operator"
+
+	return obj
+}
+
+func getOrCreateLabels(obj controllerutil.Object) map[string]string {
+	labels := obj.GetLabels()
+	if labels == nil {
+		labels = map[string]string{}
+		obj.SetLabels(labels)
+	}
+	return labels
+}
+
+func addInstanceLabels(request *Request, to map[string]string) {
+	if request.Instance.Labels == nil {
+		return
+	}
+
+	copyLabel(request.Instance.Labels, to, AppKubernetesPartOfLabel)
+	copyLabel(request.Instance.Labels, to, AppKubernetesVersionLabel)
+}
+
+func copyLabel(from, to map[string]string, key string) {
+	to[key] = from[key]
+}

--- a/internal/common/labels.go
+++ b/internal/common/labels.go
@@ -1,6 +1,9 @@
 package common
 
-import "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+import (
+	"kubevirt.io/ssp-operator/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
 
 const (
 	AppKubernetesNameLabel      = "app.kubernetes.io/name"
@@ -26,9 +29,9 @@ const (
 // Name will translate into the AppKubernetesNameLabel
 // Component will translate into the AppKubernetesComponentLabel
 // Instance wide labels will be taken from the request if available
-func AddAppLabels(request *Request, name string, component AppComponent, obj controllerutil.Object) controllerutil.Object {
+func AddAppLabels(requestInstance *v1beta1.SSP, name string, component AppComponent, obj controllerutil.Object) controllerutil.Object {
 	labels := getOrCreateLabels(obj)
-	addInstanceLabels(request, labels)
+	addInstanceLabels(requestInstance, labels)
 
 	labels[AppKubernetesNameLabel] = name
 	labels[AppKubernetesComponentLabel] = component.String()
@@ -46,13 +49,13 @@ func getOrCreateLabels(obj controllerutil.Object) map[string]string {
 	return labels
 }
 
-func addInstanceLabels(request *Request, to map[string]string) {
-	if request.Instance.Labels == nil {
+func addInstanceLabels(requestInstance *v1beta1.SSP, to map[string]string) {
+	if requestInstance.Labels == nil {
 		return
 	}
 
-	copyLabel(request.Instance.Labels, to, AppKubernetesPartOfLabel)
-	copyLabel(request.Instance.Labels, to, AppKubernetesVersionLabel)
+	copyLabel(requestInstance.Labels, to, AppKubernetesPartOfLabel)
+	copyLabel(requestInstance.Labels, to, AppKubernetesVersionLabel)
 }
 
 func copyLabel(from, to map[string]string, key string) {

--- a/internal/common/labels_test.go
+++ b/internal/common/labels_test.go
@@ -1,0 +1,78 @@
+package common
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	ssp "kubevirt.io/ssp-operator/api/v1beta1"
+)
+
+var _ = Describe("AddAppLabels", func() {
+	var (
+		request Request
+	)
+
+	BeforeEach(func() {
+		request = Request{
+			Instance: &ssp.SSP{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "SSP",
+					APIVersion: ssp.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+					Labels: map[string]string{
+						AppKubernetesPartOfLabel:  "tests",
+						AppKubernetesVersionLabel: "v0.0.0-tests",
+					},
+				},
+			},
+		}
+	})
+
+	When("SSP CR has app labels", func() {
+		It("adds app labels from request", func() {
+			obj := AddAppLabels(&request, "test", AppComponent("testing"), &v1.ConfigMap{})
+
+			labels := obj.GetLabels()
+			Expect(labels[AppKubernetesPartOfLabel]).To(Equal("tests"))
+			Expect(labels[AppKubernetesVersionLabel]).To(Equal("v0.0.0-tests"))
+		})
+	})
+	When("SSP CR does not have app labels", func() {
+		It("does not add app labels on nil", func() {
+			request.Instance.Labels = nil
+			obj := AddAppLabels(&request, "test", AppComponent("testing"), &v1.ConfigMap{})
+
+			labels := obj.GetLabels()
+			Expect(labels[AppKubernetesPartOfLabel]).To(Equal(""))
+			Expect(labels[AppKubernetesVersionLabel]).To(Equal(""))
+		})
+		It("does not add app labels empty map", func() {
+			request.Instance.Labels = map[string]string{}
+			obj := AddAppLabels(&request, "test", AppComponent("testing"), &v1.ConfigMap{})
+
+			labels := obj.GetLabels()
+			Expect(labels[AppKubernetesPartOfLabel]).To(Equal(""))
+			Expect(labels[AppKubernetesVersionLabel]).To(Equal(""))
+		})
+	})
+
+	It("adds dynamic app labels", func() {
+		obj := AddAppLabels(&request, "test", AppComponent("testing"), &v1.ConfigMap{})
+
+		labels := obj.GetLabels()
+		Expect(labels[AppKubernetesComponentLabel]).To(Equal("testing"))
+		Expect(labels[AppKubernetesNameLabel]).To(Equal("test"))
+	})
+
+	It("adds managed-by label", func() {
+		obj := AddAppLabels(&request, "test", AppComponent("testing"), &v1.ConfigMap{})
+
+		labels := obj.GetLabels()
+		Expect(labels[AppKubernetesManagedByLabel]).To(Equal("ssp-operator"))
+	})
+})

--- a/internal/common/labels_test.go
+++ b/internal/common/labels_test.go
@@ -35,7 +35,7 @@ var _ = Describe("AddAppLabels", func() {
 
 	When("SSP CR has app labels", func() {
 		It("adds app labels from request", func() {
-			obj := AddAppLabels(&request, "test", AppComponent("testing"), &v1.ConfigMap{})
+			obj := AddAppLabels(request.Instance, "test", AppComponent("testing"), &v1.ConfigMap{})
 
 			labels := obj.GetLabels()
 			Expect(labels[AppKubernetesPartOfLabel]).To(Equal("tests"))
@@ -45,7 +45,7 @@ var _ = Describe("AddAppLabels", func() {
 	When("SSP CR does not have app labels", func() {
 		It("does not add app labels on nil", func() {
 			request.Instance.Labels = nil
-			obj := AddAppLabels(&request, "test", AppComponent("testing"), &v1.ConfigMap{})
+			obj := AddAppLabels(request.Instance, "test", AppComponent("testing"), &v1.ConfigMap{})
 
 			labels := obj.GetLabels()
 			Expect(labels[AppKubernetesPartOfLabel]).To(Equal(""))
@@ -53,7 +53,7 @@ var _ = Describe("AddAppLabels", func() {
 		})
 		It("does not add app labels empty map", func() {
 			request.Instance.Labels = map[string]string{}
-			obj := AddAppLabels(&request, "test", AppComponent("testing"), &v1.ConfigMap{})
+			obj := AddAppLabels(request.Instance, "test", AppComponent("testing"), &v1.ConfigMap{})
 
 			labels := obj.GetLabels()
 			Expect(labels[AppKubernetesPartOfLabel]).To(Equal(""))
@@ -62,7 +62,7 @@ var _ = Describe("AddAppLabels", func() {
 	})
 
 	It("adds dynamic app labels", func() {
-		obj := AddAppLabels(&request, "test", AppComponent("testing"), &v1.ConfigMap{})
+		obj := AddAppLabels(request.Instance, "test", AppComponent("testing"), &v1.ConfigMap{})
 
 		labels := obj.GetLabels()
 		Expect(labels[AppKubernetesComponentLabel]).To(Equal("testing"))
@@ -70,7 +70,7 @@ var _ = Describe("AddAppLabels", func() {
 	})
 
 	It("adds managed-by label", func() {
-		obj := AddAppLabels(&request, "test", AppComponent("testing"), &v1.ConfigMap{})
+		obj := AddAppLabels(request.Instance, "test", AppComponent("testing"), &v1.ConfigMap{})
 
 		labels := obj.GetLabels()
 		Expect(labels[AppKubernetesManagedByLabel]).To(Equal("ssp-operator"))

--- a/internal/operands/common-templates/reconcile.go
+++ b/internal/operands/common-templates/reconcile.go
@@ -43,8 +43,13 @@ func GetOperand() operands.Operand {
 }
 
 func (c *commonTemplates) Name() string {
-	return "CommonTemplates"
+	return operandName
 }
+
+const (
+	operandName      = "common-templates"
+	operandComponent = common.AppComponentTemplating
+)
 
 func (c *commonTemplates) AddWatchTypesToScheme(s *runtime.Scheme) error {
 	return templatev1.Install(s)
@@ -106,13 +111,15 @@ func (c *commonTemplates) Cleanup(request *common.Request) error {
 }
 
 func reconcileGoldenImagesNS(request *common.Request) (common.ResourceStatus, error) {
-	return common.CreateOrUpdateClusterResource(request, newGoldenImagesNS(GoldenImagesNSname),
+	return common.CreateOrUpdateClusterResource(request,
+		common.AddAppLabels(request, operandName, operandComponent, newGoldenImagesNS(GoldenImagesNSname)),
 		func(_, _ controllerutil.Object) {
 			// Namespace spec only contains finalizers, which can be modified
 		})
 }
 func reconcileViewRole(request *common.Request) (common.ResourceStatus, error) {
-	return common.CreateOrUpdateClusterResource(request, newViewRole(GoldenImagesNSname),
+	return common.CreateOrUpdateClusterResource(request,
+		common.AddAppLabels(request, operandName, operandComponent, newViewRole(GoldenImagesNSname)),
 		func(newRes, foundRes controllerutil.Object) {
 			foundRole := foundRes.(*rbac.Role)
 			newRole := newRes.(*rbac.Role)
@@ -121,7 +128,8 @@ func reconcileViewRole(request *common.Request) (common.ResourceStatus, error) {
 }
 
 func reconcileViewRoleBinding(request *common.Request) (common.ResourceStatus, error) {
-	return common.CreateOrUpdateClusterResource(request, newViewRoleBinding(GoldenImagesNSname),
+	return common.CreateOrUpdateClusterResource(request,
+		common.AddAppLabels(request, operandName, operandComponent, newViewRoleBinding(GoldenImagesNSname)),
 		func(newRes, foundRes controllerutil.Object) {
 			newBinding := newRes.(*rbac.RoleBinding)
 			foundBinding := foundRes.(*rbac.RoleBinding)
@@ -131,7 +139,8 @@ func reconcileViewRoleBinding(request *common.Request) (common.ResourceStatus, e
 }
 
 func reconcileEditRole(request *common.Request) (common.ResourceStatus, error) {
-	return common.CreateOrUpdateClusterResource(request, newEditRole(),
+	return common.CreateOrUpdateClusterResource(request,
+		common.AddAppLabels(request, operandName, operandComponent, newEditRole()),
 		func(newRes, foundRes controllerutil.Object) {
 			newRole := newRes.(*rbac.ClusterRole)
 			foundRole := foundRes.(*rbac.ClusterRole)
@@ -171,7 +180,8 @@ func reconcileOlderTemplates(request *common.Request) ([]common.ReconcileFunc, e
 	for i := range existingTemplates.Items {
 		template := &existingTemplates.Items[i]
 		funcs = append(funcs, func(*common.Request) (common.ResourceStatus, error) {
-			return common.CreateOrUpdateClusterResource(request, template,
+			return common.CreateOrUpdateClusterResource(request,
+				common.AddAppLabels(request, operandName, operandComponent, template),
 				func(_, foundRes controllerutil.Object) {
 					foundTemplate := foundRes.(*templatev1.Template)
 					for key := range foundTemplate.Labels {
@@ -208,7 +218,8 @@ func reconcileTemplatesFuncs(request *common.Request) []common.ReconcileFunc {
 		template := &templatesBundle[i]
 		template.ObjectMeta.Namespace = namespace
 		funcs = append(funcs, func(request *common.Request) (common.ResourceStatus, error) {
-			return common.CreateOrUpdateClusterResource(request, template,
+			return common.CreateOrUpdateClusterResource(request,
+				common.AddAppLabels(request, operandName, operandComponent, template),
 				func(newRes, foundRes controllerutil.Object) {
 					newTemplate := newRes.(*templatev1.Template)
 					foundTemplate := foundRes.(*templatev1.Template)

--- a/internal/operands/common-templates/reconcile.go
+++ b/internal/operands/common-templates/reconcile.go
@@ -112,14 +112,14 @@ func (c *commonTemplates) Cleanup(request *common.Request) error {
 
 func reconcileGoldenImagesNS(request *common.Request) (common.ResourceStatus, error) {
 	return common.CreateOrUpdateClusterResource(request,
-		common.AddAppLabels(request, operandName, operandComponent, newGoldenImagesNS(GoldenImagesNSname)),
+		common.AddAppLabels(request.Instance, operandName, operandComponent, newGoldenImagesNS(GoldenImagesNSname)),
 		func(_, _ controllerutil.Object) {
 			// Namespace spec only contains finalizers, which can be modified
 		})
 }
 func reconcileViewRole(request *common.Request) (common.ResourceStatus, error) {
 	return common.CreateOrUpdateClusterResource(request,
-		common.AddAppLabels(request, operandName, operandComponent, newViewRole(GoldenImagesNSname)),
+		common.AddAppLabels(request.Instance, operandName, operandComponent, newViewRole(GoldenImagesNSname)),
 		func(newRes, foundRes controllerutil.Object) {
 			foundRole := foundRes.(*rbac.Role)
 			newRole := newRes.(*rbac.Role)
@@ -129,7 +129,7 @@ func reconcileViewRole(request *common.Request) (common.ResourceStatus, error) {
 
 func reconcileViewRoleBinding(request *common.Request) (common.ResourceStatus, error) {
 	return common.CreateOrUpdateClusterResource(request,
-		common.AddAppLabels(request, operandName, operandComponent, newViewRoleBinding(GoldenImagesNSname)),
+		common.AddAppLabels(request.Instance, operandName, operandComponent, newViewRoleBinding(GoldenImagesNSname)),
 		func(newRes, foundRes controllerutil.Object) {
 			newBinding := newRes.(*rbac.RoleBinding)
 			foundBinding := foundRes.(*rbac.RoleBinding)
@@ -140,7 +140,7 @@ func reconcileViewRoleBinding(request *common.Request) (common.ResourceStatus, e
 
 func reconcileEditRole(request *common.Request) (common.ResourceStatus, error) {
 	return common.CreateOrUpdateClusterResource(request,
-		common.AddAppLabels(request, operandName, operandComponent, newEditRole()),
+		common.AddAppLabels(request.Instance, operandName, operandComponent, newEditRole()),
 		func(newRes, foundRes controllerutil.Object) {
 			newRole := newRes.(*rbac.ClusterRole)
 			foundRole := foundRes.(*rbac.ClusterRole)
@@ -181,7 +181,7 @@ func reconcileOlderTemplates(request *common.Request) ([]common.ReconcileFunc, e
 		template := &existingTemplates.Items[i]
 		funcs = append(funcs, func(*common.Request) (common.ResourceStatus, error) {
 			return common.CreateOrUpdateClusterResource(request,
-				common.AddAppLabels(request, operandName, operandComponent, template),
+				common.AddAppLabels(request.Instance, operandName, operandComponent, template),
 				func(_, foundRes controllerutil.Object) {
 					foundTemplate := foundRes.(*templatev1.Template)
 					for key := range foundTemplate.Labels {
@@ -219,7 +219,7 @@ func reconcileTemplatesFuncs(request *common.Request) []common.ReconcileFunc {
 		template.ObjectMeta.Namespace = namespace
 		funcs = append(funcs, func(request *common.Request) (common.ResourceStatus, error) {
 			return common.CreateOrUpdateClusterResource(request,
-				common.AddAppLabels(request, operandName, operandComponent, template),
+				common.AddAppLabels(request.Instance, operandName, operandComponent, template),
 				func(newRes, foundRes controllerutil.Object) {
 					newTemplate := newRes.(*templatev1.Template)
 					foundTemplate := foundRes.(*templatev1.Template)

--- a/internal/operands/metrics/reconcile.go
+++ b/internal/operands/metrics/reconcile.go
@@ -46,9 +46,14 @@ func GetOperand() operands.Operand {
 	return &metrics{}
 }
 
+const (
+	operandName      = "metrics"
+	operandComponent = common.AppComponentMonitoring
+)
+
 func reconcilePrometheusRule(request *common.Request) (common.ResourceStatus, error) {
 	return common.CreateOrUpdateResource(request,
-		newPrometheusRule(request.Namespace),
+		common.AddAppLabels(request, operandName, operandComponent, newPrometheusRule(request.Namespace)),
 		func(newRes, foundRes controllerutil.Object) {
 			foundRes.(*promv1.PrometheusRule).Spec = newRes.(*promv1.PrometheusRule).Spec
 		})

--- a/internal/operands/metrics/reconcile.go
+++ b/internal/operands/metrics/reconcile.go
@@ -53,7 +53,7 @@ const (
 
 func reconcilePrometheusRule(request *common.Request) (common.ResourceStatus, error) {
 	return common.CreateOrUpdateResource(request,
-		common.AddAppLabels(request, operandName, operandComponent, newPrometheusRule(request.Namespace)),
+		common.AddAppLabels(request.Instance, operandName, operandComponent, newPrometheusRule(request.Namespace)),
 		func(newRes, foundRes controllerutil.Object) {
 			foundRes.(*promv1.PrometheusRule).Spec = newRes.(*promv1.PrometheusRule).Spec
 		})

--- a/internal/operands/metrics/reconcile.go
+++ b/internal/operands/metrics/reconcile.go
@@ -15,7 +15,7 @@ import (
 type metrics struct{}
 
 func (m *metrics) Name() string {
-	return "Metrics"
+	return operandName
 }
 
 func (m *metrics) AddWatchTypesToScheme(scheme *runtime.Scheme) error {

--- a/internal/operands/node-labeller/reconcile.go
+++ b/internal/operands/node-labeller/reconcile.go
@@ -85,9 +85,14 @@ func GetOperand() operands.Operand {
 	return &nodeLabeller{}
 }
 
+const (
+	operandName      = "node-labeler"
+	operandComponent = common.AppComponentSchedule
+)
+
 func reconcileClusterRole(request *common.Request) (common.ResourceStatus, error) {
 	return common.CreateOrUpdateClusterResource(request,
-		newClusterRole(),
+		common.AddAppLabels(request, operandName, operandComponent, newClusterRole()),
 		func(newRes, foundRes controllerutil.Object) {
 			foundRes.(*rbac.ClusterRole).Rules = newRes.(*rbac.ClusterRole).Rules
 		})
@@ -95,13 +100,13 @@ func reconcileClusterRole(request *common.Request) (common.ResourceStatus, error
 
 func reconcileServiceAccount(request *common.Request) (common.ResourceStatus, error) {
 	return common.CreateOrUpdateResource(request,
-		newServiceAccount(request.Namespace),
+		common.AddAppLabels(request, operandName, operandComponent, newServiceAccount(request.Namespace)),
 		func(_, _ controllerutil.Object) {})
 }
 
 func reconcileClusterRoleBinding(request *common.Request) (common.ResourceStatus, error) {
 	return common.CreateOrUpdateClusterResource(request,
-		newClusterRoleBinding(request.Namespace),
+		common.AddAppLabels(request, operandName, operandComponent, newClusterRoleBinding(request.Namespace)),
 		func(newRes, foundRes controllerutil.Object) {
 			newBinding := newRes.(*rbac.ClusterRoleBinding)
 			foundBinding := foundRes.(*rbac.ClusterRoleBinding)
@@ -112,7 +117,7 @@ func reconcileClusterRoleBinding(request *common.Request) (common.ResourceStatus
 
 func reconcileConfigMap(request *common.Request) (common.ResourceStatus, error) {
 	return common.CreateOrUpdateResource(request,
-		newConfigMap(request.Namespace),
+		common.AddAppLabels(request, operandName, operandComponent, newConfigMap(request.Namespace)),
 		func(newRes, foundRes controllerutil.Object) {
 			newConfigMap := newRes.(*v1.ConfigMap)
 			foundConfigMap := foundRes.(*v1.ConfigMap)
@@ -125,7 +130,7 @@ func reconcileDaemonSet(request *common.Request) (common.ResourceStatus, error) 
 	daemonSet := newDaemonSet(request.Namespace)
 	addPlacementFields(daemonSet, nodeLabellerSpec.Placement)
 	return common.CreateOrUpdateResourceWithStatus(request,
-		daemonSet,
+		common.AddAppLabels(request, operandName, operandComponent, daemonSet),
 		func(newRes, foundRes controllerutil.Object) {
 			foundRes.(*apps.DaemonSet).Spec = newRes.(*apps.DaemonSet).Spec
 		},
@@ -157,7 +162,7 @@ func addPlacementFields(daemonset *apps.DaemonSet, nodePlacement *lifecycleapi.N
 
 func reconcileSecurityContextConstraint(request *common.Request) (common.ResourceStatus, error) {
 	return common.CreateOrUpdateClusterResource(request,
-		newSecurityContextConstraint(request.Namespace),
+		common.AddAppLabels(request, operandName, operandComponent, newSecurityContextConstraint(request.Namespace)),
 		func(newRes, foundRes controllerutil.Object) {
 			foundRes.(*secv1.SecurityContextConstraints).AllowPrivilegedContainer = newRes.(*secv1.SecurityContextConstraints).AllowPrivilegedContainer
 			foundRes.(*secv1.SecurityContextConstraints).RunAsUser = newRes.(*secv1.SecurityContextConstraints).RunAsUser

--- a/internal/operands/node-labeller/reconcile.go
+++ b/internal/operands/node-labeller/reconcile.go
@@ -92,7 +92,7 @@ const (
 
 func reconcileClusterRole(request *common.Request) (common.ResourceStatus, error) {
 	return common.CreateOrUpdateClusterResource(request,
-		common.AddAppLabels(request, operandName, operandComponent, newClusterRole()),
+		common.AddAppLabels(request.Instance, operandName, operandComponent, newClusterRole()),
 		func(newRes, foundRes controllerutil.Object) {
 			foundRes.(*rbac.ClusterRole).Rules = newRes.(*rbac.ClusterRole).Rules
 		})
@@ -100,13 +100,13 @@ func reconcileClusterRole(request *common.Request) (common.ResourceStatus, error
 
 func reconcileServiceAccount(request *common.Request) (common.ResourceStatus, error) {
 	return common.CreateOrUpdateResource(request,
-		common.AddAppLabels(request, operandName, operandComponent, newServiceAccount(request.Namespace)),
+		common.AddAppLabels(request.Instance, operandName, operandComponent, newServiceAccount(request.Namespace)),
 		func(_, _ controllerutil.Object) {})
 }
 
 func reconcileClusterRoleBinding(request *common.Request) (common.ResourceStatus, error) {
 	return common.CreateOrUpdateClusterResource(request,
-		common.AddAppLabels(request, operandName, operandComponent, newClusterRoleBinding(request.Namespace)),
+		common.AddAppLabels(request.Instance, operandName, operandComponent, newClusterRoleBinding(request.Namespace)),
 		func(newRes, foundRes controllerutil.Object) {
 			newBinding := newRes.(*rbac.ClusterRoleBinding)
 			foundBinding := foundRes.(*rbac.ClusterRoleBinding)
@@ -117,7 +117,7 @@ func reconcileClusterRoleBinding(request *common.Request) (common.ResourceStatus
 
 func reconcileConfigMap(request *common.Request) (common.ResourceStatus, error) {
 	return common.CreateOrUpdateResource(request,
-		common.AddAppLabels(request, operandName, operandComponent, newConfigMap(request.Namespace)),
+		common.AddAppLabels(request.Instance, operandName, operandComponent, newConfigMap(request.Namespace)),
 		func(newRes, foundRes controllerutil.Object) {
 			newConfigMap := newRes.(*v1.ConfigMap)
 			foundConfigMap := foundRes.(*v1.ConfigMap)
@@ -130,7 +130,7 @@ func reconcileDaemonSet(request *common.Request) (common.ResourceStatus, error) 
 	daemonSet := newDaemonSet(request.Namespace)
 	addPlacementFields(daemonSet, nodeLabellerSpec.Placement)
 	return common.CreateOrUpdateResourceWithStatus(request,
-		common.AddAppLabels(request, operandName, operandComponent, daemonSet),
+		common.AddAppLabels(request.Instance, operandName, operandComponent, daemonSet),
 		func(newRes, foundRes controllerutil.Object) {
 			foundRes.(*apps.DaemonSet).Spec = newRes.(*apps.DaemonSet).Spec
 		},
@@ -162,7 +162,7 @@ func addPlacementFields(daemonset *apps.DaemonSet, nodePlacement *lifecycleapi.N
 
 func reconcileSecurityContextConstraint(request *common.Request) (common.ResourceStatus, error) {
 	return common.CreateOrUpdateClusterResource(request,
-		common.AddAppLabels(request, operandName, operandComponent, newSecurityContextConstraint(request.Namespace)),
+		common.AddAppLabels(request.Instance, operandName, operandComponent, newSecurityContextConstraint(request.Namespace)),
 		func(newRes, foundRes controllerutil.Object) {
 			foundRes.(*secv1.SecurityContextConstraints).AllowPrivilegedContainer = newRes.(*secv1.SecurityContextConstraints).AllowPrivilegedContainer
 			foundRes.(*secv1.SecurityContextConstraints).RunAsUser = newRes.(*secv1.SecurityContextConstraints).RunAsUser

--- a/internal/operands/node-labeller/reconcile.go
+++ b/internal/operands/node-labeller/reconcile.go
@@ -30,7 +30,7 @@ import (
 type nodeLabeller struct{}
 
 func (nl *nodeLabeller) Name() string {
-	return "NodeLabeller"
+	return operandName
 }
 
 func (nl *nodeLabeller) AddWatchTypesToScheme(s *runtime.Scheme) error {

--- a/internal/operands/template-validator/reconcile.go
+++ b/internal/operands/template-validator/reconcile.go
@@ -90,7 +90,7 @@ const (
 
 func reconcileClusterRole(request *common.Request) (common.ResourceStatus, error) {
 	return common.CreateOrUpdateClusterResource(request,
-		common.AddAppLabels(request, operandName, operandComponent, newClusterRole()),
+		common.AddAppLabels(request.Instance, operandName, operandComponent, newClusterRole()),
 		func(newRes, foundRes controllerutil.Object) {
 			foundRes.(*rbac.ClusterRole).Rules = newRes.(*rbac.ClusterRole).Rules
 		})
@@ -98,13 +98,13 @@ func reconcileClusterRole(request *common.Request) (common.ResourceStatus, error
 
 func reconcileServiceAccount(request *common.Request) (common.ResourceStatus, error) {
 	return common.CreateOrUpdateResource(request,
-		common.AddAppLabels(request, operandName, operandComponent, newServiceAccount(request.Namespace)),
+		common.AddAppLabels(request.Instance, operandName, operandComponent, newServiceAccount(request.Namespace)),
 		func(_, _ controllerutil.Object) {})
 }
 
 func reconcileClusterRoleBinding(request *common.Request) (common.ResourceStatus, error) {
 	return common.CreateOrUpdateClusterResource(request,
-		common.AddAppLabels(request, operandName, operandComponent, newClusterRoleBinding(request.Namespace)),
+		common.AddAppLabels(request.Instance, operandName, operandComponent, newClusterRoleBinding(request.Namespace)),
 		func(newRes, foundRes controllerutil.Object) {
 			newBinding := newRes.(*rbac.ClusterRoleBinding)
 			foundBinding := foundRes.(*rbac.ClusterRoleBinding)
@@ -115,7 +115,7 @@ func reconcileClusterRoleBinding(request *common.Request) (common.ResourceStatus
 
 func reconcileService(request *common.Request) (common.ResourceStatus, error) {
 	return common.CreateOrUpdateResource(request,
-		common.AddAppLabels(request, operandName, operandComponent, newService(request.Namespace)),
+		common.AddAppLabels(request.Instance, operandName, operandComponent, newService(request.Namespace)),
 		func(newRes, foundRes controllerutil.Object) {
 			newService := newRes.(*v1.Service)
 			foundService := foundRes.(*v1.Service)
@@ -133,7 +133,7 @@ func reconcileDeployment(request *common.Request) (common.ResourceStatus, error)
 	deployment := newDeployment(request.Namespace, *validatorSpec.Replicas, image)
 	addPlacementFields(deployment, validatorSpec.Placement)
 	return common.CreateOrUpdateResourceWithStatus(request,
-		common.AddAppLabels(request, operandName, operandComponent, deployment),
+		common.AddAppLabels(request.Instance, operandName, operandComponent, deployment),
 		func(newRes, foundRes controllerutil.Object) {
 			foundRes.(*apps.Deployment).Spec = newRes.(*apps.Deployment).Spec
 		},
@@ -170,7 +170,7 @@ func addPlacementFields(deployment *apps.Deployment, nodePlacement *lifecycleapi
 
 func reconcileValidatingWebhook(request *common.Request) (common.ResourceStatus, error) {
 	return common.CreateOrUpdateClusterResource(request,
-		common.AddAppLabels(request, operandName, operandComponent, newValidatingWebhook(request.Namespace)),
+		common.AddAppLabels(request.Instance, operandName, operandComponent, newValidatingWebhook(request.Namespace)),
 		func(newRes, foundRes controllerutil.Object) {
 			newWebhookConf := newRes.(*admission.ValidatingWebhookConfiguration)
 			foundWebhookConf := foundRes.(*admission.ValidatingWebhookConfiguration)

--- a/internal/operands/template-validator/reconcile.go
+++ b/internal/operands/template-validator/reconcile.go
@@ -28,7 +28,7 @@ import (
 type templateValidator struct{}
 
 func (t *templateValidator) Name() string {
-	return "TemplateValidator"
+	return operatorName
 }
 
 func (t *templateValidator) AddWatchTypesToScheme(*runtime.Scheme) error {

--- a/internal/operands/template-validator/reconcile.go
+++ b/internal/operands/template-validator/reconcile.go
@@ -28,7 +28,7 @@ import (
 type templateValidator struct{}
 
 func (t *templateValidator) Name() string {
-	return operatorName
+	return operandName
 }
 
 func (t *templateValidator) AddWatchTypesToScheme(*runtime.Scheme) error {

--- a/internal/operands/template-validator/reconcile.go
+++ b/internal/operands/template-validator/reconcile.go
@@ -83,9 +83,14 @@ func GetOperand() operands.Operand {
 	return &templateValidator{}
 }
 
+const (
+	operandName      = "template-validator"
+	operandComponent = common.AppComponentTemplating
+)
+
 func reconcileClusterRole(request *common.Request) (common.ResourceStatus, error) {
 	return common.CreateOrUpdateClusterResource(request,
-		newClusterRole(),
+		common.AddAppLabels(request, operandName, operandComponent, newClusterRole()),
 		func(newRes, foundRes controllerutil.Object) {
 			foundRes.(*rbac.ClusterRole).Rules = newRes.(*rbac.ClusterRole).Rules
 		})
@@ -93,13 +98,13 @@ func reconcileClusterRole(request *common.Request) (common.ResourceStatus, error
 
 func reconcileServiceAccount(request *common.Request) (common.ResourceStatus, error) {
 	return common.CreateOrUpdateResource(request,
-		newServiceAccount(request.Namespace),
+		common.AddAppLabels(request, operandName, operandComponent, newServiceAccount(request.Namespace)),
 		func(_, _ controllerutil.Object) {})
 }
 
 func reconcileClusterRoleBinding(request *common.Request) (common.ResourceStatus, error) {
 	return common.CreateOrUpdateClusterResource(request,
-		newClusterRoleBinding(request.Namespace),
+		common.AddAppLabels(request, operandName, operandComponent, newClusterRoleBinding(request.Namespace)),
 		func(newRes, foundRes controllerutil.Object) {
 			newBinding := newRes.(*rbac.ClusterRoleBinding)
 			foundBinding := foundRes.(*rbac.ClusterRoleBinding)
@@ -110,7 +115,7 @@ func reconcileClusterRoleBinding(request *common.Request) (common.ResourceStatus
 
 func reconcileService(request *common.Request) (common.ResourceStatus, error) {
 	return common.CreateOrUpdateResource(request,
-		newService(request.Namespace),
+		common.AddAppLabels(request, operandName, operandComponent, newService(request.Namespace)),
 		func(newRes, foundRes controllerutil.Object) {
 			newService := newRes.(*v1.Service)
 			foundService := foundRes.(*v1.Service)
@@ -128,7 +133,7 @@ func reconcileDeployment(request *common.Request) (common.ResourceStatus, error)
 	deployment := newDeployment(request.Namespace, *validatorSpec.Replicas, image)
 	addPlacementFields(deployment, validatorSpec.Placement)
 	return common.CreateOrUpdateResourceWithStatus(request,
-		deployment,
+		common.AddAppLabels(request, operandName, operandComponent, deployment),
 		func(newRes, foundRes controllerutil.Object) {
 			foundRes.(*apps.Deployment).Spec = newRes.(*apps.Deployment).Spec
 		},
@@ -165,7 +170,7 @@ func addPlacementFields(deployment *apps.Deployment, nodePlacement *lifecycleapi
 
 func reconcileValidatingWebhook(request *common.Request) (common.ResourceStatus, error) {
 	return common.CreateOrUpdateClusterResource(request,
-		newValidatingWebhook(request.Namespace),
+		common.AddAppLabels(request, operandName, operandComponent, newValidatingWebhook(request.Namespace)),
 		func(newRes, foundRes controllerutil.Object) {
 			newWebhookConf := newRes.(*admission.ValidatingWebhookConfiguration)
 			foundWebhookConf := foundRes.(*admission.ValidatingWebhookConfiguration)

--- a/tests/commonTemplates_test.go
+++ b/tests/commonTemplates_test.go
@@ -16,7 +16,6 @@ import (
 	core "k8s.io/api/core/v1"
 	rbac "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"kubevirt.io/ssp-operator/internal/common"
@@ -263,7 +262,7 @@ var _ = Describe("Common templates", func() {
 			// might be deployed in a different namespace than the CR, and will be immediately
 			// removed by the GC, the choice to use a template as an owner object was arbitrary
 			ownerTemplate = &templatev1.Template{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:      "owner-template",
 					Namespace: strategy.GetTemplatesNamespace(),
 				},
@@ -271,7 +270,7 @@ var _ = Describe("Common templates", func() {
 			Expect(apiClient.Create(ctx, ownerTemplate)).ToNot(HaveOccurred(), "failed to create dummy owner for an old template")
 
 			oldTemplate = &templatev1.Template{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-old-template",
 					Namespace: strategy.GetTemplatesNamespace(),
 					Labels: map[string]string{
@@ -281,7 +280,7 @@ var _ = Describe("Common templates", func() {
 						"flavor.template.kubevirt.io/test":     "true",
 						"workload.template.kubevirt.io/server": "true",
 					},
-					OwnerReferences: []v1.OwnerReference{{
+					OwnerReferences: []metav1.OwnerReference{{
 						APIVersion: "template.openshift.io/v1",
 						Kind:       "Template",
 						Name:       ownerTemplate.Name,

--- a/tests/commonTemplates_test.go
+++ b/tests/commonTemplates_test.go
@@ -33,11 +33,12 @@ var _ = Describe("Common templates", func() {
 	)
 
 	BeforeEach(func() {
+		expectedLabels := expectedLabelsFor("common-templates", common.AppComponentTemplating)
 		viewRole = testResource{
 			Name:           commonTemplates.ViewRoleName,
 			Namespace:      commonTemplates.GoldenImagesNSname,
 			Resource:       &rbac.Role{},
-			ExpectedLabels: expectedLabelsFor("common-templates", common.AppComponentTemplating),
+			ExpectedLabels: expectedLabels,
 			UpdateFunc: func(role *rbac.Role) {
 				role.Rules = []rbac.PolicyRule{}
 			},
@@ -49,7 +50,7 @@ var _ = Describe("Common templates", func() {
 			Name:           commonTemplates.ViewRoleName,
 			Namespace:      commonTemplates.GoldenImagesNSname,
 			Resource:       &rbac.RoleBinding{},
-			ExpectedLabels: expectedLabelsFor("common-templates", common.AppComponentTemplating),
+			ExpectedLabels: expectedLabels,
 			UpdateFunc: func(roleBinding *rbac.RoleBinding) {
 				roleBinding.Subjects = nil
 			},
@@ -60,7 +61,7 @@ var _ = Describe("Common templates", func() {
 		editClusterRole = testResource{
 			Name:           commonTemplates.EditClusterRoleName,
 			Resource:       &rbac.ClusterRole{},
-			ExpectedLabels: expectedLabelsFor("common-templates", common.AppComponentTemplating),
+			ExpectedLabels: expectedLabels,
 			Namespace:      "",
 			UpdateFunc: func(role *rbac.ClusterRole) {
 				role.Rules[0].Verbs = []string{"watch"}
@@ -72,14 +73,14 @@ var _ = Describe("Common templates", func() {
 		goldenImageNS = testResource{
 			Name:           commonTemplates.GoldenImagesNSname,
 			Resource:       &core.Namespace{},
-			ExpectedLabels: expectedLabelsFor("common-templates", common.AppComponentTemplating),
+			ExpectedLabels: expectedLabels,
 			Namespace:      "",
 		}
 		testTemplate = testResource{
 			Name:           "rhel8-desktop-tiny",
 			Namespace:      strategy.GetTemplatesNamespace(),
 			Resource:       &templatev1.Template{},
-			ExpectedLabels: expectedLabelsFor("common-templates", common.AppComponentTemplating),
+			ExpectedLabels: expectedLabels,
 			UpdateFunc: func(t *templatev1.Template) {
 				t.Parameters = nil
 			},

--- a/tests/commonTemplates_test.go
+++ b/tests/commonTemplates_test.go
@@ -23,14 +23,6 @@ import (
 	commonTemplates "kubevirt.io/ssp-operator/internal/operands/common-templates"
 )
 
-var commonTemplateExpectedLabels = map[string]string{
-	common.AppKubernetesNameLabel:      "common-templates",
-	common.AppKubernetesManagedByLabel: "ssp-operator",
-	common.AppKubernetesPartOfLabel:    "test",
-	common.AppKubernetesVersionLabel:   "v0.0.0-test",
-	common.AppKubernetesComponentLabel: common.AppComponentTemplating.String(),
-}
-
 var _ = Describe("Common templates", func() {
 	var (
 		viewRole        testResource
@@ -45,7 +37,7 @@ var _ = Describe("Common templates", func() {
 			Name:           commonTemplates.ViewRoleName,
 			Namespace:      commonTemplates.GoldenImagesNSname,
 			Resource:       &rbac.Role{},
-			ExpectedLabels: commonTemplateExpectedLabels,
+			ExpectedLabels: expectedLabelsFor("common-templates", common.AppComponentTemplating),
 			UpdateFunc: func(role *rbac.Role) {
 				role.Rules = []rbac.PolicyRule{}
 			},
@@ -57,7 +49,7 @@ var _ = Describe("Common templates", func() {
 			Name:           commonTemplates.ViewRoleName,
 			Namespace:      commonTemplates.GoldenImagesNSname,
 			Resource:       &rbac.RoleBinding{},
-			ExpectedLabels: commonTemplateExpectedLabels,
+			ExpectedLabels: expectedLabelsFor("common-templates", common.AppComponentTemplating),
 			UpdateFunc: func(roleBinding *rbac.RoleBinding) {
 				roleBinding.Subjects = nil
 			},
@@ -68,7 +60,7 @@ var _ = Describe("Common templates", func() {
 		editClusterRole = testResource{
 			Name:           commonTemplates.EditClusterRoleName,
 			Resource:       &rbac.ClusterRole{},
-			ExpectedLabels: commonTemplateExpectedLabels,
+			ExpectedLabels: expectedLabelsFor("common-templates", common.AppComponentTemplating),
 			Namespace:      "",
 			UpdateFunc: func(role *rbac.ClusterRole) {
 				role.Rules[0].Verbs = []string{"watch"}
@@ -80,14 +72,14 @@ var _ = Describe("Common templates", func() {
 		goldenImageNS = testResource{
 			Name:           commonTemplates.GoldenImagesNSname,
 			Resource:       &core.Namespace{},
-			ExpectedLabels: commonTemplateExpectedLabels,
+			ExpectedLabels: expectedLabelsFor("common-templates", common.AppComponentTemplating),
 			Namespace:      "",
 		}
 		testTemplate = testResource{
 			Name:           "rhel8-desktop-tiny",
 			Namespace:      strategy.GetTemplatesNamespace(),
 			Resource:       &templatev1.Template{},
-			ExpectedLabels: commonTemplateExpectedLabels,
+			ExpectedLabels: expectedLabelsFor("common-templates", common.AppComponentTemplating),
 			UpdateFunc: func(t *templatev1.Template) {
 				t.Parameters = nil
 			},

--- a/tests/labels_test.go
+++ b/tests/labels_test.go
@@ -30,25 +30,23 @@ func expectAppLabels(res *testResource) {
 }
 
 func expectAppLabelsRestoreAfterUpdate(res *testResource) {
-	testExpectedLabelsRestoreAfterUpdate(res.NewResource(), res.GetKey(), res.ExpectedLabels)
-}
+	resource := res.NewResource()
+	key := res.GetKey()
+	testExpectedLabels(resource, key, res.ExpectedLabels)
 
-func testExpectedLabels(resource controllerutil.Object, key client.ObjectKey, expectedLabels map[string]string) {
-	patchAppLabelsIntoSSP(expectedLabels)
-	waitForLabelMatch(resource, key, expectedLabels)
-}
-
-func testExpectedLabelsRestoreAfterUpdate(resource controllerutil.Object, key client.ObjectKey, expectedLabels map[string]string) {
-	testExpectedLabels(resource, key, expectedLabels)
-
-	operations := newLabelOperations(expectedLabels)
-	for label := range expectedLabels {
+	operations := newLabelOperations(res.ExpectedLabels)
+	for label := range res.ExpectedLabels {
 		operations = append(operations, labelPatchOperationFor("replace", label, "wrong"))
 	}
 	patch := encodePatch(operations)
 	err := apiClient.Patch(ctx, resource, patch)
 	Expect(err).NotTo(HaveOccurred())
-	Expect(labelsMatch(expectedLabels, resource)).To(BeFalse())
+	waitForLabelMatch(resource, key, res.ExpectedLabels)
+}
+
+func testExpectedLabels(resource controllerutil.Object, key client.ObjectKey, expectedLabels map[string]string) {
+	patchAppLabelsIntoSSP(expectedLabels)
+	waitForLabelMatch(resource, key, expectedLabels)
 }
 
 func patchAppLabelsIntoSSP(expectedLabels map[string]string) {

--- a/tests/labels_test.go
+++ b/tests/labels_test.go
@@ -16,6 +16,16 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
+func expectedLabelsFor(name string, component common.AppComponent) map[string]string {
+	return map[string]string{
+		common.AppKubernetesNameLabel:      name,
+		common.AppKubernetesManagedByLabel: "ssp-operator",
+		common.AppKubernetesPartOfLabel:    strategy.GetPartOfLabel(),
+		common.AppKubernetesVersionLabel:   strategy.GetVersionLabel(),
+		common.AppKubernetesComponentLabel: component.String(),
+	}
+}
+
 func expectAppLabels(res *testResource) {
 	testExpectedLabels(res.NewResource(), res.GetKey(), res.ExpectedLabels)
 }

--- a/tests/labels_test.go
+++ b/tests/labels_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -47,7 +46,7 @@ func testExpectedLabelsRestoreAfterUpdate(resource controllerutil.Object, key cl
 		operations = append(operations, labelPatchOperationFor("replace", label, "wrong"))
 	}
 	patch := encodePatch(operations)
-	err := apiClient.Patch(context.TODO(), resource, patch)
+	err := apiClient.Patch(ctx, resource, patch)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(labelsMatch(expectedLabels, resource)).To(BeFalse())
 }
@@ -66,7 +65,7 @@ func patchAppLabelsIntoSSP(expectedLabels map[string]string) {
 	}
 
 	patch := buildLabelsPatchAdding(newLabels)
-	err := apiClient.Patch(context.TODO(), ssp, patch)
+	err := apiClient.Patch(ctx, ssp, patch)
 	Expect(err).NotTo(HaveOccurred(), "app labels could not be added to SSP CR")
 }
 
@@ -104,7 +103,7 @@ func encodePatch(operations []jsonpatch.Operation) client.Patch {
 
 func waitForLabelMatch(resource controllerutil.Object, key client.ObjectKey, expectedLabels map[string]string) {
 	Eventually(func() bool {
-		err := apiClient.Get(context.TODO(), key, resource)
+		err := apiClient.Get(ctx, key, resource)
 		if err != nil {
 			fmt.Fprintln(GinkgoWriter, err)
 			return false

--- a/tests/labels_test.go
+++ b/tests/labels_test.go
@@ -1,0 +1,122 @@
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"kubevirt.io/ssp-operator/internal/common"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"gomodules.xyz/jsonpatch/v2"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+func expectAppLabels(res *testResource) {
+	resource := res.NewResource()
+	testExpectedLabels(resource, res.GetKey(), res.ExpectedLabels)
+}
+
+func expectAppLabelsRestoreAfterUpdate(res *testResource) {
+	testExpectedLabelsRestoreAfterUpdate(res.NewResource(), res.GetKey(), res.ExpectedLabels)
+}
+
+func testExpectedLabels(resource controllerutil.Object, key client.ObjectKey, expectedLabels map[string]string) {
+	patchAppLabelsIntoSSP(expectedLabels)
+	waitForLabelMatch(resource, key, expectedLabels)
+}
+
+func testExpectedLabelsRestoreAfterUpdate(resource controllerutil.Object, key client.ObjectKey, expectedLabels map[string]string) {
+	testExpectedLabels(resource, key, expectedLabels)
+
+	operations := newLabelOperations(expectedLabels)
+	for label := range expectedLabels {
+		operations = append(operations, labelPatchOperationFor("replace", label, "wrong"))
+	}
+	patch := encodePatch(operations)
+	err := apiClient.Patch(context.TODO(), resource, patch)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(labelsMatch(expectedLabels, resource)).To(BeFalse())
+}
+
+func patchAppLabelsIntoSSP(expectedLabels map[string]string) {
+	ssp := getSsp()
+	Expect(ssp).NotTo(BeNil())
+
+	if ssp.Labels != nil && labelsMatch(expectedLabels, ssp) {
+		return
+	}
+
+	newLabels := map[string]string{
+		common.AppKubernetesPartOfLabel:  expectedLabels[common.AppKubernetesPartOfLabel],
+		common.AppKubernetesVersionLabel: expectedLabels[common.AppKubernetesVersionLabel],
+	}
+
+	patch := buildLabelsPatchAdding(newLabels)
+	err := apiClient.Patch(context.TODO(), ssp, patch)
+	Expect(err).NotTo(HaveOccurred(), "app labels could not be added to SSP CR")
+}
+
+func buildLabelsPatchAdding(labels map[string]string) client.Patch {
+	return buildLabelsPatch("add", labels)
+}
+
+func buildLabelsPatch(operation string, labels map[string]string) client.Patch {
+	operations := newLabelOperations(labels)
+
+	for label, value := range labels {
+		operations = append(operations, labelPatchOperationFor(operation, label, value))
+	}
+
+	return encodePatch(operations)
+}
+
+func newLabelOperations(labels map[string]string) []jsonpatch.Operation {
+	operations := make([]jsonpatch.Operation, 0, len(labels)+1)
+	operations = append(operations, jsonpatch.NewPatch("add", "/metadata/labels", struct{}{}))
+	return operations
+}
+
+func labelPatchOperationFor(op, label, value string) jsonpatch.Operation {
+	return jsonpatch.NewPatch(op, fmt.Sprintf("/metadata/labels/%s", strings.ReplaceAll(label, "/", "~1")), value)
+}
+
+func encodePatch(operations []jsonpatch.Operation) client.Patch {
+	patchBytes, err := json.Marshal(operations)
+	Expect(err).NotTo(HaveOccurred())
+
+	fmt.Fprintf(GinkgoWriter, "sending patch: %s", string(patchBytes))
+	return client.RawPatch(types.JSONPatchType, patchBytes)
+}
+
+func waitForLabelMatch(resource controllerutil.Object, key client.ObjectKey, expectedLabels map[string]string) {
+	Eventually(func() bool {
+		err := apiClient.Get(context.TODO(), key, resource)
+		if err != nil {
+			fmt.Fprintln(GinkgoWriter, err)
+			return false
+		}
+		return labelsMatch(expectedLabels, resource)
+	}, shortTimeout).Should(BeTrue(), "app labels were not added")
+}
+
+func labelsMatch(expectedLabels map[string]string, obj controllerutil.Object) bool {
+	labels := obj.GetLabels()
+	if labels == nil {
+		return false
+	}
+
+	for label, value := range expectedLabels {
+		foundValue, foundLabel := labels[label]
+		if !foundLabel || foundValue != value {
+			fmt.Fprintf(GinkgoWriter, "expected label %s=%s, got: %s\n", label, value, foundValue)
+			return false
+		}
+	}
+
+	return true
+}

--- a/tests/labels_test.go
+++ b/tests/labels_test.go
@@ -17,8 +17,7 @@ import (
 )
 
 func expectAppLabels(res *testResource) {
-	resource := res.NewResource()
-	testExpectedLabels(resource, res.GetKey(), res.ExpectedLabels)
+	testExpectedLabels(res.NewResource(), res.GetKey(), res.ExpectedLabels)
 }
 
 func expectAppLabelsRestoreAfterUpdate(res *testResource) {

--- a/tests/metrics_test.go
+++ b/tests/metrics_test.go
@@ -16,16 +16,10 @@ var _ = Describe("Metrics", func() {
 
 	BeforeEach(func() {
 		prometheusRuleRes = testResource{
-			Name:      metrics.PrometheusRuleName,
-			Namespace: strategy.GetNamespace(),
-			Resource:  &promv1.PrometheusRule{},
-			ExpectedLabels: map[string]string{
-				common.AppKubernetesNameLabel:      "metrics",
-				common.AppKubernetesManagedByLabel: "ssp-operator",
-				common.AppKubernetesPartOfLabel:    "test",
-				common.AppKubernetesVersionLabel:   "v0.0.0-test",
-				common.AppKubernetesComponentLabel: common.AppComponentMonitoring.String(),
-			},
+			Name:           metrics.PrometheusRuleName,
+			Namespace:      strategy.GetNamespace(),
+			Resource:       &promv1.PrometheusRule{},
+			ExpectedLabels: expectedLabelsFor("metrics", common.AppComponentMonitoring),
 			UpdateFunc: func(rule *promv1.PrometheusRule) {
 				rule.Spec.Groups[0].Name = "changed-name"
 				rule.Spec.Groups[0].Rules = []promv1.Rule{}

--- a/tests/metrics_test.go
+++ b/tests/metrics_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"kubevirt.io/ssp-operator/internal/common"
 	"kubevirt.io/ssp-operator/internal/operands/metrics"
 )
 
@@ -53,6 +54,28 @@ var _ = Describe("Metrics", func() {
 
 		It("[test_id:5397] should recreate modified prometheus rule after pause", func() {
 			expectRestoreAfterUpdateWithPause(&prometheusRuleRes)
+		})
+	})
+
+	Context("app labels", func() {
+		expectedLabels := map[string]string{
+			common.AppKubernetesNameLabel:      "metrics",
+			common.AppKubernetesManagedByLabel: "ssp-operator",
+			common.AppKubernetesPartOfLabel:    "test",
+			common.AppKubernetesVersionLabel:   "v0.0.0-test",
+			common.AppKubernetesComponentLabel: common.AppComponentMonitoring.String(),
+		}
+
+		It("adds app labels from SSP CR", func() {
+			resource := &promv1.PrometheusRule{}
+			key := prometheusRuleRes.GetKey()
+			testExpectedLabels(resource, key, expectedLabels)
+		})
+
+		It("restores modified app labels", func() {
+			resource := &promv1.PrometheusRule{}
+			key := prometheusRuleRes.GetKey()
+			testExpectedLabelsRestoreAfterUpdate(resource, key, expectedLabels)
 		})
 	})
 })

--- a/tests/metrics_test.go
+++ b/tests/metrics_test.go
@@ -19,6 +19,13 @@ var _ = Describe("Metrics", func() {
 			Name:      metrics.PrometheusRuleName,
 			Namespace: strategy.GetNamespace(),
 			Resource:  &promv1.PrometheusRule{},
+			ExpectedLabels: map[string]string{
+				common.AppKubernetesNameLabel:      "metrics",
+				common.AppKubernetesManagedByLabel: "ssp-operator",
+				common.AppKubernetesPartOfLabel:    "test",
+				common.AppKubernetesVersionLabel:   "v0.0.0-test",
+				common.AppKubernetesComponentLabel: common.AppComponentMonitoring.String(),
+			},
 			UpdateFunc: func(rule *promv1.PrometheusRule) {
 				rule.Spec.Groups[0].Name = "changed-name"
 				rule.Spec.Groups[0].Rules = []promv1.Rule{}
@@ -58,24 +65,12 @@ var _ = Describe("Metrics", func() {
 	})
 
 	Context("app labels", func() {
-		expectedLabels := map[string]string{
-			common.AppKubernetesNameLabel:      "metrics",
-			common.AppKubernetesManagedByLabel: "ssp-operator",
-			common.AppKubernetesPartOfLabel:    "test",
-			common.AppKubernetesVersionLabel:   "v0.0.0-test",
-			common.AppKubernetesComponentLabel: common.AppComponentMonitoring.String(),
-		}
-
 		It("adds app labels from SSP CR", func() {
-			resource := &promv1.PrometheusRule{}
-			key := prometheusRuleRes.GetKey()
-			testExpectedLabels(resource, key, expectedLabels)
+			expectAppLabels(&prometheusRuleRes)
 		})
 
 		It("restores modified app labels", func() {
-			resource := &promv1.PrometheusRule{}
-			key := prometheusRuleRes.GetKey()
-			testExpectedLabelsRestoreAfterUpdate(resource, key, expectedLabels)
+			expectAppLabelsRestoreAfterUpdate(&prometheusRuleRes)
 		})
 	})
 })

--- a/tests/nodeLabeller_test.go
+++ b/tests/nodeLabeller_test.go
@@ -20,14 +20,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var nodeLabelerExpectedLabels = map[string]string{
-	common.AppKubernetesNameLabel:      "node-labeler",
-	common.AppKubernetesManagedByLabel: "ssp-operator",
-	common.AppKubernetesPartOfLabel:    "test",
-	common.AppKubernetesVersionLabel:   "v0.0.0-test",
-	common.AppKubernetesComponentLabel: common.AppComponentSchedule.String(),
-}
-
 var _ = Describe("Node Labeller", func() {
 	var (
 		clusterRoleRes               testResource
@@ -43,7 +35,7 @@ var _ = Describe("Node Labeller", func() {
 			Name:           nodelabeller.ClusterRoleName,
 			Resource:       &rbac.ClusterRole{},
 			Namespace:      "",
-			ExpectedLabels: nodeLabelerExpectedLabels,
+			ExpectedLabels: expectedLabelsFor("node-labeler", common.AppComponentSchedule),
 			UpdateFunc: func(role *rbac.ClusterRole) {
 				role.Rules[0].Verbs = []string{"watch"}
 			},
@@ -55,7 +47,7 @@ var _ = Describe("Node Labeller", func() {
 			Name:           nodelabeller.ClusterRoleBindingName,
 			Resource:       &rbac.ClusterRoleBinding{},
 			Namespace:      "",
-			ExpectedLabels: nodeLabelerExpectedLabels,
+			ExpectedLabels: expectedLabelsFor("node-labeler", common.AppComponentSchedule),
 			UpdateFunc: func(roleBinding *rbac.ClusterRoleBinding) {
 				roleBinding.Subjects = nil
 			},
@@ -67,13 +59,13 @@ var _ = Describe("Node Labeller", func() {
 			Name:           nodelabeller.ServiceAccountName,
 			Namespace:      strategy.GetNamespace(),
 			Resource:       &core.ServiceAccount{},
-			ExpectedLabels: nodeLabelerExpectedLabels,
+			ExpectedLabels: expectedLabelsFor("node-labeler", common.AppComponentSchedule),
 		}
 		securityContextConstraintRes = testResource{
 			Name:           nodelabeller.SecurityContextName,
 			Namespace:      "",
 			Resource:       &secv1.SecurityContextConstraints{},
-			ExpectedLabels: nodeLabelerExpectedLabels,
+			ExpectedLabels: expectedLabelsFor("node-labeler", common.AppComponentSchedule),
 			UpdateFunc: func(scc *secv1.SecurityContextConstraints) {
 				scc.Users = []string{"test-user"}
 			},
@@ -85,7 +77,7 @@ var _ = Describe("Node Labeller", func() {
 			Name:           nodelabeller.ConfigMapName,
 			Namespace:      strategy.GetNamespace(),
 			Resource:       &core.ConfigMap{},
-			ExpectedLabels: nodeLabelerExpectedLabels,
+			ExpectedLabels: expectedLabelsFor("node-labeler", common.AppComponentSchedule),
 			UpdateFunc: func(configMap *core.ConfigMap) {
 				configMap.Data = map[string]string{
 					"cpu-plugin-configmap.yaml": "change data",
@@ -99,7 +91,7 @@ var _ = Describe("Node Labeller", func() {
 			Name:           nodelabeller.DaemonSetName,
 			Namespace:      strategy.GetNamespace(),
 			Resource:       &apps.DaemonSet{},
-			ExpectedLabels: nodeLabelerExpectedLabels,
+			ExpectedLabels: expectedLabelsFor("node-labeler", common.AppComponentSchedule),
 			UpdateFunc: func(daemonSet *apps.DaemonSet) {
 				daemonSet.Spec.Template.Spec.ServiceAccountName = "test-account"
 			},

--- a/tests/tests_common_test.go
+++ b/tests/tests_common_test.go
@@ -27,6 +27,8 @@ type testResource struct {
 	Namespace string
 	Resource  controllerutil.Object
 
+	ExpectedLabels map[string]string
+
 	UpdateFunc interface{}
 	EqualsFunc interface{}
 }

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -420,13 +420,17 @@ func createOrUpdateSsp(ssp *sspv1beta1.SSP) {
 				return nil
 			}
 			foundSsp.Spec = ssp.Spec
+			foundSsp.Annotations = ssp.Annotations
+			foundSsp.Labels = ssp.Labels
 			return apiClient.Update(ctx, foundSsp)
 		}
 		if errors.IsNotFound(err) {
 			newSsp := &sspv1beta1.SSP{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      ssp.Name,
-					Namespace: ssp.Namespace,
+					Name:        ssp.Name,
+					Namespace:   ssp.Namespace,
+					Annotations: ssp.Annotations,
+					Labels:      ssp.Labels,
 				},
 				Spec: ssp.Spec,
 			}

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -154,15 +154,9 @@ func (s *newSspStrategy) GetValidatorReplicas() int {
 }
 
 func (s *newSspStrategy) GetVersionLabel() string {
-	if s.ssp.Labels == nil {
-		return ""
-	}
 	return s.ssp.Labels[common.AppKubernetesVersionLabel]
 }
 func (s *newSspStrategy) GetPartOfLabel() string {
-	if s.ssp.Labels == nil {
-		return ""
-	}
 	return s.ssp.Labels[common.AppKubernetesPartOfLabel]
 }
 
@@ -259,15 +253,9 @@ func (s *existingSspStrategy) GetValidatorReplicas() int {
 }
 
 func (s *existingSspStrategy) GetVersionLabel() string {
-	if s.ssp.Labels == nil {
-		return ""
-	}
 	return s.ssp.Labels[common.AppKubernetesVersionLabel]
 }
 func (s *existingSspStrategy) GetPartOfLabel() string {
-	if s.ssp.Labels == nil {
-		return ""
-	}
 	return s.ssp.Labels[common.AppKubernetesPartOfLabel]
 }
 

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -192,22 +192,6 @@ func (s *existingSspStrategy) Init() {
 		return
 	}
 
-	appLabels := map[string]string{
-		common.AppKubernetesNameLabel:      "ssp-cr",
-		common.AppKubernetesManagedByLabel: "ssp-test-strategy",
-		common.AppKubernetesPartOfLabel:    "hyperconverged-cluster",
-		common.AppKubernetesVersionLabel:   "v0.0.0-test",
-		common.AppKubernetesComponentLabel: common.AppComponentSchedule.String(),
-	}
-	patch := buildLabelsPatchAdding(appLabels)
-	err = apiClient.Patch(ctx, existingSsp, patch)
-	Expect(err).NotTo(HaveOccurred(), "app labels could not be added to SSP CR")
-	Expect(s.ssp.Labels).To(HaveKeyWithValue(common.AppKubernetesNameLabel, "ssp-cr"))
-	Expect(s.ssp.Labels).To(HaveKeyWithValue(common.AppKubernetesManagedByLabel, "ssp-test-strategy"))
-	Expect(s.ssp.Labels).To(HaveKeyWithValue(common.AppKubernetesPartOfLabel, "hyperconverged-cluster"))
-	Expect(s.ssp.Labels).To(HaveKeyWithValue(common.AppKubernetesVersionLabel, "v0.0.0-test"))
-	Expect(s.ssp.Labels).To(HaveKeyWithValue(common.AppKubernetesComponentLabel, common.AppComponentSchedule.String()))
-
 	// Try to modify the SSP and check if it is not reverted by another operator
 	defer s.RevertToOriginalSspCr()
 

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -416,7 +416,10 @@ func createOrUpdateSsp(ssp *sspv1beta1.SSP) {
 		foundSsp := &sspv1beta1.SSP{}
 		err := apiClient.Get(ctx, key, foundSsp)
 		if err == nil {
-			if reflect.DeepEqual(foundSsp.Spec, ssp.Spec) {
+			isEqual := reflect.DeepEqual(foundSsp.Spec, ssp.Spec) &&
+				reflect.DeepEqual(foundSsp.ObjectMeta.Annotations, ssp.ObjectMeta.Annotations) &&
+				reflect.DeepEqual(foundSsp.ObjectMeta.Labels, ssp.ObjectMeta.Labels)
+			if isEqual {
 				return nil
 			}
 			foundSsp.Spec = ssp.Spec

--- a/tests/validator_test.go
+++ b/tests/validator_test.go
@@ -22,14 +22,6 @@ import (
 	validator "kubevirt.io/ssp-operator/internal/operands/template-validator"
 )
 
-var templateValidatorExpectedLabels = map[string]string{
-	common.AppKubernetesNameLabel:      "template-validator",
-	common.AppKubernetesManagedByLabel: "ssp-operator",
-	common.AppKubernetesPartOfLabel:    "test",
-	common.AppKubernetesVersionLabel:   "v0.0.0-test",
-	common.AppKubernetesComponentLabel: common.AppComponentTemplating.String(),
-}
-
 var _ = Describe("Template validator", func() {
 	var (
 		clusterRoleRes        testResource
@@ -46,7 +38,7 @@ var _ = Describe("Template validator", func() {
 		clusterRoleRes = testResource{
 			Name:           validator.ClusterRoleName,
 			Resource:       &rbac.ClusterRole{},
-			ExpectedLabels: templateValidatorExpectedLabels,
+			ExpectedLabels: expectedLabelsFor("template-validator", common.AppComponentTemplating),
 			UpdateFunc: func(role *rbac.ClusterRole) {
 				role.Rules[0].Verbs = []string{"watch"}
 			},
@@ -57,7 +49,7 @@ var _ = Describe("Template validator", func() {
 		clusterRoleBindingRes = testResource{
 			Name:           validator.ClusterRoleBindingName,
 			Resource:       &rbac.ClusterRoleBinding{},
-			ExpectedLabels: templateValidatorExpectedLabels,
+			ExpectedLabels: expectedLabelsFor("template-validator", common.AppComponentTemplating),
 			UpdateFunc: func(roleBinding *rbac.ClusterRoleBinding) {
 				roleBinding.Subjects = nil
 			},
@@ -69,7 +61,7 @@ var _ = Describe("Template validator", func() {
 		webhookConfigRes = testResource{
 			Name:           validator.WebhookName,
 			Resource:       &admission.ValidatingWebhookConfiguration{},
-			ExpectedLabels: templateValidatorExpectedLabels,
+			ExpectedLabels: expectedLabelsFor("template-validator", common.AppComponentTemplating),
 			UpdateFunc: func(webhook *admission.ValidatingWebhookConfiguration) {
 				webhook.Webhooks[0].Rules = nil
 			},
@@ -81,13 +73,13 @@ var _ = Describe("Template validator", func() {
 			Name:           validator.ServiceAccountName,
 			Namespace:      strategy.GetNamespace(),
 			Resource:       &core.ServiceAccount{},
-			ExpectedLabels: templateValidatorExpectedLabels,
+			ExpectedLabels: expectedLabelsFor("template-validator", common.AppComponentTemplating),
 		}
 		serviceRes = testResource{
 			Name:           validator.ServiceName,
 			Namespace:      strategy.GetNamespace(),
 			Resource:       &core.Service{},
-			ExpectedLabels: templateValidatorExpectedLabels,
+			ExpectedLabels: expectedLabelsFor("template-validator", common.AppComponentTemplating),
 			UpdateFunc: func(service *core.Service) {
 				service.Spec.Ports[0].Port = 44331
 				service.Spec.Ports[0].TargetPort = intstr.FromInt(44331)
@@ -100,7 +92,7 @@ var _ = Describe("Template validator", func() {
 			Name:           validator.DeploymentName,
 			Namespace:      strategy.GetNamespace(),
 			Resource:       &apps.Deployment{},
-			ExpectedLabels: templateValidatorExpectedLabels,
+			ExpectedLabels: expectedLabelsFor("template-validator", common.AppComponentTemplating),
 			UpdateFunc: func(deployment *apps.Deployment) {
 				deployment.Spec.Replicas = pointer.Int32Ptr(0)
 			},

--- a/tests/validator_test.go
+++ b/tests/validator_test.go
@@ -35,10 +35,11 @@ var _ = Describe("Template validator", func() {
 	)
 
 	BeforeEach(func() {
+		expectedLabels := expectedLabelsFor("template-validator", common.AppComponentTemplating)
 		clusterRoleRes = testResource{
 			Name:           validator.ClusterRoleName,
 			Resource:       &rbac.ClusterRole{},
-			ExpectedLabels: expectedLabelsFor("template-validator", common.AppComponentTemplating),
+			ExpectedLabels: expectedLabels,
 			UpdateFunc: func(role *rbac.ClusterRole) {
 				role.Rules[0].Verbs = []string{"watch"}
 			},
@@ -49,7 +50,7 @@ var _ = Describe("Template validator", func() {
 		clusterRoleBindingRes = testResource{
 			Name:           validator.ClusterRoleBindingName,
 			Resource:       &rbac.ClusterRoleBinding{},
-			ExpectedLabels: expectedLabelsFor("template-validator", common.AppComponentTemplating),
+			ExpectedLabels: expectedLabels,
 			UpdateFunc: func(roleBinding *rbac.ClusterRoleBinding) {
 				roleBinding.Subjects = nil
 			},
@@ -61,7 +62,7 @@ var _ = Describe("Template validator", func() {
 		webhookConfigRes = testResource{
 			Name:           validator.WebhookName,
 			Resource:       &admission.ValidatingWebhookConfiguration{},
-			ExpectedLabels: expectedLabelsFor("template-validator", common.AppComponentTemplating),
+			ExpectedLabels: expectedLabels,
 			UpdateFunc: func(webhook *admission.ValidatingWebhookConfiguration) {
 				webhook.Webhooks[0].Rules = nil
 			},
@@ -73,13 +74,13 @@ var _ = Describe("Template validator", func() {
 			Name:           validator.ServiceAccountName,
 			Namespace:      strategy.GetNamespace(),
 			Resource:       &core.ServiceAccount{},
-			ExpectedLabels: expectedLabelsFor("template-validator", common.AppComponentTemplating),
+			ExpectedLabels: expectedLabels,
 		}
 		serviceRes = testResource{
 			Name:           validator.ServiceName,
 			Namespace:      strategy.GetNamespace(),
 			Resource:       &core.Service{},
-			ExpectedLabels: expectedLabelsFor("template-validator", common.AppComponentTemplating),
+			ExpectedLabels: expectedLabels,
 			UpdateFunc: func(service *core.Service) {
 				service.Spec.Ports[0].Port = 44331
 				service.Spec.Ports[0].TargetPort = intstr.FromInt(44331)
@@ -92,7 +93,7 @@ var _ = Describe("Template validator", func() {
 			Name:           validator.DeploymentName,
 			Namespace:      strategy.GetNamespace(),
 			Resource:       &apps.Deployment{},
-			ExpectedLabels: expectedLabelsFor("template-validator", common.AppComponentTemplating),
+			ExpectedLabels: expectedLabels,
 			UpdateFunc: func(deployment *apps.Deployment) {
 				deployment.Spec.Replicas = pointer.Int32Ptr(0)
 			},

--- a/tests/validator_test.go
+++ b/tests/validator_test.go
@@ -18,8 +18,17 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	sspv1beta1 "kubevirt.io/ssp-operator/api/v1beta1"
+	"kubevirt.io/ssp-operator/internal/common"
 	validator "kubevirt.io/ssp-operator/internal/operands/template-validator"
 )
+
+var templateValidatorExpectedLabels = map[string]string{
+	common.AppKubernetesNameLabel:      "template-validator",
+	common.AppKubernetesManagedByLabel: "ssp-operator",
+	common.AppKubernetesPartOfLabel:    "test",
+	common.AppKubernetesVersionLabel:   "v0.0.0-test",
+	common.AppKubernetesComponentLabel: common.AppComponentTemplating.String(),
+}
 
 var _ = Describe("Template validator", func() {
 	var (
@@ -35,8 +44,9 @@ var _ = Describe("Template validator", func() {
 
 	BeforeEach(func() {
 		clusterRoleRes = testResource{
-			Name:     validator.ClusterRoleName,
-			Resource: &rbac.ClusterRole{},
+			Name:           validator.ClusterRoleName,
+			Resource:       &rbac.ClusterRole{},
+			ExpectedLabels: templateValidatorExpectedLabels,
 			UpdateFunc: func(role *rbac.ClusterRole) {
 				role.Rules[0].Verbs = []string{"watch"}
 			},
@@ -45,8 +55,9 @@ var _ = Describe("Template validator", func() {
 			},
 		}
 		clusterRoleBindingRes = testResource{
-			Name:     validator.ClusterRoleBindingName,
-			Resource: &rbac.ClusterRoleBinding{},
+			Name:           validator.ClusterRoleBindingName,
+			Resource:       &rbac.ClusterRoleBinding{},
+			ExpectedLabels: templateValidatorExpectedLabels,
 			UpdateFunc: func(roleBinding *rbac.ClusterRoleBinding) {
 				roleBinding.Subjects = nil
 			},
@@ -56,8 +67,9 @@ var _ = Describe("Template validator", func() {
 			},
 		}
 		webhookConfigRes = testResource{
-			Name:     validator.WebhookName,
-			Resource: &admission.ValidatingWebhookConfiguration{},
+			Name:           validator.WebhookName,
+			Resource:       &admission.ValidatingWebhookConfiguration{},
+			ExpectedLabels: templateValidatorExpectedLabels,
 			UpdateFunc: func(webhook *admission.ValidatingWebhookConfiguration) {
 				webhook.Webhooks[0].Rules = nil
 			},
@@ -66,14 +78,16 @@ var _ = Describe("Template validator", func() {
 			},
 		}
 		serviceAccountRes = testResource{
-			Name:      validator.ServiceAccountName,
-			Namespace: strategy.GetNamespace(),
-			Resource:  &core.ServiceAccount{},
+			Name:           validator.ServiceAccountName,
+			Namespace:      strategy.GetNamespace(),
+			Resource:       &core.ServiceAccount{},
+			ExpectedLabels: templateValidatorExpectedLabels,
 		}
 		serviceRes = testResource{
-			Name:      validator.ServiceName,
-			Namespace: strategy.GetNamespace(),
-			Resource:  &core.Service{},
+			Name:           validator.ServiceName,
+			Namespace:      strategy.GetNamespace(),
+			Resource:       &core.Service{},
+			ExpectedLabels: templateValidatorExpectedLabels,
 			UpdateFunc: func(service *core.Service) {
 				service.Spec.Ports[0].Port = 44331
 				service.Spec.Ports[0].TargetPort = intstr.FromInt(44331)
@@ -83,9 +97,10 @@ var _ = Describe("Template validator", func() {
 			},
 		}
 		deploymentRes = testResource{
-			Name:      validator.DeploymentName,
-			Namespace: strategy.GetNamespace(),
-			Resource:  &apps.Deployment{},
+			Name:           validator.DeploymentName,
+			Namespace:      strategy.GetNamespace(),
+			Resource:       &apps.Deployment{},
+			ExpectedLabels: templateValidatorExpectedLabels,
 			UpdateFunc: func(deployment *apps.Deployment) {
 				deployment.Spec.Replicas = pointer.Int32Ptr(0)
 			},
@@ -116,6 +131,15 @@ var _ = Describe("Template validator", func() {
 			table.Entry("[test_id:4910] service account", &serviceAccountRes),
 			table.Entry("[test_id:4911] service", &serviceRes),
 			table.Entry("[test_id:4912] deployment", &deploymentRes),
+		)
+
+		table.DescribeTable("should set app labels", expectAppLabels,
+			table.Entry("cluster role", &clusterRoleRes),
+			table.Entry("cluster role binding", &clusterRoleBindingRes),
+			table.Entry("validating webhook configuration", &webhookConfigRes),
+			table.Entry("service account", &serviceAccountRes),
+			table.Entry("service", &serviceRes),
+			table.Entry("deployment", &deploymentRes),
 		)
 	})
 
@@ -156,6 +180,14 @@ var _ = Describe("Template validator", func() {
 				table.Entry("[test_id:5539] deployment", &deploymentRes),
 			)
 		})
+
+		table.DescribeTable("should restore modified app labels", expectAppLabelsRestoreAfterUpdate,
+			table.Entry("cluster role", &clusterRoleRes),
+			table.Entry("cluster role binding", &clusterRoleBindingRes),
+			table.Entry("validating webhook configuration", &webhookConfigRes),
+			table.Entry("service", &serviceRes),
+			table.Entry("deployment", &deploymentRes),
+		)
 	})
 
 	It("[test_id:4913] should successfully start template-validator pod", func() {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -241,6 +241,7 @@ golang.org/x/tools/internal/typesinternal
 golang.org/x/xerrors
 golang.org/x/xerrors/internal
 # gomodules.xyz/jsonpatch/v2 v2.0.1
+## explicit
 gomodules.xyz/jsonpatch/v2
 # google.golang.org/appengine v1.6.6
 google.golang.org/appengine


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR adds the [kubernetes app labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/#labels) to all resources maintained by the operator.

We are adding:
```
app.kubernetes.io/name: <name of the operand>
app.kubernetes.io/version: <version of the CSV (more details below)>
app.kubernetes.io/component: <component in the overall architecture this belongs to>
app.kubernetes.io/part-of: <name of the entire deployment (more details below)>
app.kubernetes.io/managed-by: "ssp-operator"
```

The values for `app.kubernetes.io/version` and `app.kubernetes.io/part-of` should be provided by HCO as they are based on the CSV.
To get those values when reconciling resources, we look at the SSP CR and extract those two labels from it if available.

**Special notes for your reviewer**:
The kitchen recommends to consume this PR by commits. It should give you the changes grouped by operand.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add app.kubernetes.io/* labels to resources managed by the operator.
```
