### PR TITLE
(v0.1) Template validator webhook rule for v1 VMs

### DIFF
--- a/internal/operands/template-validator/resources.go
+++ b/internal/operands/template-validator/resources.go
@@ -199,6 +199,15 @@ func newValidatingWebhook(namespace string) *admission.ValidatingWebhookConfigur
 				},
 				Rule: admission.Rule{
 					APIGroups:   []string{"kubevirt.io"},
+					APIVersions: []string{"v1"},
+					Resources:   []string{"virtualmachines"},
+				},
+			}, {
+				Operations: []admission.OperationType{
+					admission.Create, admission.Update,
+				},
+				Rule: admission.Rule{
+					APIGroups:   []string{"kubevirt.io"},
 					APIVersions: []string{"v1alpha3"},
 					Resources:   []string{"virtualmachines"},
 				},


### PR DESCRIPTION
**What this PR does / why we need it**:
Added rule to `ValidatingWebhookConfiguration` of template validator to be called also for `v1` version of `VirtualMachine`.

**Which issue(s) this PR fixes**:
https://bugzilla.redhat.com/show_bug.cgi?id=1936926

**Release note**:
```release-note
Set template validator webhook to receive v1 versions of VirtualMachines.
```
