### PR TITLE
ssp operator deletes the node-labeller

### DIFF
--- a/internal/operands/node-labeller/defaults.go
+++ b/internal/operands/node-labeller/defaults.go
@@ -1,5 +1,11 @@
 package node_labeller
 
+/*
+*
+* This package is deprecated! Do not add any new code here.
+*
+ */
+
 const (
 	// quay.io/kubevirt/node-labeller:v0.2.0
 	KubevirtNodeLabellerDefaultImage = "quay.io/kubevirt/node-labeller@sha256:45391da5e8ecdd393830650061f8d68248a3b2961d60f42a04e4e0c58a7d3a3b"

--- a/internal/operands/node-labeller/reconcile_test.go
+++ b/internal/operands/node-labeller/reconcile_test.go
@@ -61,30 +61,22 @@ var _ = Describe("Node Labeller operand", func() {
 		}
 	})
 
-	It("should create node labeller resources", func() {
+	It("should delete node-labeller during reconcile", func() {
+		reconcileClusterRole(&request)
+		reconcileServiceAccount(&request)
+		reconcileClusterRoleBinding(&request)
+		reconcileConfigMap(&request)
+		reconcileDaemonSet(&request)
+		reconcileSecurityContextConstraint(&request)
+
 		_, err := operand.Reconcile(&request)
 		Expect(err).ToNot(HaveOccurred())
-
-		ExpectResourceExists(newClusterRole(), request)
-		ExpectResourceExists(newServiceAccount(namespace), request)
-		ExpectResourceExists(newClusterRoleBinding(namespace), request)
-		ExpectResourceExists(newConfigMap(namespace), request)
-		ExpectResourceExists(newDaemonSet(namespace), request)
-		ExpectResourceExists(newSecurityContextConstraint(namespace), request)
-	})
-
-	It("should remove cluster resources on cleanup", func() {
-		_, err := operand.Reconcile(&request)
-		Expect(err).ToNot(HaveOccurred())
-
-		ExpectResourceExists(newClusterRole(), request)
-		ExpectResourceExists(newClusterRoleBinding(namespace), request)
-		ExpectResourceExists(newSecurityContextConstraint(namespace), request)
-
-		Expect(operand.Cleanup(&request)).ToNot(HaveOccurred())
 
 		ExpectResourceNotExists(newClusterRole(), request)
+		ExpectResourceNotExists(newServiceAccount(namespace), request)
 		ExpectResourceNotExists(newClusterRoleBinding(namespace), request)
+		ExpectResourceNotExists(newConfigMap(namespace), request)
+		ExpectResourceNotExists(newDaemonSet(namespace), request)
 		ExpectResourceNotExists(newSecurityContextConstraint(namespace), request)
 	})
 })


### PR DESCRIPTION
**What this PR does / why we need it**:

**Do not merge. Work in progress. It is missing upgrade test**
ssp operator deletes the node-labeller

This PR updates the reconcile function for node-labeller,
so now it instead of creating/updating deletes all components of labeller.
**Release note**:
```
SSP operator now deletes all node-labeller components, because labeller was moved into Kubevirt.
```
Signed-off-by: Karel Simon <ksimon@redhat.com>