### PR TITLE
Update cnv:vmi_status_running:count labels

### DIFF
--- a/internal/operands/metrics/resources.go
+++ b/internal/operands/metrics/resources.go
@@ -23,7 +23,7 @@ func newPrometheusRule(namespace string) *promv1.PrometheusRule {
 			Groups: []promv1.RuleGroup{{
 				Name: "cnv.rules",
 				Rules: []promv1.Rule{{
-					Expr:   intstr.FromString("sum(kubevirt_vmi_phase_count{phase=\"running\"}) by (node)"),
+					Expr:   intstr.FromString("sum(kubevirt_vmi_phase_count{phase=\"running\"}) by (node,os,workload,flavor)"),
 					Record: "cnv:vmi_status_running:count",
 				}},
 			}},


### PR DESCRIPTION
Signed-off-by: Shirly Radco <sradco@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Add os, workload and flavor labels to
cnv:vmi_status_running:count metric.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Check that the cnv:vmi_status_running:count metric, for vms that were created by a template (templates should include the os, flavor and workload annotations), is aggregated by node, os, workload and flavor labels.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
