### PR TITLE
Stabilize functional tests

### DIFF
--- a/tests/labels_test.go
+++ b/tests/labels_test.go
@@ -63,18 +63,17 @@ func encodePatch(operations []jsonpatch.Operation) client.Patch {
 
 func waitForLabelMatch(resource client.Object, key client.ObjectKey, expectedLabels map[string]string) {
 	var lastResult badLabels
-	Eventually(func() bool {
+	Eventually(func() (bool, error) {
 		err := apiClient.Get(ctx, key, resource)
 		if err != nil {
-			fmt.Fprintln(GinkgoWriter, err)
-			return false
+			return false, err
 		}
 		badLabels := labelsMatch(expectedLabels, resource)
 		if len(badLabels) > 0 {
 			lastResult = badLabels
-			return false
+			return false, nil
 		}
-		return true
+		return true, nil
 	}, shortTimeout).Should(BeTrue(), func() string {
 		return lastResult.String()
 	})

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -304,7 +304,7 @@ var _ = AfterSuite(func() {
 
 func expectSuccessOrNotFound(err error) {
 	if err != nil && !errors.IsNotFound(err) {
-		Expect(err).ToNot(HaveOccurred())
+		ExpectWithOffset(1, err).ToNot(HaveOccurred())
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

- Use `GenerateName` to create unique temporary resources for tests. This helps with timing issues, when a temporary resource from one test was not yet deleted and is used by a different test.

- Template validator tests wait until new templates propagate to template validator.

- Make test failures more verbose


**Release note**:
```release-note
None
```
