### PR TITLE
Create a builder for reconcile methods

### DIFF
--- a/internal/common/resource_test.go
+++ b/internal/common/resource_test.go
@@ -98,12 +98,13 @@ var _ = Describe("Create or update resource", func() {
 	})
 
 	It("should set owner annotations", func() {
-		_, err := CreateOrUpdateClusterResource(&request,
-			newTestResource(""),
-			func(expected, found controllerutil.Object) {
+		_, err := CreateOrUpdate(&request).
+			ClusterResource(newTestResource("")).
+			UpdateFunc(func(expected, found controllerutil.Object) {
 				found.(*v1.Service).Spec = expected.(*v1.Service).Spec
-			},
-		)
+			}).
+			Reconcile()
+
 		Expect(err).ToNot(HaveOccurred())
 
 		key, err := client.ObjectKeyFromObject(newTestResource(""))
@@ -161,12 +162,12 @@ var _ = Describe("Create or update resource", func() {
 })
 
 func createOrUpdateTestResource(request *Request) (ResourceStatus, error) {
-	return CreateOrUpdateResource(request,
-		newTestResource(namespace),
-		func(expected, found controllerutil.Object) {
+	return CreateOrUpdate(request).
+		NamespacedResource(newTestResource(namespace)).
+		UpdateFunc(func(expected, found controllerutil.Object) {
 			found.(*v1.Service).Spec = expected.(*v1.Service).Spec
-		},
-	)
+		}).
+		Reconcile()
 }
 
 func newTestResource(namespace string) *v1.Service {

--- a/internal/operands/metrics/reconcile.go
+++ b/internal/operands/metrics/reconcile.go
@@ -52,9 +52,11 @@ const (
 )
 
 func reconcilePrometheusRule(request *common.Request) (common.ResourceStatus, error) {
-	return common.CreateOrUpdateResource(request,
-		common.AddAppLabels(request.Instance, operandName, operandComponent, newPrometheusRule(request.Namespace)),
-		func(newRes, foundRes controllerutil.Object) {
+	return common.CreateOrUpdate(request).
+		NamespacedResource(newPrometheusRule(request.Namespace)).
+		WithAppLabels(operandName, operandComponent).
+		UpdateFunc(func(newRes, foundRes controllerutil.Object) {
 			foundRes.(*promv1.PrometheusRule).Spec = newRes.(*promv1.PrometheusRule).Spec
-		})
+		}).
+		Reconcile()
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
There are four `CreateAndUpdate` methods with various parameters. This patch creates a builder to use instead of these functions.

**Release note**:
```release-note
NONE
```
