### PR TITLE
Validate that this repository does not contain offensive language

### DIFF
--- a/.github/workflows/validate-no-offensive-lang.yml
+++ b/.github/workflows/validate-no-offensive-lang.yml
@@ -1,0 +1,15 @@
+name: validate-no-offensive-lang
+
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: validate-no-offensive-lang
+      run: hack/validate-no-offensive-lang.sh

--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,10 @@ fmt:
 vet:
 	go vet ./...
 
+# Validate that this repository does not contain offensive language
+validate-no-offensive-lang:
+	./hack/validate-no-offensive-lang.sh
+
 # Generate code
 generate: controller-gen
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."

--- a/automation/ocp-ci-run-e2e-upgrade-tests.sh
+++ b/automation/ocp-ci-run-e2e-upgrade-tests.sh
@@ -13,11 +13,6 @@ oc apply -n $NAMESPACE -f "https://github.com/kubevirt/ssp-operator/releases/dow
 # Wait for deployment to be available, otherwise the validating webhook would reject the SSP CR.
 oc wait --for=condition=Available --timeout=600s -n ${NAMESPACE} deployments/ssp-operator
 
-# TODO - Temporarily adding sleep to wait for the webhook to be available.
-#        The master version has a readiness probe, but this test deploys the latest released version,
-#        which does not have the probe. Remove sleep after release of next version.
-sleep 10
-
 SSP_NAME="ssp-test"
 SSP_NAMESPACE="ssp-operator-functests"
 SSP_TEMPLATES_NAMESPACE="ssp-operator-functests-templates"

--- a/hack/validate-no-offensive-lang.sh
+++ b/hack/validate-no-offensive-lang.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+OFFENSIVE_WORDS="black[ -]?list|white[ -]?list|master|slave"
+ALLOW_LIST=".+[:/=]master[a-zA-Z]*/?"
+
+if git grep -inE "${OFFENSIVE_WORDS}" -- ':!vendor' ":!${BASH_SOURCE[0]}" ':!.github/workflows/' | grep -viE "${ALLOW_LIST}"; then
+  echo "Validation failed. Found offensive language"
+  exit 1
+fi


### PR DESCRIPTION
Add a check to the sannity test that fails if there is a usage
of offensive language in one of the files.

The script forbit the use of the words `master`, `slave`,
`blacklist` and `whitelist`

Sinse `master` is very common word as a name of default
branches or as a node name in clusters, the script allows
the usage of it if this word is part of a URL or a path.
The script does not check several directories that may
contain third party usage of the word `master`:
`vendor/` `deploy/` and `cluster`.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**: 
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```
NONE
```
