### PR TITLE
Add readiness probe to the operator pod

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -26,8 +26,7 @@ spec:
       containers:
       - command:
         - /manager
-        args:
-        - --enable-leader-election
+        args: ["--enable-leader-election", "--ready-probe-addr", ":9440"]
         env:
           - name: KVM_INFO_IMAGE
           - name: VALIDATOR_IMAGE
@@ -37,4 +36,9 @@ spec:
           - name: OPERATOR_VERSION
         image: controller:latest
         name: manager
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 9440
+          initialDelaySeconds: 5
       terminationGracePeriodSeconds: 10

--- a/data/olm-catalog/ssp-operator.clusterserviceversion.yaml
+++ b/data/olm-catalog/ssp-operator.clusterserviceversion.yaml
@@ -335,6 +335,8 @@ spec:
                 containers:
                   - args:
                       - --enable-leader-election
+                      - --ready-probe-addr
+                      - :9440
                     command:
                       - /manager
                     env:
@@ -350,6 +352,11 @@ spec:
                       - containerPort: 9443
                         name: webhook-server
                         protocol: TCP
+                    readinessProbe:
+                      httpGet:
+                        path: /readyz
+                        port: 9440
+                      initialDelaySeconds: 5
                     resources: {}
                 serviceAccountName: ssp-operator
                 terminationGracePeriodSeconds: 10


### PR DESCRIPTION
Added readiness probe to the operator pod to signal when the webhook is ready to receive requests.

**Release note**:
```release-note
None
```
