### PR TITLE
Add a dry-run to verify placement fields

### DIFF
--- a/api/v1beta1/ssp_webhook.go
+++ b/api/v1beta1/ssp_webhook.go
@@ -20,8 +20,13 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/pkg/errors"
+	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/pointer"
+	"kubevirt.io/controller-lifecycle-operator-sdk/pkg/sdk/api"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -65,6 +70,10 @@ func (r *SSP) ValidateCreate() error {
 		return fmt.Errorf("creation failed, the configured namespace for common templates does not exist: %v", namespaceName)
 	}
 
+	if err = validatePlacement(r); err != nil {
+		return errors.Wrap(err, "placement api validation error")
+	}
+
 	return nil
 }
 
@@ -79,6 +88,10 @@ func (r *SSP) ValidateUpdate(old runtime.Object) error {
 			r.Spec.CommonTemplates.Namespace)
 	}
 
+	if err := validatePlacement(r); err != nil {
+		return errors.Wrap(err, "placement api validation error")
+	}
+
 	return nil
 }
 
@@ -90,4 +103,60 @@ func (r *SSP) ValidateDelete() error {
 // Forces the value of clt, to be used in unit tests
 func setClientForWebhook(c client.Client) {
 	clt = c
+}
+
+func validatePlacement(ssp *SSP) error {
+	return validateOperandPlacement(ssp.Spec.TemplateValidator.Placement)
+}
+
+func validateOperandPlacement(placement *api.NodePlacement) error {
+	if placement == nil {
+		return nil
+	}
+
+	const (
+		dplName          = "ssp-webhook-placement-verification-deployment"
+		namespace        = "default"
+		webhookTestLabel = "webhook.ssp.kubevirt.io/placement-verification-pod"
+		podName          = "ssp-webhook-placement-verification-pod"
+		naImage          = "ssp.kubevirt.io/not-available"
+	)
+
+	// Does a dry-run on a deployment creation to verify that placement fields are correct
+	deployment := &apps.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      dplName,
+			Namespace: namespace,
+		},
+		Spec: apps.DeploymentSpec{
+			Replicas: pointer.Int32Ptr(1),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					webhookTestLabel: "",
+				},
+			},
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: podName,
+					Labels: map[string]string{
+						webhookTestLabel: "",
+					},
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name:  podName,
+							Image: naImage,
+						},
+					},
+					// Inject placement fields here
+					NodeSelector: placement.NodeSelector,
+					Affinity:     placement.Affinity,
+					Tolerations:  placement.Tolerations,
+				},
+			},
+		},
+	}
+
+	return clt.Create(context.TODO(), deployment, &client.CreateOptions{DryRun: []string{metav1.DryRunAll}})
 }

--- a/tests/webhook_test.go
+++ b/tests/webhook_test.go
@@ -5,11 +5,59 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"kubevirt.io/controller-lifecycle-operator-sdk/pkg/sdk/api"
 	ssp "kubevirt.io/ssp-operator/api/v1beta1"
