### PR TITLE
Add Resource requests to pods

### DIFF
--- a/config/manager/manager.template.yaml
+++ b/config/manager/manager.template.yaml
@@ -44,3 +44,7 @@ spec:
             port: 9440
           initialDelaySeconds: 5
       terminationGracePeriodSeconds: 10
+      resources:
+        requests:
+          memory: "150Mi"
+          cpu: "100m"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Add resource requests to ssp-operator and template-validator containers

Following the Openshift [CONVENTIONS](https://github.com/openshift/enhancements/blob/master/CONVENTIONS.md#resources-and-limits), no limits are set, keeping in mind that recourse needs would grow as the cluster grows 


**Which issue(s) this PR fixes**: 
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1953485

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
