### PR TITLE
fixed deprecated label which is set during upgrade to up-to-date template

### DIFF
--- a/internal/operands/common-templates/reconcile.go
+++ b/internal/operands/common-templates/reconcile.go
@@ -22,6 +22,7 @@ import (
 var (
 	loadTemplatesOnce sync.Once
 	templatesBundle   []templatev1.Template
+	deployedTemplates = make(map[string]bool)
 )
 
 // Define RBAC rules needed by this operand:
@@ -77,6 +78,25 @@ func (c *commonTemplates) Reconcile(request *common.Request) ([]common.ResourceS
 		reconcileViewRoleBinding,
 		reconcileEditRole,
 	}
+
+	loadTemplates := func() {
+		var err error
+		filename := filepath.Join(BundleDir, "common-templates-"+Version+".yaml")
+		templatesBundle, err = ReadTemplates(filename)
+		if err != nil {
+			request.Logger.Error(err, fmt.Sprintf("Error reading from template bundle, %v", err))
+			panic(err)
+		}
+		if len(templatesBundle) == 0 {
+			panic("No templates could be found in the installed bundle")
+		}
+
+		for _, template := range templatesBundle {
+			deployedTemplates[template.Name] = true
+		}
+	}
+	// Only load templates Once
+	loadTemplatesOnce.Do(loadTemplates)
 
 	oldTemplateFuncs, err := reconcileOlderTemplates(request)
 	if err != nil {
@@ -186,6 +206,11 @@ func reconcileOlderTemplates(request *common.Request) ([]common.ReconcileFunc, e
 	funcs := make([]common.ReconcileFunc, 0, len(existingTemplates.Items))
 	for i := range existingTemplates.Items {
 		template := &existingTemplates.Items[i]
+
+		if _, ok := deployedTemplates[template.Name]; ok {
+			continue
+		}
+
 		if template.Annotations == nil {
 			template.Annotations = make(map[string]string)
 		}
@@ -212,21 +237,6 @@ func reconcileOlderTemplates(request *common.Request) ([]common.ReconcileFunc, e
 }
 
 func reconcileTemplatesFuncs(request *common.Request) []common.ReconcileFunc {
-	loadTemplates := func() {
-		var err error
-		filename := filepath.Join(BundleDir, "common-templates-"+Version+".yaml")
-		templatesBundle, err = ReadTemplates(filename)
-		if err != nil {
-			request.Logger.Error(err, fmt.Sprintf("Error reading from template bundle, %v", err))
-			panic(err)
-		}
-		if len(templatesBundle) == 0 {
-			panic("No templates could be found in the installed bundle")
-		}
-	}
-	// Only load templates Once
-	loadTemplatesOnce.Do(loadTemplates)
-
 	namespace := request.Instance.Spec.CommonTemplates.Namespace
 	funcs := make([]common.ReconcileFunc, 0, len(templatesBundle))
 	for i := range templatesBundle {

--- a/internal/operands/common-templates/reconcile_test.go
+++ b/internal/operands/common-templates/reconcile_test.go
@@ -213,6 +213,8 @@ var _ = Describe("Common-Templates operand", func() {
 					Expect(template.Labels[TemplateTypeLabel]).To(Equal("base"), TemplateTypeLabel+" should equal base")
 					Expect(template.Labels[TemplateVersionLabel]).To(Equal(Version), TemplateVersionLabel+" should equal "+Version)
 				}
+				Expect(template.Annotations[TemplateDeprecatedAnnotation]).To(Equal(""), TemplateDeprecatedAnnotation+" should be empty")
+
 			}
 		})
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:
fixed deprecated label which is set during upgrade to up-to-date template
When deprecated label is set to old templates and new templates are deployed with the same name, during update the deprecated label stays on updated template. 
This patch updates the behaviour, so at first it loads all templates which will be deployed and then it applies deprecated label only to templates which will not be updated.
**Which issue(s) this PR fixes**: 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1964583

**Special notes for your reviewer**:

**Release note**:
```
NONE
```
Signed-off-by: Karel Šimon <ksimon@redhat.com>
