### PR TITLE
Move test scripts from OCP CI jobs to automation directory

### DIFF
--- a/automation/e2e-functests/run.sh
+++ b/automation/e2e-functests/run.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+# This file runs the tests.
+# It is run from the root of the repository.
+
+# These evn variables are defined by the CI:
+# CI_OPERATOR_IMG - path of the operator image in the local repository accessible on the CI
+# CI_VALIDATOR_IMG - path of the validator image in the local repository accessible on the CI
+
+export VALIDATOR_IMG=${CI_VALIDATOR_IMG}
+export IMG=${CI_OPERATOR_IMG}
+export SKIP_CLEANUP_AFTER_TESTS=true
+
+make deploy functest

--- a/automation/e2e-functests/setup.sh
+++ b/automation/e2e-functests/setup.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+# This file is run before tests. It should be used to install other required components on the cluster.
+# It is run from the root of the repository.
+
+./hack/deploy-kubevirt-and-cdi.sh

--- a/automation/e2e-upgrade-from-old-operator-functests/run.sh
+++ b/automation/e2e-upgrade-from-old-operator-functests/run.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+# This file runs the tests.
+# It is run from the root of the repository.
+
+# These evn variables are defined by the CI:
+# CI_OPERATOR_IMG - path of the operator image in the local repository accessible on the CI
+# CI_VALIDATOR_IMG - path of the validator image in the local repository accessible on the CI
+
+export VALIDATOR_IMG=${CI_VALIDATOR_IMG}
+export IMG=${CI_OPERATOR_IMG}
+export SKIP_CLEANUP_AFTER_TESTS=true
+
+make deploy functest

--- a/automation/e2e-upgrade-from-old-operator-functests/setup.sh
+++ b/automation/e2e-upgrade-from-old-operator-functests/setup.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+# This file is run before tests. It should be used to install other required components on the cluster.
+# It is run from the root of the repository.
+
+./hack/deploy-kubevirt-and-cdi.sh
+./hack/deploy-old-ssp-operator.sh

--- a/automation/e2e-upgrade-functests/run.sh
+++ b/automation/e2e-upgrade-functests/run.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+# This file runs the tests.
+# It is run from the root of the repository.
+
+# These evn variables are defined by the CI:
+# CI_OPERATOR_IMG - path of the operator image in the local repository accessible on the CI
+# CI_VALIDATOR_IMG - path of the validator image in the local repository accessible on the CI
+
+export VALIDATOR_IMG=${CI_VALIDATOR_IMG}
+export IMG=${CI_OPERATOR_IMG}
+
+./automation/ocp-ci-run-e2e-upgrade-tests.sh

--- a/automation/e2e-upgrade-functests/setup.sh
+++ b/automation/e2e-upgrade-functests/setup.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+# This file is run before tests. It should be used to install other required components on the cluster.
+# It is run from the root of the repository.
+
+# Empty


### PR DESCRIPTION

**What this PR does / why we need it**:
The test scripts from OCP CI jobs are moved to this repository. Then CI jobs for different branches can be merged into a single job.

**Release note**:
```release-note
None
```
