### PR TITLE
[admission-webhook] Use namespace in which the SSP CR was created for the placement validation dry-run

### DIFF
--- a/api/v1beta1/ssp_webhook.go
+++ b/api/v1beta1/ssp_webhook.go
@@ -106,17 +106,16 @@ func setClientForWebhook(c client.Client) {
 }
 
 func validatePlacement(ssp *SSP) error {
-	return validateOperandPlacement(ssp.Spec.TemplateValidator.Placement)
+	return validateOperandPlacement(ssp.Namespace, ssp.Spec.TemplateValidator.Placement)
 }
 
-func validateOperandPlacement(placement *api.NodePlacement) error {
+func validateOperandPlacement(namespace string, placement *api.NodePlacement) error {
 	if placement == nil {
 		return nil
 	}
 
 	const (
 		dplName          = "ssp-webhook-placement-verification-deployment"
-		namespace        = "default"
 		webhookTestLabel = "webhook.ssp.kubevirt.io/placement-verification-pod"
 		podName          = "ssp-webhook-placement-verification-pod"
 		naImage          = "ssp.kubevirt.io/not-available"


### PR DESCRIPTION
Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

**What this PR does / why we need it**:
It is possible to remove the `kubenetes` finalizer from `default` namespace and remove the namespace itself.
This PR suggests a bit safer approach to validate the placement configuration, using the namespace in which the SSP
CR was created.

**Special notes for your reviewer**:
My assumption is that the SSP CR and it's components are deployed in the same namespace, therefore there souldn't
be any RBAC issues with the dry-run. If it's not the case feel free to ignore the PR/

**Release note**:
```release-note
NONE
```
