### PR TITLE
Remove a TODO comment from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,6 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
-# TODO -- validate that this is useful
 # Setting SHELL to bash allows bash commands to be executed by recipes.
 # Options are set to exit when a recipe line exits non-zero or a piped command fails.
 SHELL = /usr/bin/env bash -o pipefail


### PR DESCRIPTION
**What this PR does / why we need it**:
I forgot to remove the `TODO` in my previous PR.

**Release note**:
```release-note
None
```
