### PR TITLE
Update node-labeller to pull virt-launcher image from quay

### DIFF
--- a/internal/operands/node-labeller/defaults.go
+++ b/internal/operands/node-labeller/defaults.go
@@ -4,5 +4,5 @@ const (
 	kubevirtNodeLabellerDefaultImage = "quay.io/kubevirt/node-labeller:v0.2.0"
 	kvmInfoNfdDefaultImage           = "quay.io/kubevirt/kvm-info-nfd-plugin:v0.5.8"
 	kvmCpuNfdDefaultImage            = "quay.io/kubevirt/cpu-nfd-plugin:v0.1.1"
-	libvirtDefaultImage              = "docker.io/kubevirt/virt-launcher:v0.21.0"
+	libvirtDefaultImage              = "quay.io/kubevirt/virt-launcher:v0.37.2"
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
Update node-labeller to pull virt-launcher image from quay, and also bumped virt-launcher to the latest release

**Which issue(s) this PR fixes**:
Dockerhub's pull policy limitations prevents node-labeller from properly deploying for upstream users

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
