### PR TITLE
Rollback Golang version back to 1.15

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module kubevirt.io/ssp-operator
 
-go 1.16
+go 1.15
 
 require (
 	github.com/blang/semver/v4 v4.0.0


### PR DESCRIPTION
**What this PR does / why we need it**:
Golang version in the dockerfile is currently at 1.15 and can not be upgraded to 1.16 because UBI currently does not have it. Rolling the version back to 1.15 in go.mod to avoid any version conflicts.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
