### PR TITLE
Add remark on kustomize version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,7 +148,7 @@ endif
 
 # Generate bundle manifests and metadata, then validate generated files.
 .PHONY: bundle
-bundle: operator-sdk manifests csv-generator
+bundle: kustomize operator-sdk manifests csv-generator
 	./operator-sdk generate kustomize manifests -q
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
 	$(KUSTOMIZE) build config/manifests | ./operator-sdk generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)

--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ An example is in [config/samples/ssp_v1beta1_ssp.yaml](config/samples/ssp_v1beta
 
 ## Building
 
+The Make will try to install kustomize, however if it is already installed it will not reinstall it.
+In case of an error, make sure you are using at least v3 of kustomize, available here: https://kustomize.io/
+
 To build the container image run:
 ```shell
 make container-build


### PR DESCRIPTION
Currently the dnf installs v2 of kustomize by default which fails the build.
Added a note about installing a newer version.

Signed-off-by: borod108 <bodnopoz@redhat.com>

```release-note
NONE
```