### PR TITLE
Move common-templates version to separate file

### DIFF
--- a/internal/operands/common-templates/constants.go
+++ b/internal/operands/common-templates/constants.go
@@ -3,7 +3,6 @@ package common_templates
 const (
 	GoldenImagesNSname = "kubevirt-os-images"
 	BundleDir          = "data/common-templates-bundle/"
-	Version            = "v0.13.1"
 
 	TemplateVersionLabel        = "template.kubevirt.io/version"
 	TemplateTypeLabel           = "template.kubevirt.io/type"

--- a/internal/operands/common-templates/version.go
+++ b/internal/operands/common-templates/version.go
@@ -1,0 +1,12 @@
+// Code modified by common-templates release script.
+// When editing this file, make sure that the release
+// script does not modify it in unexpected ways.
+//
+// Release script:
+// https://github.com/kubevirt/common-templates/blob/master/.github/workflows/release.yaml
+
+package common_templates
+
+const (
+	Version = "v0.13.1"
+)


### PR DESCRIPTION
**What this PR does / why we need it**:
The `Version` is changed by common-templates release script. Moving it to separate file is safer.

**Release note**:
```release-note
None
```
