### PR TITLE
Add release automation for template-validator

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,6 +22,7 @@ jobs:
         run: |
           docker login -u="${{ secrets.QUAY_BOT }}" -p="${{ secrets.QUAY_PASSWORD }}" quay.io
           export IMG_TAG="${{ steps.get_release.outputs.tag_name }}"
+          export VALIDATOR_IMG_TAG="${{ steps.get_release.outputs.tag_name }}"
           export VERSION="`echo ${{ steps.get_release.outputs.tag_name }} | sed 's/^v//'`"
           make release
 

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,8 @@ IMG ?= ${IMG_REPOSITORY}:${IMG_TAG}
 
 # Image URL variables for template-validator
 VALIDATOR_REPOSITORY ?= quay.io/kubevirt/kubevirt-template-validator
-VALIDAOTR_IMAGE_TAG ?= latest
-VALIDATOR_IMG ?= ${VALIDATOR_REPOSITORY}:${VALIDAOTR_IMAGE_TAG}
+VALIDATOR_IMG_TAG ?= latest
+VALIDATOR_IMG ?= ${VALIDATOR_REPOSITORY}:${VALIDATOR_IMG_TAG}
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -115,10 +115,10 @@ container-push:
 build-template-validator:
 	./hack/build-template-validator.sh ${VERSION}
 
-build-template-validator-container: build-template-validator
+build-template-validator-container:
 	docker build -t ${VALIDATOR_IMG} . -f validator.Dockerfile
 
-push-template-validator-container: build-template-validator-container
+push-template-validator-container:
 	docker push ${VALIDATOR_IMG}
 
 # find or download controller-gen
@@ -176,5 +176,5 @@ bundle-build:
 	docker build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
 
 .PHONY: release
-release: container-build container-push bundle build-functests
+release: container-build container-push build-template-validator-container push-template-validator-container bundle build-functests
 	cp ./tests.test _out/tests.test


### PR DESCRIPTION
Signed-off-by: Vatsal Parekh <vparekh@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This adds the release automation needed to publish container images for template-validator when we do a release for ssp-operator 
Also, this will change the versioning for template-validator images to one equal to ssp-operator release 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
