### PR TITLE
Remove global variables from resource objects

### DIFF
--- a/internal/operands/node-labeller/resources.go
+++ b/internal/operands/node-labeller/resources.go
@@ -33,28 +33,6 @@ type nodeLabellerImages struct {
 	virtLauncher string
 }
 
-var commonLabels = map[string]string{
-	"app": "kubevirt-node-labeller",
-}
-
-var cpuPluginConfigmap = `obsoleteCPUs:
-  - "486"
-  - "pentium"
-  - "pentium2"
-  - "pentium3"
-  - "pentiumpro"
-  - "coreduo"
-  - "n270"
-  - "core2duo"
-  - "Conroe"
-  - "athlon"
-  - "phenom"
-minCPU: "Penryn"`
-
-var configMapData = map[string]string{
-	"cpu-plugin-configmap.yaml": cpuPluginConfigmap,
-}
-
 func getNodeLabellerImages() nodeLabellerImages {
 	return nodeLabellerImages{
 		nodeLabeller: common.EnvOrDefault(common.KubevirtNodeLabellerImageKey, KubevirtNodeLabellerDefaultImage),
@@ -106,12 +84,28 @@ func newClusterRoleBinding(namespace string) *rbac.ClusterRoleBinding {
 }
 
 func newConfigMap(namespace string) *core.ConfigMap {
+	const cpuPluginConfigmap = `obsoleteCPUs:
+  - "486"
+  - "pentium"
+  - "pentium2"
+  - "pentium3"
+  - "pentiumpro"
+  - "coreduo"
+  - "n270"
+  - "core2duo"
+  - "Conroe"
+  - "athlon"
+  - "phenom"
+minCPU: "Penryn"`
+
 	return &core.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      ConfigMapName,
 			Namespace: namespace,
 		},
-		Data: configMapData,
+		Data: map[string]string{
+			"cpu-plugin-configmap.yaml": cpuPluginConfigmap,
+		},
 	}
 }
 
@@ -228,6 +222,10 @@ func newDaemonSet(namespace string) *apps.DaemonSet {
 	//Build the containers
 	containers := []core.Container{
 		*kubevirtNodeLabellerSleeperContainer(),
+	}
+
+	commonLabels := map[string]string{
+		"app": "kubevirt-node-labeller",
 	}
 	return &apps.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/operands/template-validator/resources.go
+++ b/internal/operands/template-validator/resources.go
@@ -30,8 +30,10 @@ const (
 	DeploymentName         = virtTemplateValidator
 )
 
-var commonLabels = map[string]string{
-	kubevirtIo: virtTemplateValidator,
+func commonLabels() map[string]string {
+	return map[string]string{
+		kubevirtIo: virtTemplateValidator,
+	}
 }
 
 func getTemplateValidatorImage() string {
@@ -60,7 +62,7 @@ func newServiceAccount(namespace string) *core.ServiceAccount {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      ServiceAccountName,
 			Namespace: namespace,
-			Labels:    commonLabels,
+			Labels:    commonLabels(),
 		},
 	}
 }
@@ -70,7 +72,7 @@ func newClusterRoleBinding(namespace string) *rbac.ClusterRoleBinding {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      ClusterRoleBindingName,
 			Namespace: "",
-			Labels:    commonLabels,
+			Labels:    commonLabels(),
 		},
 		RoleRef: rbac.RoleRef{
 			Kind:     "ClusterRole",
@@ -90,7 +92,7 @@ func newService(namespace string) *core.Service {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      ServiceName,
 			Namespace: namespace,
-			Labels:    commonLabels,
+			Labels:    commonLabels(),
 			Annotations: map[string]string{
 				"service.beta.openshift.io/serving-cert-secret-name": secretName,
 			},
@@ -101,9 +103,7 @@ func newService(namespace string) *core.Service {
 				Port:       443,
 				TargetPort: intstr.FromInt(containerPort),
 			}},
-			Selector: map[string]string{
-				kubevirtIo: virtTemplateValidator,
-			},
+			Selector: commonLabels(),
 		},
 	}
 }
@@ -124,14 +124,12 @@ func newDeployment(namespace string, replicas int32, image string) *apps.Deploym
 		Spec: apps.DeploymentSpec{
 			Replicas: &replicas,
 			Selector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{
-					kubevirtIo: virtTemplateValidator,
-				},
+				MatchLabels: commonLabels(),
 			},
 			Template: core.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:   virtTemplateValidator,
-					Labels: commonLabels,
+					Labels: commonLabels(),
 				},
 				Spec: core.PodSpec{
 					ServiceAccountName: ServiceAccountName,


### PR DESCRIPTION
**What this PR does / why we need it**:
Created resources could be modified during reconciliation, which would modify global instances of objects.

**Release note**:
```release-note
NONE
```
