### PR TITLE
Use a rhel8 template during testing instead of centos6

### DIFF
--- a/tests/commonTemplates_test.go
+++ b/tests/commonTemplates_test.go
@@ -71,7 +71,7 @@ var _ = Describe("Common templates", func() {
 			Namespace: "",
 		}
 		testTemplate = testResource{
-			Name:      "centos6-server-large",
+			Name:      "rhel8-desktop-tiny",
 			Namespace: strategy.GetTemplatesNamespace(),
 			Resource:  &templatev1.Template{},
 			UpdateFunc: func(t *templatev1.Template) {


### PR DESCRIPTION
**What this PR does / why we need it**:
The centos6 templates do not exist downstream, which causes tests to fail, so let's use rhel instead

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
