### PR TITLE
csv-generator: Override environment variables only when needed

### DIFF
--- a/hack/csv-generator.go
+++ b/hack/csv-generator.go
@@ -185,10 +185,10 @@ func replaceVariables(flags generatorFlags, csv *csvv1.ClusterServiceVersion) er
 			updatedContainer.Image = flags.operatorImage
 			updatedVariables := make([]v1.EnvVar, 0)
 			for _, envVariable := range container.Env {
-				if envVariable.Name == common.TemplateValidatorImageKey {
+				if envVariable.Name == common.TemplateValidatorImageKey && flags.validatorImage != "" {
 					envVariable.Value = flags.validatorImage
 				}
-				if envVariable.Name == common.OperatorVersionKey {
+				if envVariable.Name == common.OperatorVersionKey && flags.operatorVersion != "" {
 					envVariable.Value = flags.operatorVersion
 				}
 				updatedVariables = append(updatedVariables, envVariable)


### PR DESCRIPTION
**What this PR does / why we need it**:
The csv-generator does not override environment variables `VALIDATOR_IMAGE` and `OPERATOR_VERSION`, if no override flag is specified on the command line.

**Release note**:
```release-note
None
```
