### PR TITLE
csv-generator: populate spec.relatedImages

### DIFF
--- a/internal/operands/node-labeller/defaults.go
+++ b/internal/operands/node-labeller/defaults.go
@@ -1,8 +1,12 @@
 package node_labeller
 
 const (
-	kubevirtNodeLabellerDefaultImage = "quay.io/kubevirt/node-labeller:v0.2.0"
-	kvmInfoNfdDefaultImage           = "quay.io/kubevirt/kvm-info-nfd-plugin:v0.5.8"
-	kvmCpuNfdDefaultImage            = "quay.io/kubevirt/cpu-nfd-plugin:v0.1.1"
-	libvirtDefaultImage              = "quay.io/kubevirt/virt-launcher:v0.37.2"
+	// quay.io/kubevirt/node-labeller:v0.2.0
+	KubevirtNodeLabellerDefaultImage = "quay.io/kubevirt/node-labeller@sha256:45391da5e8ecdd393830650061f8d68248a3b2961d60f42a04e4e0c58a7d3a3b"
+	// quay.io/kubevirt/kvm-info-nfd-plugin:v0.5.8
+	KvmInfoNfdDefaultImage = "quay.io/kubevirt/kvm-info-nfd-plugin@sha256:c74083d42f9503007712dea435289e5f10a846433df2d3af4358463adb3fc9ff"
+	// quay.io/kubevirt/cpu-nfd-plugin:v0.1.1
+	KvmCpuNfdDefaultImage = "quay.io/kubevirt/cpu-nfd-plugin@sha256:20225a3d7569295fa7607e069bdc75b3235bc2218dbe52c4302ec4e2e55df8b9"
+	// quay.io/kubevirt/virt-launcher:v0.37.2
+	LibvirtDefaultImage = "quay.io/kubevirt/virt-launcher@sha256:970a078f150d14b053b69db66a9fc035182e5e7010d65b524a28f70498c158f3"
 )

--- a/internal/operands/node-labeller/resources.go
+++ b/internal/operands/node-labeller/resources.go
@@ -57,11 +57,11 @@ var configMapData = map[string]string{
 
 func getNodeLabellerImages() nodeLabellerImages {
 	return nodeLabellerImages{
-		nodeLabeller: common.EnvOrDefault(common.KubevirtNodeLabellerImageKey, kubevirtNodeLabellerDefaultImage),
-		sleeper:      common.EnvOrDefault(common.KubevirtNodeLabellerImageKey, kubevirtNodeLabellerDefaultImage),
-		kvmInfoNFD:   common.EnvOrDefault(common.KvmInfoNfdPluginImageKey, kvmInfoNfdDefaultImage),
-		cpuNFD:       common.EnvOrDefault(common.KubevirtCpuNfdPluginImageKey, kvmCpuNfdDefaultImage),
-		virtLauncher: common.EnvOrDefault(common.VirtLauncherImageKey, libvirtDefaultImage),
+		nodeLabeller: common.EnvOrDefault(common.KubevirtNodeLabellerImageKey, KubevirtNodeLabellerDefaultImage),
+		sleeper:      common.EnvOrDefault(common.KubevirtNodeLabellerImageKey, KubevirtNodeLabellerDefaultImage),
+		kvmInfoNFD:   common.EnvOrDefault(common.KvmInfoNfdPluginImageKey, KvmInfoNfdDefaultImage),
+		cpuNFD:       common.EnvOrDefault(common.KubevirtCpuNfdPluginImageKey, KvmCpuNfdDefaultImage),
+		virtLauncher: common.EnvOrDefault(common.VirtLauncherImageKey, LibvirtDefaultImage),
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
csv-generator now computes and populates proper `relatedImages` for the CSV

```release-note
The relatedImages spec field is now populated and image caching should be supported
```
