### PR TITLE
Remove the relatedImages field from the CRD

### DIFF
--- a/hack/csv-generator.go
+++ b/hack/csv-generator.go
@@ -146,7 +146,7 @@ func runGenerator() error {
 				return err
 			}
 
-			err = marshallObject(crd, relatedImages, os.Stdout)
+			err = marshallObject(crd, nil, os.Stdout)
 			if err != nil {
 				return err
 			}
@@ -327,7 +327,9 @@ func marshallObject(obj interface{}, relatedImages []interface{}, writer io.Writ
 		unstructured.SetNestedSlice(r.Object, deployments, "spec", "install", "spec", "deployments")
 	}
 
-	unstructured.SetNestedSlice(r.Object, relatedImages, "spec", "relatedImages")
+	if len(relatedImages) > 0 {
+		unstructured.SetNestedSlice(r.Object, relatedImages, "spec", "relatedImages")
+	}
 
 	jsonBytes, err = json.Marshal(r.Object)
 	if err != nil {


### PR DESCRIPTION
CRD should not contain the `relatedImages` field.

Fixes #143

Remove the `relatedImages` field from the CRD.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

```release-note
NONE
```
