### PR TITLE
add deprecated label to old templates

### DIFF
--- a/internal/operands/common-templates/constants.go
+++ b/internal/operands/common-templates/constants.go
@@ -9,4 +9,5 @@ const (
 	TemplateOsLabelPrefix       = "os.template.kubevirt.io/"
 	TemplateFlavorLabelPrefix   = "flavor.template.kubevirt.io/"
 	TemplateWorkloadLabelPrefix = "workload.template.kubevirt.io/"
+	TemplateDeprecatedLabel     = "template.kubevirt.io/deprecated"
 )

--- a/internal/operands/common-templates/reconcile.go
+++ b/internal/operands/common-templates/reconcile.go
@@ -185,6 +185,7 @@ func reconcileOlderTemplates(request *common.Request) ([]common.ReconcileFunc, e
 	funcs := make([]common.ReconcileFunc, 0, len(existingTemplates.Items))
 	for i := range existingTemplates.Items {
 		template := &existingTemplates.Items[i]
+		template.Labels[TemplateDeprecatedLabel] = "true"
 		funcs = append(funcs, func(*common.Request) (common.ResourceStatus, error) {
 			return common.CreateOrUpdate(request).
 				ClusterResource(template).

--- a/internal/operands/common-templates/reconcile_test.go
+++ b/internal/operands/common-templates/reconcile_test.go
@@ -196,6 +196,7 @@ var _ = Describe("Common-Templates operand", func() {
 			Expect(updatedTpl.Labels[testWorkflowLabel]).To(Equal(""), TemplateWorkloadLabelPrefix+" should be empty")
 			Expect(updatedTpl.Labels[TemplateTypeLabel]).To(Equal("base"), TemplateTypeLabel+" should equal base")
 			Expect(updatedTpl.Labels[TemplateVersionLabel]).To(Equal("not-latest"), TemplateVersionLabel+" should equal not-latest")
+			Expect(updatedTpl.Labels[TemplateDeprecatedLabel]).To(Equal("true"), TemplateDeprecatedLabel+" should not be empty")
 		})
 		It("should not remove labels from latest templates", func() {
 			_, err := operand.Reconcile(&request)


### PR DESCRIPTION
**What this PR does / why we need it**:
During reconcilation ssp operator now adds deprecated label to old
templates

**Which issue(s) this PR fixes**:
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1925019

**Release note**:
```
Operator now adds `template.kubevirt.io/deprecated` label to old templates
```

Signed-off-by: Karel Simon <ksimon@redhat.com>