### PR TITLE
[v0.11] Fix VERSION variable in Makefile, and update CSV

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
 # Current Operator version
-VERSION ?= 0.1.3
+# The value here should be equal to the next version:
+# - next minor version on main branch
+# - next patch version on release branches
+VERSION ?= 0.11.3
+
 # Default bundle image tag
 BUNDLE_IMG ?= controller-bundle:$(VERSION)
 #operator-sdk version

--- a/data/olm-catalog/ssp-operator.clusterserviceversion.yaml
+++ b/data/olm-catalog/ssp-operator.clusterserviceversion.yaml
@@ -28,7 +28,7 @@ metadata:
     description: Manages KubeVirt addons for Scheduling, Scale, Performance
     operators.operatorframework.io/builder: operator-sdk-v1.4.2
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
-  name: ssp-operator.v0.1.3
+  name: ssp-operator.v0.11.3
   namespace: kubevirt
 spec:
   apiservicedefinitions: {}
@@ -355,11 +355,12 @@ spec:
                 env:
                 - name: KVM_INFO_IMAGE
                 - name: VALIDATOR_IMAGE
+                  value: quay.io/kubevirt/kubevirt-template-validator:latest
                 - name: VIRT_LAUNCHER_IMAGE
                 - name: NODE_LABELLER_IMAGE
                 - name: CPU_PLUGIN_IMAGE
                 - name: OPERATOR_VERSION
-                  value: 0.1.3
+                  value: 0.11.3
                 image: quay.io/kubevirt/ssp-operator:latest
                 name: manager
                 ports:
@@ -440,7 +441,7 @@ spec:
     matchLabels:
       alm-owner-kubevirt: ssp-operator
       operated-by: ssp-operator
-  version: 0.1.3
+  version: 0.11.3
   webhookdefinitions:
   - admissionReviewVersions:
     - v1


### PR DESCRIPTION
**What this PR does / why we need it**:
The VERSION variable in makefile should be equal to the next release version in the sequence.

Regenerated CSV in data/olm-catalog.

**Release note**:
```release-note
None
```
