### PR TITLE
Fix flaky tests

### DIFF
--- a/tests/tests_common_test.go
+++ b/tests/tests_common_test.go
@@ -214,15 +214,15 @@ func getResourceKey(obj client.Object) client.ObjectKey {
 }
 
 func expectUserCan(sars *authv1.SubjectAccessReviewSpec) {
-	sar, err := coreClient.AuthorizationV1().SubjectAccessReviews().Create(ctx, &authv1.SubjectAccessReview{
-		Spec: *sars,
-	}, metav1.CreateOptions{})
-	ExpectWithOffset(1, err).ToNot(HaveOccurred())
-	ExpectWithOffset(1, sar.Status.Allowed).To(BeTrue(),
-		fmt.Sprintf("user [%s] with groups %v cannot [%s] resource: [%s], subresource: [%s], name: [%s] in group [%s/%s] in namespace [%s]",
-			sars.User, sars.Groups, sars.ResourceAttributes.Verb, sars.ResourceAttributes.Resource,
-			sars.ResourceAttributes.Subresource, sars.ResourceAttributes.Name, sars.ResourceAttributes.Group,
-			sars.ResourceAttributes.Version, sars.ResourceAttributes.Namespace))
+	Eventually(func() bool {
+		sar, err := coreClient.AuthorizationV1().SubjectAccessReviews().Create(ctx, &authv1.SubjectAccessReview{
+			Spec: *sars,
+		}, metav1.CreateOptions{})
+		return err == nil && sar.Status.Allowed
+	}, 15*time.Second, 2*time.Second).Should(BeTrue(), fmt.Sprintf("user [%s] with groups %v cannot [%s] resource: [%s], subresource: [%s], name: [%s] in group [%s/%s] in namespace [%s]",
+		sars.User, sars.Groups, sars.ResourceAttributes.Verb, sars.ResourceAttributes.Resource,
+		sars.ResourceAttributes.Subresource, sars.ResourceAttributes.Name, sars.ResourceAttributes.Group,
+		sars.ResourceAttributes.Version, sars.ResourceAttributes.Namespace))
 }
 
 func expectUserCannot(sars *authv1.SubjectAccessReviewSpec) {

--- a/tests/validator_test.go
+++ b/tests/validator_test.go
@@ -3,13 +3,14 @@ package tests
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"reflect"
+	"strings"
+	"time"
+
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
-	"reflect"
-	"strings"
-	"time"
 
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/extensions/table"
@@ -113,6 +114,7 @@ var _ = Describe("Template validator", func() {
 		}
 
 		waitUntilDeployed()
+		waitUntilTemplateValidatorIsRunning()
 	})
 
 	Context("resource creation", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
Add eventually command to edit permission tests
Add check which controls if at least one validator pod is running

edit permissions tests are failing on baremetal. This PR
add eventually command, which will try to run test multiple time

Some validator tests are failing on baremetal due to not validating
rules. One of the possible root cause can be, that the validator is not
running. This PR adds check which controls if at least one validator pod
is running before test.
Signed-off-by: Karel Šimon <ksimon@redhat.com>

**Special notes for your reviewer**:

**Release note**:
```
NONE
```
