### PR TITLE
Add build process to validator Dockerfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ build-template-validator:
 	./hack/build-template-validator.sh ${VERSION}
 
 build-template-validator-container: build-template-validator
-	docker build -t ${VALIDATOR_IMG} ./internal/template-validator/
+	docker build -t ${VALIDATOR_IMG} . -f validator.Dockerfile
 
 push-template-validator-container: build-template-validator-container
 	docker push ${VALIDATOR_IMG}

--- a/internal/template-validator/Dockerfile
+++ b/internal/template-validator/Dockerfile
@@ -1,8 +1,0 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal
-RUN mkdir -p /etc/webhook/certs
-
-WORKDIR /
-COPY ./_out/kubevirt-template-validator /usr/sbin/kubevirt-template-validator
-USER 1000
-
-ENTRYPOINT [ "/usr/sbin/kubevirt-template-validator" ]

--- a/validator.Dockerfile
+++ b/validator.Dockerfile
@@ -1,0 +1,30 @@
+FROM golang:1.15 as builder
+
+ARG VERSION=latest
+ARG COMPONENT="kubevirt-template-validator"
+ARG BRANCH=master
+ARG REVISION=master
+
+WORKDIR /workspace
+
+# Copy the Go Modules manifests and vendor directory
+COPY go.mod go.mod
+COPY go.sum go.sum
+COPY vendor/ vendor/
+
+# Copy the go source
+COPY internal/ internal/
+
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -ldflags="-X 'kubevirt.io/ssp-operator/internal/template-validator/version.COMPONENT=$COMPONENT'\
+-X 'kubevirt.io/ssp-operator/internal/template-validator/version.VERSION=$VERSION'\
+-X 'kubevirt.io/ssp-operator/internal/template-validator/version.BRANCH=$BRANCH'\
+-X 'kubevirt.io/ssp-operator/internal/template-validator/version.REVISION=$REVISION'" -o kubevirt-template-validator internal/template-validator/main.go
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal
+RUN mkdir -p /etc/webhook/certs
+
+WORKDIR /
+COPY --from=builder /workspace/kubevirt-template-validator /usr/sbin/kubevirt-template-validator
+USER 1000
+
+ENTRYPOINT [ "/usr/sbin/kubevirt-template-validator" ]


### PR DESCRIPTION
**What this PR does / why we need it**:
This enables openshift CI to use the new Dockerfile for template-validator and build the template-validator container from the latest source code

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes the CI errors for https://github.com/openshift/release/pull/18098 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
