### PR TITLE
[v0.11] Update webhook version for template validator to v1

### DIFF
--- a/internal/operands/template-validator/resources.go
+++ b/internal/operands/template-validator/resources.go
@@ -14,10 +14,6 @@ import (
 	"kubevirt.io/ssp-operator/internal/common"
 )
 
-// Resources from kubevirt-template-validator version v0.7.0
-// TODO - move this code to the kubevirt-template-validator
-//        repository, and import it as a go module
-
 const (
 	ContainerPort          = 8443
 	KubevirtIo             = "kubevirt.io"
@@ -217,11 +213,9 @@ func newValidatingWebhook(namespace string) *admission.ValidatingWebhookConfigur
 					Resources:   []string{"virtualmachines"},
 				},
 			}},
-			FailurePolicy: &fail,
-			SideEffects:   &sideEffectsNone,
-			// TODO - add "v1" to the list once the template-validator
-			//        is updated to new API
-			AdmissionReviewVersions: []string{"v1beta1"},
+			FailurePolicy:           &fail,
+			SideEffects:             &sideEffectsNone,
+			AdmissionReviewVersions: []string{"v1"},
 		}},
 	}
 }

--- a/internal/template-validator/webhooks/hook.go
+++ b/internal/template-validator/webhooks/hook.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	admissionv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"kubevirt.io/client-go/log"
 )
@@ -66,7 +67,6 @@ func admitVMTemplate(ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResp
 }
 
 func serve(resp http.ResponseWriter, req *http.Request, admit admitFunc) {
-	response := admissionv1.AdmissionReview{}
 	review, err := GetAdmissionReview(req)
 
 	log.Log.V(8).Infof("evaluating admission")
@@ -82,6 +82,13 @@ func serve(resp http.ResponseWriter, req *http.Request, admit admitFunc) {
 	reviewResponse := admit(review)
 
 	log.Log.V(8).Infof("admission review response:\n%s", spew.Sdump(reviewResponse))
+
+	response := admissionv1.AdmissionReview{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: admissionv1.SchemeGroupVersion.String(),
+			Kind:       "AdmissionReview",
+		},
+	}
 
 	if reviewResponse != nil {
 		response.Response = reviewResponse


### PR DESCRIPTION
**What this PR does / why we need it**:
The `ValidatingWebhookConfiguration` uses `v1` admission review version.

Added missing fields to `AdmissionReview` response. Without them, k8s will reject the response.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1936926

**Release note**:
```release-note
None
```
