### PR TITLE
Change securityContext on operator, so that scc is 'restricted'

### DIFF
--- a/config/manager/manager.template.yaml
+++ b/config/manager/manager.template.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: ssp-operator
       priorityClassName: system-cluster-critical
       securityContext:
-        runAsUser: 1000
+        runAsNonRoot: true
       containers:
       - command:
         - /manager

--- a/tests/misc_test.go
+++ b/tests/misc_test.go
@@ -3,10 +3,13 @@ package tests
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	core "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	lifecycleapi "kubevirt.io/controller-lifecycle-operator-sdk/pkg/sdk/api"
 
 	sspv1beta1 "kubevirt.io/ssp-operator/api/v1beta1"
+	validator "kubevirt.io/ssp-operator/internal/operands/template-validator"
 )
 
 var _ = Describe("Observed generation", func() {
@@ -71,5 +74,42 @@ var _ = Describe("Observed generation", func() {
 				updatedSsp.Generation == updatedSsp.Status.ObservedGeneration
 		}, shortTimeout)
 		Expect(err).ToNot(HaveOccurred())
+	})
+})
+
+var _ = Describe("SCC annotation", func() {
+	const (
+		sccAnnotation = "openshift.io/scc"
+		sccRestricted = "restricted"
+	)
+
+	BeforeEach(func() {
+		waitUntilDeployed()
+	})
+
+	It("[test_id:7162] operator pod should have 'restricted' scc annotation", func() {
+		pods := &core.PodList{}
+		err := apiClient.List(ctx, pods, client.MatchingLabels{"control-plane": "ssp-operator"})
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(pods.Items).ToNot(BeEmpty())
+
+		for _, pod := range pods.Items {
+			Expect(pod.Annotations).To(HaveKeyWithValue(sccAnnotation, sccRestricted), "Expected pod %s/%s to have scc 'restricted'", pod.Namespace, pod.Name)
+		}
+	})
+
+	It("[test_id:7163] template validator pods should have 'restricted' scc annotation", func() {
+		pods := &core.PodList{}
+		err := apiClient.List(ctx, pods,
+			client.InNamespace(strategy.GetNamespace()),
+			client.MatchingLabels{validator.KubevirtIo: validator.VirtTemplateValidator})
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(pods.Items).ToNot(BeEmpty())
+
+		for _, pod := range pods.Items {
+			Expect(pod.Annotations).To(HaveKeyWithValue(sccAnnotation, sccRestricted), "Expected pod %s/%s to have scc 'restricted'", pod.Namespace, pod.Name)
+		}
 	})
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
Changing the security context on the deployment, changes the assigned SCC from `privileged` to `restricted`.

**Which issue(s) this PR fixes**: 
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1995295

**Release note**:
```release-note
None
```
