### PR TITLE
Extract label strings and simplify API calls with label selector

### DIFF
--- a/internal/operands/common-templates/constants.go
+++ b/internal/operands/common-templates/constants.go
@@ -1,0 +1,13 @@
+package common_templates
+
+const (
+	GoldenImagesNSname = "kubevirt-os-images"
+	BundleDir          = "data/common-templates-bundle/"
+	Version            = "v0.13.1"
+
+	TemplateVersionLabel        = "template.kubevirt.io/version"
+	TemplateTypeLabel           = "template.kubevirt.io/type"
+	TemplateOsLabelPrefix       = "os.template.kubevirt.io/"
+	TemplateFlavorLabelPrefix   = "flavor.template.kubevirt.io/"
+	TemplateWorkloadLabelPrefix = "workload.template.kubevirt.io/"
+)

--- a/internal/operands/common-templates/reconcile.go
+++ b/internal/operands/common-templates/reconcile.go
@@ -157,15 +157,15 @@ func reconcileEditRole(request *common.Request) (common.ResourceStatus, error) {
 func reconcileOlderTemplates(request *common.Request) ([]common.ReconcileFunc, error) {
 	// Append functions to take ownership of previously deployed templates during an upgrade
 	templatesSelector := func() labels.Selector {
-		baseRequirement, err := labels.NewRequirement("template.kubevirt.io/type", selection.Equals, []string{"base"})
+		baseRequirement, err := labels.NewRequirement(TemplateTypeLabel, selection.Equals, []string{"base"})
 		if err != nil {
-			panic("Failed creating label selector for 'template.kubevirt.io/type=base")
+			panic(fmt.Sprintf("Failed creating label selector for '%s=%s'", TemplateTypeLabel, "base"))
 		}
 
 		// Only fetching older templates  to prevent duplication of API calls
-		versionRequirement, err := labels.NewRequirement("template.kubevirt.io/version", selection.NotEquals, []string{Version})
+		versionRequirement, err := labels.NewRequirement(TemplateVersionLabel, selection.NotEquals, []string{Version})
 		if err != nil {
-			panic("Failed creating label selector for 'template.kubevirt.io/version")
+			panic(fmt.Sprintf("Failed creating label selector for '%s!=%s'", TemplateVersionLabel, Version))
 		}
 
 		return labels.NewSelector().Add(*baseRequirement, *versionRequirement)
@@ -192,9 +192,9 @@ func reconcileOlderTemplates(request *common.Request) ([]common.ReconcileFunc, e
 				UpdateFunc(func(_, foundRes controllerutil.Object) {
 					foundTemplate := foundRes.(*templatev1.Template)
 					for key := range foundTemplate.Labels {
-						if strings.HasPrefix(key, "os.template.kubevirt.io/") ||
-							strings.HasPrefix(key, "flavor.template.kubevirt.io/") ||
-							strings.HasPrefix(key, "workload.template.kubevirt.io/") {
+						if strings.HasPrefix(key, TemplateOsLabelPrefix) ||
+							strings.HasPrefix(key, TemplateFlavorLabelPrefix) ||
+							strings.HasPrefix(key, TemplateWorkloadLabelPrefix) {
 							delete(foundTemplate.Labels, key)
 						}
 					}

--- a/internal/operands/common-templates/reconcile_test.go
+++ b/internal/operands/common-templates/reconcile_test.go
@@ -2,8 +2,6 @@ package common_templates
 
 import (
 	"context"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/selection"
 	"strings"
 	"testing"
 
@@ -204,13 +202,8 @@ var _ = Describe("Common-Templates operand", func() {
 			Expect(err).ToNot(HaveOccurred(), "reconciliation in order to update old template failed")
 
 			var latestTemplates templatev1.TemplateList
-			versionRequirement, err := labels.NewRequirement(TemplateVersionLabel, selection.Equals, []string{Version})
+			err = request.Client.List(request.Context, &latestTemplates, client.MatchingLabels{TemplateVersionLabel: Version})
 			Expect(err).ToNot(HaveOccurred())
-			labelsSelector := labels.NewSelector().Add(*versionRequirement)
-			opts := client.ListOptions{
-				LabelSelector: labelsSelector,
-			}
-			Expect(request.Client.List(request.Context, &latestTemplates, &opts)).ToNot(HaveOccurred())
 			for _, template := range latestTemplates.Items {
 				for _, label := range template.Labels {
 					if strings.HasPrefix(label, TemplateOsLabelPrefix) {

--- a/internal/operands/common-templates/reconcile_test.go
+++ b/internal/operands/common-templates/reconcile_test.go
@@ -32,6 +32,10 @@ var (
 const (
 	namespace = "kubevirt"
 	name      = "test-ssp"
+
+	testOsLabel       = TemplateOsLabelPrefix + "some-os"
+	testFlavorLabel   = TemplateFlavorLabelPrefix + "test"
+	testWorkflowLabel = TemplateWorkloadLabelPrefix + "server"
 )
 
 func TestTemplates(t *testing.T) {
@@ -135,11 +139,11 @@ var _ = Describe("Common-Templates operand", func() {
 					Name:      "test-tpl",
 					Namespace: request.Instance.Spec.CommonTemplates.Namespace,
 					Labels: map[string]string{
-						"template.kubevirt.io/version":         "not-latest",
-						"template.kubevirt.io/type":            "base",
-						"os.template.kubevirt.io/some-os":      "true",
-						"flavor.template.kubevirt.io/test":     "true",
-						"workload.template.kubevirt.io/server": "true",
+						TemplateVersionLabel: "not-latest",
+						TemplateTypeLabel:    "base",
+						testOsLabel:          "true",
+						testFlavorLabel:      "true",
+						testWorkflowLabel:    "true",
 					},
 					Annotations: map[string]string{},
 					OwnerReferences: []metav1.OwnerReference{{
@@ -189,18 +193,18 @@ var _ = Describe("Common-Templates operand", func() {
 			err = request.Client.Get(request.Context, key, updatedTpl)
 			Expect(err).ToNot(HaveOccurred(), "failed fetching updated template")
 
-			Expect(updatedTpl.Labels["os.template.kubevirt.io/some-os"]).To(Equal(""), "os.template.kubevirt.io should be empty")
-			Expect(updatedTpl.Labels["flavor.template.kubevirt.io/test"]).To(Equal(""), "flavor.template.kubevirt.io should be empty")
-			Expect(updatedTpl.Labels["workload.template.kubevirt.io/server"]).To(Equal(""), "workload.template.kubevirt.io should be empty")
-			Expect(updatedTpl.Labels["template.kubevirt.io/type"]).To(Equal("base"), "template.kubevirt.io/type should equal base")
-			Expect(updatedTpl.Labels["template.kubevirt.io/version"]).To(Equal("not-latest"), "template.kubevirt.io/version should equal not-latest")
+			Expect(updatedTpl.Labels[testOsLabel]).To(Equal(""), TemplateOsLabelPrefix+" should be empty")
+			Expect(updatedTpl.Labels[testFlavorLabel]).To(Equal(""), TemplateFlavorLabelPrefix+" should be empty")
+			Expect(updatedTpl.Labels[testWorkflowLabel]).To(Equal(""), TemplateWorkloadLabelPrefix+" should be empty")
+			Expect(updatedTpl.Labels[TemplateTypeLabel]).To(Equal("base"), TemplateTypeLabel+" should equal base")
+			Expect(updatedTpl.Labels[TemplateVersionLabel]).To(Equal("not-latest"), TemplateVersionLabel+" should equal not-latest")
 		})
 		It("should not remove labels from latest templates", func() {
 			_, err := operand.Reconcile(&request)
 			Expect(err).ToNot(HaveOccurred(), "reconciliation in order to update old template failed")
 
 			var latestTemplates templatev1.TemplateList
-			versionRequirement, err := labels.NewRequirement("template.kubevirt.io/version", selection.Equals, []string{Version})
+			versionRequirement, err := labels.NewRequirement(TemplateVersionLabel, selection.Equals, []string{Version})
 			Expect(err).ToNot(HaveOccurred())
 			labelsSelector := labels.NewSelector().Add(*versionRequirement)
 			opts := client.ListOptions{
@@ -209,17 +213,17 @@ var _ = Describe("Common-Templates operand", func() {
 			Expect(request.Client.List(request.Context, &latestTemplates, &opts)).ToNot(HaveOccurred())
 			for _, template := range latestTemplates.Items {
 				for _, label := range template.Labels {
-					if strings.HasPrefix(label, "os.template.kubevirt.io/") {
-						Expect(template.Labels[label]).To(Equal("true"), "os.template.kubevirt.io should not be empty")
+					if strings.HasPrefix(label, TemplateOsLabelPrefix) {
+						Expect(template.Labels[label]).To(Equal("true"), TemplateOsLabelPrefix+" should not be empty")
 					}
-					if strings.HasPrefix(label, "flavor.template.kubevirt.io/") {
-						Expect(template.Labels[label]).To(Equal("true"), "flavor.template.kubevirt.io should not be empty")
+					if strings.HasPrefix(label, TemplateFlavorLabelPrefix) {
+						Expect(template.Labels[label]).To(Equal("true"), TemplateFlavorLabelPrefix+" should not be empty")
 					}
-					if strings.HasPrefix(label, "workload.template.kubevirt.io/") {
-						Expect(template.Labels[label]).To(Equal("true"), "workload.template.kubevirt.io should not be empty")
+					if strings.HasPrefix(label, TemplateWorkloadLabelPrefix) {
+						Expect(template.Labels[label]).To(Equal("true"), TemplateWorkloadLabelPrefix+" should not be empty")
 					}
-					Expect(template.Labels["template.kubevirt.io/type"]).To(Equal("base"), "template.kubevirt.io/type should equal base")
-					Expect(template.Labels["template.kubevirt.io/version"]).To(Equal(Version), "template.kubevirt.io/version should equal "+Version)
+					Expect(template.Labels[TemplateTypeLabel]).To(Equal("base"), TemplateTypeLabel+" should equal base")
+					Expect(template.Labels[TemplateVersionLabel]).To(Equal(Version), TemplateVersionLabel+" should equal "+Version)
 				}
 			}
 		})

--- a/internal/operands/common-templates/resource.go
+++ b/internal/operands/common-templates/resource.go
@@ -13,11 +13,8 @@ import (
 )
 
 const (
-	GoldenImagesNSname  = "kubevirt-os-images"
-	BundleDir           = "data/common-templates-bundle/"
 	ViewRoleName        = "os-images.kubevirt.io:view"
 	EditClusterRoleName = "os-images.kubevirt.io:edit"
-	Version             = "v0.13.1"
 )
 
 // ReadTemplates from the combined yaml file and return the list of its templates


### PR DESCRIPTION
**What this PR does / why we need it**:
- Extracts common label strings to constants.
- Simplifies API calls that use label selector.

Fixes issues found by SonarCloud.

**Release note**:
```release-note
None
```
