### PR TITLE
Add priorityClassName to ssp-operator pod

### DIFF
--- a/config/manager/manager.template.yaml
+++ b/config/manager/manager.template.yaml
@@ -23,6 +23,7 @@ spec:
         control-plane: ssp-operator
     spec:
       serviceAccountName: ssp-operator
+      priorityClassName: system-cluster-critical
       containers:
       - command:
         - /manager

--- a/internal/operands/template-validator/resources.go
+++ b/internal/operands/template-validator/resources.go
@@ -134,6 +134,7 @@ func newDeployment(namespace string, replicas int32, image string) *apps.Deploym
 				},
 				Spec: core.PodSpec{
 					ServiceAccountName: ServiceAccountName,
+					PriorityClassName: "system-cluster-critical",
 					Containers: []core.Container{{
 						Name:            "webhook",
 						Image:           image,


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds a `priorityClassName` to the ssp-operator & template-validator pod spec
More about priorityclasses: https://docs.openshift.com/container-platform/4.7/nodes/pods/nodes-pods-priority.html

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1953483

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
