### PR TITLE
switch base image from golang-1.15 to ubi8/ubi-minimal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 # Build the manager binary
-FROM golang:1.15 as builder
+FROM registry.access.redhat.com/ubi8/ubi-minimal as builder
+
+RUN microdnf install -y make golang-1.15.* which && microdnf clean all
 
 # Consume required variables so we can work with make
 ARG IMG_REPOSITORY

--- a/validator.Dockerfile
+++ b/validator.Dockerfile
@@ -1,4 +1,6 @@
-FROM golang:1.15 as builder
+FROM registry.access.redhat.com/ubi8/ubi-minimal as builder
+
+RUN microdnf install -y golang-1.15.* && microdnf clean all
 
 ARG VERSION=latest
 ARG COMPONENT="kubevirt-template-validator"


### PR DESCRIPTION
**What this PR does / why we need it**:
switch base image from golang-1.15 to ubi8/ubi-minimal
Due to pull rate limit from docker hub our tests constantly fails.
This PR switches main docker image to ubi8 image.

@akrejcir @kwiesmueller @omeryahud @vatsalparekh @dominikholler WDYT about this change?
**Special notes for your reviewer**:

**Release note**:

```
NONE
```
Signed-off-by: Karel Šimon <ksimon@redhat.com>
