### PR TITLE
Update the default template-validator image to the latest released one

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,14 @@
 # Build the manager binary
 FROM golang:1.15 as builder
 
+# Consume required variables so we can work with make
+ARG IMG_REPOSITORY
+ARG IMG_TAG
+ARG IMG
+ARG VALIDATOR_REPOSITORY
+ARG VALIDATOR_IMG_TAG
+ARG VALIDATOR_IMG
+
 WORKDIR /workspace
 # Copy the Go Modules manifests and vendor directory
 COPY go.mod go.mod
@@ -8,24 +16,25 @@ COPY go.sum go.sum
 COPY vendor/ vendor/
 
 # Copy the go source
+COPY Makefile Makefile
 COPY main.go main.go
 COPY api/ api/
 COPY controllers/ controllers/
 COPY internal/ internal/
 
-COPY hack/csv-generator.go csv-generator.go
+COPY hack/csv-generator.go hack/csv-generator.go
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on make manager
 
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o csv-generator csv-generator.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on make csv-generator
 RUN chmod +x csv-generator
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
 LABEL org.kubevirt.hco.csv-generator.v1="/csv-generator"
 
 WORKDIR /
-COPY --from=builder /workspace/manager .
+COPY --from=builder /workspace/bin/manager .
 COPY data/ data/
 USER 1000
 

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,9 @@ functest: generate fmt vet manifests
 
 # Build manager binary
 manager: generate fmt vet
-	go build -o bin/manager main.go
+	go build -o bin/manager \
+		-ldflags="-X 'kubevirt.io/ssp-operator/internal/operands/template-validator.defaultTemplateValidatorImage=${VALIDATOR_IMG}'" \
+		main.go
 
 # Build csv-generator binary
 csv-generator: generate fmt vet
@@ -106,7 +108,14 @@ container-build: unittest bundle
 	mkdir -p data/crd
 	cp bundle/manifests/ssp-operator.clusterserviceversion.yaml data/olm-catalog/ssp-operator.clusterserviceversion.yaml
 	cp bundle/manifests/ssp.kubevirt.io_ssps.yaml data/crd/ssp.kubevirt.io_ssps.yaml
-	docker build -t ${IMG} .
+	docker build -t ${IMG} \
+		--build-arg IMG_REPOSITORY=${IMG_REPOSITORY} \
+		--build-arg IMG_TAG=${IMG_TAG} \
+		--build-arg IMG=${IMG} \
+		--build-arg VALIDATOR_REPOSITORY=${VALIDATOR_REPOSITORY} \
+		--build-arg VALIDATOR_IMG_TAG=${VALIDATOR_IMG_TAG} \
+		--build-arg VALIDATOR_IMG=${VALIDATOR_IMG} \
+		.
 
 # Push the container image
 container-push:
@@ -116,7 +125,14 @@ build-template-validator:
 	./hack/build-template-validator.sh ${VERSION}
 
 build-template-validator-container:
-	docker build -t ${VALIDATOR_IMG} . -f validator.Dockerfile
+	docker build -t ${VALIDATOR_IMG} \
+		--build-arg IMG_REPOSITORY=${IMG_REPOSITORY} \
+		--build-arg IMG_TAG=${IMG_TAG} \
+		--build-arg IMG=${IMG} \
+		--build-arg VALIDATOR_REPOSITORY=${VALIDATOR_REPOSITORY} \
+		--build-arg VALIDATOR_IMG_TAG=${VALIDATOR_IMG_TAG} \
+		--build-arg VALIDATOR_IMG=${VALIDATOR_IMG} \
+		. -f validator.Dockerfile
 
 push-template-validator-container:
 	docker push ${VALIDATOR_IMG}

--- a/internal/operands/template-validator/defaults.go
+++ b/internal/operands/template-validator/defaults.go
@@ -1,5 +1,7 @@
 package template_validator
 
-const (
-	defaultTemplateValidatorImage = "quay.io/kubevirt/kubevirt-template-validator:v0.10.0"
+var (
+	// This value will be updated at build time to point to the latest released validator image's
+	// tag, for example vx.y.z
+	defaultTemplateValidatorImage = "quay.io/kubevirt/kubevirt-template-validator:latest"
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
Update the template validator image deployed by the SSP operator to the
latest released one on every release.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**Which issue(s) this PR fixes**: 
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
The default template validator image should no longer be manually updated for each release

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
/cc @akrejcir @kwiesmueller 