### PR TITLE
Update webhook version to admissionregistration.k8s.io/v1

### DIFF
--- a/api/v1beta1/ssp_webhook.go
+++ b/api/v1beta1/ssp_webhook.go
@@ -39,7 +39,7 @@ func (r *SSP) SetupWebhookWithManager(mgr ctrl.Manager) error {
 		Complete()
 }
 
-// +kubebuilder:webhook:verbs=create;update,path=/validate-ssp-kubevirt-io-v1beta1-ssp,mutating=false,failurePolicy=fail,groups=ssp.kubevirt.io,resources=ssps,versions=v1beta1,name=vssp.kb.io,webhookVersions=v1beta1,sideEffects=None
+// +kubebuilder:webhook:verbs=create;update,path=/validate-ssp-kubevirt-io-v1beta1-ssp,mutating=false,failurePolicy=fail,groups=ssp.kubevirt.io,resources=ssps,versions=v1beta1,name=validation.ssp.kubevirt.io,webhookVersions=v1,sideEffects=None
 
 var _ webhook.Validator = &SSP{}
 

--- a/config/default/webhook_ocp_cainjection_patch.yaml
+++ b/config/default/webhook_ocp_cainjection_patch.yaml
@@ -1,5 +1,5 @@
 # This patch adds an annotation to the validation webhook config to tell OpenShift to inject a CA
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validating-webhook-configuration

--- a/config/default/webhookcainjection_patch.yaml
+++ b/config/default/webhookcainjection_patch.yaml
@@ -1,13 +1,13 @@
 # This patch add annotation to admission webhook config and
 # the variables $(CERTIFICATE_NAMESPACE) and $(CERTIFICATE_NAME) will be substituted by kustomize.
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: mutating-webhook-configuration
   annotations:
     cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validating-webhook-configuration

--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -2,7 +2,7 @@
 namePrefix: "ssp-"
 
 resources:
-- manifests.v1beta1.yaml
+- manifests.yaml
 - service.yaml
 
 configurations:

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -1,19 +1,22 @@
 
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   creationTimestamp: null
   name: validating-webhook-configuration
 webhooks:
-- clientConfig:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
     caBundle: Cg==
     service:
       name: webhook-service
       namespace: system
       path: /validate-ssp-kubevirt-io-v1beta1-ssp
   failurePolicy: Fail
-  name: vssp.kb.io
+  name: validation.ssp.kubevirt.io
   rules:
   - apiGroups:
     - ssp.kubevirt.io

--- a/data/olm-catalog/ssp-operator.clusterserviceversion.yaml
+++ b/data/olm-catalog/ssp-operator.clusterserviceversion.yaml
@@ -452,11 +452,12 @@ spec:
   version: 0.1.3
   webhookdefinitions:
   - admissionReviewVersions:
+    - v1
     - v1beta1
     containerPort: 9443
     deploymentName: ssp-operator
     failurePolicy: Fail
-    generateName: vssp.kb.io
+    generateName: validation.ssp.kubevirt.io
     rules:
     - apiGroups:
       - ssp.kubevirt.io


### PR DESCRIPTION
**What this PR does / why we need it**:
Update webhook version to `admissionregistration.k8s.io/v1`. The `v1beta1` version will be removed in kubernetes 1.22

**Release note**:
```release-note
Updated webhook version to admissionregistration.k8s.io/v1`
```
