### PR TITLE
Changes to inject template-validator image to ssp-operator build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ csv-generator
 bundle/*
 cover.out
 bundle.Dockerfile
+config/manager/manager.yaml

--- a/config/manager/manager.template.yaml
+++ b/config/manager/manager.template.yaml
@@ -30,6 +30,7 @@ spec:
         env:
           - name: KVM_INFO_IMAGE
           - name: VALIDATOR_IMAGE
+            value: "$VALIDATOR_IMG"
           - name: VIRT_LAUNCHER_IMAGE
           - name: NODE_LABELLER_IMAGE
           - name: CPU_PLUGIN_IMAGE

--- a/internal/operands/template-validator/reconcile.go
+++ b/internal/operands/template-validator/reconcile.go
@@ -2,7 +2,6 @@ package template_validator
 
 import (
 	"fmt"
-
 	admission "k8s.io/api/admissionregistration/v1"
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -137,6 +136,9 @@ func reconcileService(request *common.Request) (common.ResourceStatus, error) {
 func reconcileDeployment(request *common.Request) (common.ResourceStatus, error) {
 	validatorSpec := request.Instance.Spec.TemplateValidator
 	image := getTemplateValidatorImage()
+	if image == "" {
+		panic("Cannot reconcile without valid image name")
+	}
 	deployment := newDeployment(request.Namespace, *validatorSpec.Replicas, image)
 	addPlacementFields(deployment, validatorSpec.Placement)
 	return common.CreateOrUpdate(request).


### PR DESCRIPTION
Signed-off-by: Vatsal Parekh <vparekh@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
