### PR TITLE
Add a script for upgrade testing used by OCP CI

### DIFF
--- a/automation/ocp-ci-run-e2e-upgrade-tests.sh
+++ b/automation/ocp-ci-run-e2e-upgrade-tests.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -e
+
+# Deploy KubeVirt and CDI
+./hack/deploy-kubevirt-and-cdi.sh
+
+# Deploy latest released SSP operator
+NAMESPACE=${1:-kubevirt}
+
+LATEST_SSP_VERSION=$(curl 'https://api.github.com/repos/kubevirt/ssp-operator/releases/latest' | jq '.name' | tr -d '"')
+oc apply -n $NAMESPACE -f "https://github.com/kubevirt/ssp-operator/releases/download/${LATEST_SSP_VERSION}/ssp-operator.yaml"
+
+# Wait for deployment to be available, otherwise the validating webhook would reject the SSP CR.
+oc wait --for=condition=Available --timeout=600s -n ${NAMESPACE} deployments/ssp-operator
+
+SSP_NAME="ssp-test"
+SSP_NAMESPACE="ssp-operator-functests"
+SSP_TEMPLATES_NAMESPACE="ssp-operator-functests-templates"
+
+oc apply -f - <<EOF
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ${SSP_NAMESPACE}
+EOF
+
+oc apply -f - <<EOF
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ${SSP_TEMPLATES_NAMESPACE}
+EOF
+
+# TODO - in a future release, this script should use the CR template from the latest released version
+sed -e "s/%%_SSP_NAME_%%/${SSP_NAME}/g" \
+    -e "s/%%_SSP_NAMESPACE_%%/${SSP_NAMESPACE}/g" \
+    -e "s/%%_COMMON_TEMPLATES_NAMESPACE_%%/${SSP_TEMPLATES_NAMESPACE}/g" \
+    ./automation/ssp-cr-template.yaml | oc apply -f -
+
+oc wait --for=condition=Available --timeout=600s -n ${SSP_NAMESPACE} ssp/${SSP_NAME}
+
+# $IMG variable contains the image built by OCP CI
+export GOFLAGS=""
+export SKIP_CLEANUP_AFTER_TESTS="true"
+export TEST_EXISTING_CR_NAME="${SSP_NAME}"
+export TEST_EXISTING_CR_NAMESPACE="${SSP_NAMESPACE}"
+make deploy functest

--- a/automation/ssp-cr-template.yaml
+++ b/automation/ssp-cr-template.yaml
@@ -1,0 +1,12 @@
+# This custom resource is used by upgrade tests
+
+apiVersion: ssp.kubevirt.io/v1beta1
+kind: SSP
+metadata:
+  name: %%_SSP_NAME_%%
+  namespace: %%_SSP_NAMESPACE_%%
+spec:
+  commonTemplates:
+    namespace: %%_COMMON_TEMPLATES_NAMESPACE_%%
+  templateValidator:
+    replicas: 2


### PR DESCRIPTION
**What this PR does / why we need it**:
Created a script to test upgrade from the latest released version.

**Release note**:
```release-note
None
```
