### PR TITLE
Update API version in unused config file

### DIFF
--- a/config/crd/patches/webhook_in_ssps.yaml
+++ b/config/crd/patches/webhook_in_ssps.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: ssps.ssp.kubevirt.io


### PR DESCRIPTION
**What this PR does / why we need it**:
The config was generated by operator SDK and is currently not used, but it may be used in the future.
Updating its API in case we use it.

**Release note**:
```release-note
None
```