+)
+
+// Placement API tests variables
+var (
+	placementAPIValidationTestKey         = "testKey"
+	placementAPIValidationValidOperator   = corev1.NodeSelectorOpIn
+	placementAPIValidationInvalidOperator = corev1.NodeSelectorOperator("Invalid")
+
+	placementAPIValidationValidPlacement = api.NodePlacement{
+		Affinity: &corev1.Affinity{
+			NodeAffinity: &corev1.NodeAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+					NodeSelectorTerms: []corev1.NodeSelectorTerm{
+						{
+							MatchExpressions: []corev1.NodeSelectorRequirement{
+								{
+									Key:      placementAPIValidationTestKey,
+									Operator: placementAPIValidationValidOperator,
+									Values:   []string{"val1", "val2"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	placementAPIValidationInvalidPlacement = api.NodePlacement{
+		Affinity: &corev1.Affinity{
+			NodeAffinity: &corev1.NodeAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+					NodeSelectorTerms: []corev1.NodeSelectorTerm{
+						{
+							MatchExpressions: []corev1.NodeSelectorRequirement{
+								{
+									Key:      placementAPIValidationTestKey,
+									Operator: placementAPIValidationInvalidOperator,
+									Values:   []string{"val1", "val2"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
 )
 
 var _ = Describe("Validation webhook", func() {
@@ -39,17 +87,14 @@ var _ = Describe("Validation webhook", func() {
 		})
 
 		Context("removed existing SSP CR", func() {
+			var (
+				newSsp *ssp.SSP
+			)
+
 			BeforeEach(func() {
 				strategy.SkipSspUpdateTestsIfNeeded()
-			})
 
-			AfterEach(func() {
-				strategy.RevertToOriginalSspCr()
-			})
-
-			It("should fail to create SSP CR with invalid commonTemplates.namespace", func() {
 				foundSsp := getSsp()
-
 				Expect(apiClient.Delete(ctx, foundSsp)).ToNot(HaveOccurred())
 				waitForDeletion(client.ObjectKey{Name: foundSsp.GetName(), Namespace: foundSsp.GetNamespace()}, &ssp.SSP{})
 
@@ -57,24 +102,55 @@ var _ = Describe("Validation webhook", func() {
 					Name:      foundSsp.GetName(),
 					Namespace: foundSsp.GetNamespace(),
 				}
-				foundSsp.Spec.CommonTemplates.Namespace = "nonexisting-templates-namespace"
 
-				err := apiClient.Create(ctx, foundSsp)
+				newSsp = foundSsp
+			})
+
+			AfterEach(func() {
+				strategy.RevertToOriginalSspCr()
+			})
+
+			It("should fail to create SSP CR with invalid commonTemplates.namespace", func() {
+				newSsp.Spec.CommonTemplates.Namespace = "nonexisting-templates-namespace"
+
+				err := apiClient.Create(ctx, newSsp)
 				if err == nil {
 					Fail("SSP CR with invalid commonTemplates.namespace created.")
 					return
 				}
 				Expect(err.Error()).To(ContainSubstring(fmt.Sprintf(
 					"creation failed, the configured namespace for common templates does not exist: %v",
-					foundSsp.Spec.CommonTemplates.Namespace,
+					newSsp.Spec.CommonTemplates.Namespace,
 				)))
+			})
+
+			Context("Placement API validation", func() {
+				It("should succeed with valid template-validator placement fields", func() {
+					newSsp.Spec.TemplateValidator.Placement = &placementAPIValidationValidPlacement
+
+					Expect(apiClient.Create(ctx, newSsp)).ToNot(HaveOccurred(),
+						"failed to create SSP CR with valid template-validator placement fields")
+				})
+
+				It("should fail with invalid template-validator placement fields", func() {
+					newSsp.Spec.TemplateValidator.Placement = &placementAPIValidationInvalidPlacement
+
+					Expect(apiClient.Create(ctx, newSsp)).To(HaveOccurred(),
+						"created SSP CR with invalid template-validator placement fields")
+				})
 			})
 		})
 	})
 
 	Context("update", func() {
+		var (
+			foundSsp *ssp.SSP
+		)
+
 		BeforeEach(func() {
 			strategy.SkipSspUpdateTestsIfNeeded()
+
+			foundSsp = getSsp()
 		})
 
 		AfterEach(func() {
@@ -82,12 +158,25 @@ var _ = Describe("Validation webhook", func() {
 		})
 
 		It("should fail to update commonTemplates.namespace", func() {
-			foundSsp := getSsp()
 			originalNs := foundSsp.Spec.CommonTemplates.Namespace
 			foundSsp.Spec.CommonTemplates.Namespace = originalNs + "-updated"
 			err := apiClient.Update(ctx, foundSsp)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("commonTemplates.namespace cannot be changed."))
+		})
+
+		Context("Placement API validation", func() {
+			It("should succeed with valid template-validator placement fields", func() {
+				foundSsp.Spec.TemplateValidator.Placement = &placementAPIValidationValidPlacement
+				Expect(apiClient.Update(ctx, foundSsp)).ToNot(HaveOccurred(),
+					"failed to update SSP CR with valid template-validator placement fields")
+			})
+
+			It("should fail with invalid template-validator placement fields", func() {
+				foundSsp.Spec.TemplateValidator.Placement = &placementAPIValidationInvalidPlacement
+				Expect(apiClient.Update(ctx, foundSsp)).To(HaveOccurred(),
+					"SSP CR updated with invalid template-validator placement fields")
+			})
 		})
 	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
**What this PR does / why we need it**:
This PR adds a deployment creation dry-run to the SSP webhook to reject any invalid placement fields.

**Which issue(s) this PR fixes**:
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1938241

**Special notes for your reviewer**:
- Still missing tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
