### PR TITLE
Code change: Improve validator code

### DIFF
--- a/internal/template-validator/validation/eval.go
+++ b/internal/template-validator/validation/eval.go
@@ -30,6 +30,7 @@ import (
 	"kubevirt.io/client-go/log"
 
 	k6tobjs "kubevirt.io/ssp-operator/internal/template-validator/kubevirtjobs"
+	"kubevirt.io/ssp-operator/internal/template-validator/validation/path"
 )
 
 var (
@@ -118,7 +119,7 @@ func (r *Result) ToStatusCauses() []metav1.StatusCause {
 		if ok, message := needsCause(&rr); ok {
 			causes = append(causes, metav1.StatusCause{
 				Type:    metav1.CauseTypeFieldValueInvalid,
-				Field:   TrimJSONPath(rr.Ref.Path),
+				Field:   path.TrimJSONPath(rr.Ref.Path),
 				Message: fmt.Sprintf("%s: %s", rr.Ref.Message, message),
 			})
 		}

--- a/internal/template-validator/validation/eval.go
+++ b/internal/template-validator/validation/eval.go
@@ -30,7 +30,6 @@ import (
 	"kubevirt.io/client-go/log"
 
 	k6tobjs "kubevirt.io/ssp-operator/internal/template-validator/kubevirtjobs"
-	"kubevirt.io/ssp-operator/internal/template-validator/validation/path"
 )
 
 var (
@@ -119,7 +118,7 @@ func (r *Result) ToStatusCauses() []metav1.StatusCause {
 		if ok, message := needsCause(&rr); ok {
 			causes = append(causes, metav1.StatusCause{
 				Type:    metav1.CauseTypeFieldValueInvalid,
-				Field:   path.TrimJSONPath(rr.Ref.Path),
+				Field:   rr.Ref.Path.Expr(),
 				Message: fmt.Sprintf("%s: %s", rr.Ref.Message, message),
 			})
 		}
@@ -147,8 +146,8 @@ func (ev *Evaluator) isRuleWellFormed(r *Rule, names map[string]int) (bool, erro
 		return false, ErrUnrecognizedRuleType
 	}
 
-	if r.Path == "" || r.Message == "" {
-		fmt.Fprintf(ev.Sink, "%s failed: missing keys\n", r.Name)
+	if r.Message == "" {
+		fmt.Fprintf(ev.Sink, "%s failed: missing \"Message\" key\n", r.Name)
 		return false, ErrMissingRequiredKey
 	}
 	return true, nil

--- a/internal/template-validator/validation/eval.go
+++ b/internal/template-validator/validation/eval.go
@@ -39,16 +39,6 @@ var (
 	ErrUnsatisfiedRule      = errors.New("rule is not satisfied")
 )
 
-func isValidRule(r string) bool {
-	validRules := []string{"integer", "string", "regex", "enum"}
-	for _, v := range validRules {
-		if r == v {
-			return true
-		}
-	}
-	return false
-}
-
 type Report struct {
 	Ref       *Rule
 	Skipped   bool   // because not valid, with `valid` defined as per spec
@@ -151,7 +141,7 @@ func (ev *Evaluator) isRuleWellFormed(r *Rule, names map[string]int) (bool, erro
 		return false, ErrDuplicateRuleName
 	}
 
-	if !isValidRule(r.Rule) {
+	if !r.Rule.IsValid() {
 		fmt.Fprintf(ev.Sink, "%s failed: invalid type\n", r.Name)
 		return false, ErrUnrecognizedRuleType
 	}

--- a/internal/template-validator/validation/eval.go
+++ b/internal/template-validator/validation/eval.go
@@ -110,10 +110,11 @@ func needsCause(rr *Report) (bool, string) {
 }
 
 func (r *Result) ToStatusCauses() []metav1.StatusCause {
-	var causes []metav1.StatusCause
 	if !r.failed {
-		return causes
+		return nil
 	}
+
+	var causes []metav1.StatusCause
 	for _, rr := range r.Status {
 		if ok, message := needsCause(&rr); ok {
 			causes = append(causes, metav1.StatusCause{
@@ -134,23 +135,15 @@ func NewEvaluator() *Evaluator {
 	return &Evaluator{Sink: ioutil.Discard}
 }
 
-func (ev *Evaluator) isRuleWellFormed(r *Rule, names map[string]int) (bool, error) {
-	names[r.Name] += 1
-	if names[r.Name] > 1 {
-		fmt.Fprintf(ev.Sink, "%s failed: duplicate name\n", r.Name)
-		return false, ErrDuplicateRuleName
-	}
-
+func validateRule(r *Rule) error {
 	if !r.Rule.IsValid() {
-		fmt.Fprintf(ev.Sink, "%s failed: invalid type\n", r.Name)
-		return false, ErrUnrecognizedRuleType
+		return ErrUnrecognizedRuleType
 	}
 
 	if r.Message == "" {
-		fmt.Fprintf(ev.Sink, "%s failed: missing \"Message\" key\n", r.Name)
-		return false, ErrMissingRequiredKey
+		return ErrMissingRequiredKey
 	}
-	return true, nil
+	return nil
 }
 
 // Evaluate applies *all* the rules (greedy evaluation) to the given VM.
@@ -162,7 +155,7 @@ func (ev *Evaluator) isRuleWellFormed(r *Rule, names map[string]int) (bool, erro
 func (ev *Evaluator) Evaluate(rules []Rule, vm *k6tv1.VirtualMachine) *Result {
 	// We can argue that this stage is needed because the parsing layer is too poor/dumb
 	// still, we need to do what we need to do.
-	names := make(map[string]int)
+	uniqueNames := make(map[string]struct{})
 	result := Result{}
 
 	refVm := k6tobjs.NewDefaultVirtualMachine()
@@ -174,23 +167,21 @@ func (ev *Evaluator) Evaluate(rules []Rule, vm *k6tv1.VirtualMachine) *Result {
 		// to let the cluster admin quickly identify the error in the rules. Otherwise, it
 		// we simply skip the malformed rule, the error can go unnoticed.
 		// IOW, this is a policy decision
-		if ok, err := ev.isRuleWellFormed(r, names); !ok {
+		if _, ok := uniqueNames[r.Name]; ok {
+			fmt.Fprintf(ev.Sink, "%s failed: duplicate name\n", r.Name)
+			result.Fail(r, ErrDuplicateRuleName)
+			continue
+		}
+		uniqueNames[r.Name] = struct{}{}
+
+		if err := validateRule(r); err != nil {
+			fmt.Fprintf(ev.Sink, "%s failed: %v\n", r.Name, err)
 			result.Fail(r, err)
 			continue
 		}
 
 		// Specialize() may be costly, so we do this before.
-		ok, err := r.IsAppliableOn(vm)
-		if err != nil {
-			fmt.Fprintf(ev.Sink, "%s failed: not appliable: %v\n", r.Name, err)
-			if r.JustWarning {
-				result.Warn(r.Message, err)
-			} else {
-				result.Fail(r, err)
-			}
-			continue
-		}
-		if !ok {
+		if !r.IsAppliableOn(vm) {
 			// Legit case. Nothing to do or to complain.
 			fmt.Fprintf(ev.Sink, "%s SKIPPED: not appliable\n", r.Name)
 			result.Skip(r)

--- a/internal/template-validator/validation/eval_test.go
+++ b/internal/template-validator/validation/eval_test.go
@@ -15,13 +15,13 @@ var _ = Describe("Eval", func() {
 			rules := []Rule{
 				{
 					Name: "rule-1",
-					Rule: "integer",
+					Rule: IntegerRule,
 					// any legal path is fine
 					Path:    "jsonpath::.spec.domain.cpu.cores",
 					Message: "testing",
 				}, {
 					Name: "rule-1",
-					Rule: "string",
+					Rule: StringRule,
 					// any legal path is fine
 					Path:    "jsonpath::.spec.domain.cpu.cores",
 					Message: "testing",
@@ -41,12 +41,12 @@ var _ = Describe("Eval", func() {
 			rules := []Rule{
 				{
 					Name: "rule-1",
-					Rule: "integer",
+					Rule: IntegerRule,
 					// any legal path is fine
 					Path: "jsonpath::.spec.domain.cpu.cores",
 				}, {
 					Name:    "rule-2",
-					Rule:    "string",
+					Rule:    StringRule,
 					Message: "testing",
 				},
 			}
@@ -77,7 +77,7 @@ var _ = Describe("Eval", func() {
 		It("Should detect unappliable rules", func() {
 			rules := []Rule{{
 				Name: "rule-1",
-				Rule: "integer",
+				Rule: IntegerRule,
 				// any legal path is fine
 				Path:    "jsonpath::.spec.domain.cpu.cores",
 				Message: "testing",
@@ -99,7 +99,7 @@ var _ = Describe("Eval", func() {
 			rules := []Rule{
 				{
 					Name: "rule-1",
-					Rule: "integer",
+					Rule: IntegerRule,
 					Min:  8,
 					// any legal path is fine
 					Path:        "jsonpath::.spec.domain.cpu.cores",
@@ -132,7 +132,7 @@ var _ = Describe("Eval", func() {
 		It("should skip uninitialized paths if requested", func() {
 			rules := []Rule{{
 				Name:    "LimitCores",
-				Rule:    "integer",
+				Rule:    IntegerRule,
 				Path:    "jsonpath::.spec.domain.cpu.cores",
 				Valid:   "jsonpath::.spec.domain.cpu.cores",
 				Message: "testing",
@@ -154,7 +154,7 @@ var _ = Describe("Eval", func() {
 		It("should handle uninitialized paths", func() {
 			rules := []Rule{{
 				Name:    "LimitCores",
-				Rule:    "integer",
+				Rule:    IntegerRule,
 				Path:    "jsonpath::.spec.domain.cpu.cores",
 				Message: "testing",
 				Min:     1,
@@ -170,21 +170,21 @@ var _ = Describe("Eval", func() {
 		It("should handle uninitialized paths intermixed with valid paths", func() {
 			rules := []Rule{
 				{
-					Rule:    "integer",
+					Rule:    IntegerRule,
 					Name:    "EnoughMemory",
 					Path:    "jsonpath::.spec.domain.resources.requests.memory",
 					Message: "Memory size not specified",
 					Min:     64 * 1024 * 1024,
 					Max:     512 * 1024 * 1024,
 				}, {
-					Rule:    "integer",
+					Rule:    IntegerRule,
 					Name:    "LimitCores",
 					Path:    "jsonpath::.spec.domain.cpu.cores",
 					Message: "Core amount not within range",
 					Min:     1,
 					Max:     4,
 				}, {
-					Rule:    "enum",
+					Rule:    EnumRule,
 					Name:    "SupportedChipset",
 					Path:    "jsonpath::.spec.domain.machine.type",
 					Message: "machine type must be a supported value",
@@ -204,7 +204,7 @@ var _ = Describe("Eval", func() {
 			rules := []Rule{
 				{
 					Name:        "disk bus",
-					Rule:        "enum",
+					Rule:        EnumRule,
 					Path:        "jsonpath::.spec.domain.devices.disks[*].disk.bus",
 					Message:     "testing",
 					Values:      []string{"sata"},
@@ -226,14 +226,14 @@ var _ = Describe("Eval", func() {
 			rules := []Rule{
 				{
 					Name:        "disk bus",
-					Rule:        "enum",
+					Rule:        EnumRule,
 					Path:        "jsonpath::.spec.domain.devices.disks[*].disk.bus",
 					Message:     "testing",
 					Values:      []string{"sata"},
 					JustWarning: true,
 				}, {
 					Name: "rule-2",
-					Rule: "integer",
+					Rule: IntegerRule,
 					Min:  6,
 					Max:  8,
 					// any legal path is fine
@@ -269,14 +269,14 @@ var _ = Describe("Eval", func() {
 		It("Should succeed applying a ruleset", func() {
 			rules := []Rule{
 				{
-					Rule:    "integer",
+					Rule:    IntegerRule,
 					Name:    "EnoughMemory",
 					Path:    "jsonpath::.spec.domain.resources.requests.memory",
 					Message: "Memory size not specified",
 					Min:     64 * 1024 * 1024,
 					Max:     512 * 1024 * 1024,
 				}, {
-					Rule:    "enum",
+					Rule:    EnumRule,
 					Name:    "SupportedChipset",
 					Path:    "jsonpath::.spec.domain.machine.type",
 					Message: "machine type must be a supported value",
@@ -302,7 +302,7 @@ var _ = Describe("Eval", func() {
 		It("Should fail applying a ruleset with at least one malformed rule", func() {
 			rules := []Rule{
 				{
-					Rule:    "integer",
+					Rule:    IntegerRule,
 					Name:    "EnoughMemory",
 					Path:    "jsonpath::.spec.domain.resources.requests.memory",
 					Message: "Memory size not specified",
@@ -326,14 +326,14 @@ var _ = Describe("Eval", func() {
 			rules := []Rule{
 				{
 					Name:        "disk bus",
-					Rule:        "enum",
+					Rule:        EnumRule,
 					Path:        "jsonpath::.spec.domain.devices.some.non.existing.path",
 					Message:     "testing",
 					Values:      []string{"sata"},
 					JustWarning: true,
 				}, {
 					Name: "rule-2",
-					Rule: "integer",
+					Rule: IntegerRule,
 					Min:  0,
 					Max:  8,
 					// any legal path is fine

--- a/internal/template-validator/validation/eval_test.go
+++ b/internal/template-validator/validation/eval_test.go
@@ -7,6 +7,8 @@ import (
 	. "github.com/onsi/gomega"
 
 	kubevirtv1 "kubevirt.io/client-go/api/v1"
+
+	"kubevirt.io/ssp-operator/internal/template-validator/validation/test-utils"
 )
 
 var _ = Describe("Eval", func() {
@@ -126,7 +128,7 @@ var _ = Describe("Eval", func() {
 		)
 
 		BeforeEach(func() {
-			vmCirros = NewVMCirros()
+			vmCirros = test_utils.NewVMCirros()
 		})
 
 		It("should skip uninitialized paths if requested", func() {
@@ -263,7 +265,7 @@ var _ = Describe("Eval", func() {
 		)
 
 		BeforeEach(func() {
-			vmCirros = NewVMCirros()
+			vmCirros = test_utils.NewVMCirros()
 		})
 
 		It("Should succeed applying a ruleset", func() {

--- a/internal/template-validator/validation/path/conv.go
+++ b/internal/template-validator/validation/path/conv.go
@@ -22,7 +22,7 @@ import (
 	"math"
 )
 
-func ToInt64(obj interface{}) (int64, bool) {
+func toInt64(obj interface{}) (int64, bool) {
 	switch val := obj.(type) {
 	case int:
 		return int64(val), true

--- a/internal/template-validator/validation/path/conv.go
+++ b/internal/template-validator/validation/path/conv.go
@@ -16,13 +16,13 @@
  * Copyright 2019 Red Hat, Inc.
  */
 
-package validation
+package path
 
 import (
 	"math"
 )
 
-func toInt64(obj interface{}) (int64, bool) {
+func ToInt64(obj interface{}) (int64, bool) {
 	switch val := obj.(type) {
 	case int:
 		return int64(val), true

--- a/internal/template-validator/validation/path/path_suite_test.go
+++ b/internal/template-validator/validation/path/path_suite_test.go
@@ -1,0 +1,13 @@
+package path
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestValidation(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Validation Path Suite")
+}

--- a/internal/template-validator/validation/path/variants.go
+++ b/internal/template-validator/validation/path/variants.go
@@ -1,0 +1,68 @@
+package path
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type IntOrPath struct {
+	Int  int64
+	Path *Path
+}
+
+func (r *IntOrPath) IsInt() bool {
+	return r.Path == nil
+}
+
+func (r *IntOrPath) UnmarshalJSON(bytes []byte) error {
+	var number float64
+	err := json.Unmarshal(bytes, &number)
+	if err == nil {
+		if intVal, ok := toInt64(number); ok {
+			r.Int = intVal
+			r.Path = nil
+			return nil
+		}
+	}
+
+	var path Path
+	err = json.Unmarshal(bytes, &path)
+	if err == nil {
+		r.Int = 0
+		r.Path = &path
+		return nil
+	}
+
+	return fmt.Errorf("cannot unmarshall IntOrPath from JSON: %w", err)
+}
+
+type StringOrPath struct {
+	Str  string
+	Path *Path
+}
+
+func (r *StringOrPath) IsString() bool {
+	return r.Path == nil
+}
+
+func (r *StringOrPath) UnmarshalJSON(bytes []byte) error {
+	var str string
+	err := json.Unmarshal(bytes, &str)
+	if err != nil {
+		return err
+	}
+
+	if !isJSONPath(str) {
+		r.Str = str
+		r.Path = nil
+		return nil
+	}
+
+	path, err := New(str)
+	if err != nil {
+		return err
+	}
+	r.Str = ""
+	r.Path = path
+	return nil
+}

--- a/internal/template-validator/validation/path/variants_test.go
+++ b/internal/template-validator/validation/path/variants_test.go
@@ -1,0 +1,58 @@
+package path
+
+import (
+	"encoding/json"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Variant tests", func() {
+	Context("IntOrPath", func() {
+		It("parses int from json", func() {
+			jsonData := []byte("{\"data\": 1234}")
+			data := &struct {
+				Data *IntOrPath `json:"data"`
+			}{}
+
+			Expect(json.Unmarshal(jsonData, data)).To(Succeed())
+			Expect(data.Data.IsInt()).To(BeTrue(), "Expected int value")
+			Expect(data.Data.Int).To(Equal(int64(1234)))
+		})
+
+		It("parses path form json", func() {
+			jsonData := []byte("{\"data\": \"jsonpath::.test.path\"}")
+			data := &struct {
+				Data *IntOrPath `json:"data"`
+			}{}
+
+			Expect(json.Unmarshal(jsonData, data)).To(Succeed())
+			Expect(data.Data.IsInt()).To(BeFalse(), "Expected path value")
+			Expect(data.Data.Path.Expr()).To(Equal(".test.path"))
+		})
+	})
+
+	Context("StringOrPath", func() {
+		It("parses string from json", func() {
+			jsonData := []byte("{\"data\": \"test string\"}")
+			data := &struct {
+				Data *StringOrPath `json:"data"`
+			}{}
+
+			Expect(json.Unmarshal(jsonData, data)).To(Succeed())
+			Expect(data.Data.IsString()).To(BeTrue(), "Expected string value")
+			Expect(data.Data.Str).To(Equal("test string"))
+		})
+
+		It("parses path form json", func() {
+			jsonData := []byte("{\"data\": \"jsonpath::.test.path\"}")
+			data := &struct {
+				Data *StringOrPath `json:"data"`
+			}{}
+
+			Expect(json.Unmarshal(jsonData, data)).To(Succeed())
+			Expect(data.Data.IsString()).To(BeFalse(), "Expected path value")
+			Expect(data.Data.Path.Expr()).To(Equal(".test.path"))
+		})
+	})
+})

--- a/internal/template-validator/validation/rules.go
+++ b/internal/template-validator/validation/rules.go
@@ -13,10 +13,10 @@ import (
 
 type Rule struct {
 	// mandatory keys
-	Rule    string `json:"rule"`
-	Name    string `json:"name"`
-	Path    string `json:"path"`
-	Message string `json:"message"`
+	Rule    RuleType `json:"rule"`
+	Name    string   `json:"name"`
+	Path    string   `json:"path"`
+	Message string   `json:"message"`
 	// optional keys
 	Valid       string `json:"valid,omitempty"`
 	JustWarning bool   `json:"justWarning,omitempty"`

--- a/internal/template-validator/validation/rules.go
+++ b/internal/template-validator/validation/rules.go
@@ -8,36 +8,26 @@ import (
 	"kubevirt.io/ssp-operator/internal/template-validator/validation/path"
 )
 
-// the flow:
-// 1. first you do ParseRule and get []Rule. This is little more than raw data rearranged in Go structs.
-//    You can work with that programmatically, but the first thing you may want to do is
-// 2. ...
-
 type Rule struct {
 	// mandatory keys
-	Rule    RuleType `json:"rule"`
-	Name    string   `json:"name"`
-	Path    string   `json:"path"`
-	Message string   `json:"message"`
+	Rule    RuleType  `json:"rule"`
+	Name    string    `json:"name"`
+	Path    path.Path `json:"path"`
+	Message string    `json:"message"`
 	// optional keys
-	Valid       string `json:"valid,omitempty"`
-	JustWarning bool   `json:"justWarning,omitempty"`
+	Valid       *path.Path `json:"valid,omitempty"`
+	JustWarning bool       `json:"justWarning,omitempty"`
 	// arguments (optional keys)
-	Values    []string    `json:"values,omitempty"`
-	Min       interface{} `json:"min,omitempty"`
-	Max       interface{} `json:"max,omitempty"`
-	MinLength interface{} `json:"minLength,omitempty"`
-	MaxLength interface{} `json:"maxLength,omitempty"`
-	Regex     string      `json:"regex,omitempty"`
+	Values    []path.StringOrPath `json:"values,omitempty"`
+	Min       *path.IntOrPath     `json:"min,omitempty"`
+	Max       *path.IntOrPath     `json:"max,omitempty"`
+	MinLength *path.IntOrPath     `json:"minLength,omitempty"`
+	MaxLength *path.IntOrPath     `json:"maxLength,omitempty"`
+	Regex     string              `json:"regex,omitempty"`
 }
 
 func (r *Rule) findPathOn(vm *k6tv1.VirtualMachine) (bool, error) {
-	var err error
-	p, err := path.New(r.Valid)
-	if err != nil {
-		return false, err
-	}
-	results, err := p.Find(vm)
+	results, err := r.Valid.Find(vm)
 	if err != nil {
 		return false, err
 	}
@@ -45,7 +35,7 @@ func (r *Rule) findPathOn(vm *k6tv1.VirtualMachine) (bool, error) {
 }
 
 func (r *Rule) IsAppliableOn(vm *k6tv1.VirtualMachine) (bool, error) {
-	if r.Valid == "" {
+	if r.Valid == nil {
 		// nothing to check against, so it is OK
 		return true, nil
 	}

--- a/internal/template-validator/validation/rules.go
+++ b/internal/template-validator/validation/rules.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 
 	k6tv1 "kubevirt.io/client-go/api/v1"
+
+	"kubevirt.io/ssp-operator/internal/template-validator/validation/path"
 )
 
 // the flow:
@@ -31,15 +33,15 @@ type Rule struct {
 
 func (r *Rule) findPathOn(vm *k6tv1.VirtualMachine) (bool, error) {
 	var err error
-	p, err := NewPath(r.Valid)
+	p, err := path.New(r.Valid)
 	if err != nil {
 		return false, err
 	}
-	err = p.Find(vm)
+	results, err := p.Find(vm)
 	if err != nil {
 		return false, err
 	}
-	return p.Len() > 0, nil
+	return results.Len() > 0, nil
 }
 
 func (r *Rule) IsAppliableOn(vm *k6tv1.VirtualMachine) (bool, error) {
@@ -48,7 +50,7 @@ func (r *Rule) IsAppliableOn(vm *k6tv1.VirtualMachine) (bool, error) {
 		return true, nil
 	}
 	ok, err := r.findPathOn(vm)
-	if err == ErrInvalidJSONPath {
+	if err == path.ErrInvalidJSONPath {
 		return false, nil
 	}
 	return ok, err

--- a/internal/template-validator/validation/rules.go
+++ b/internal/template-validator/validation/rules.go
@@ -26,24 +26,18 @@ type Rule struct {
 	Regex     string              `json:"regex,omitempty"`
 }
 
-func (r *Rule) findPathOn(vm *k6tv1.VirtualMachine) (bool, error) {
-	results, err := r.Valid.Find(vm)
-	if err != nil {
-		return false, err
-	}
-	return results.Len() > 0, nil
-}
-
-func (r *Rule) IsAppliableOn(vm *k6tv1.VirtualMachine) (bool, error) {
+func (r *Rule) IsAppliableOn(vm *k6tv1.VirtualMachine) bool {
 	if r.Valid == nil {
 		// nothing to check against, so it is OK
-		return true, nil
+		return true
 	}
-	ok, err := r.findPathOn(vm)
-	if err == path.ErrInvalidJSONPath {
-		return false, nil
+	// If valid path does not point to an existing JSON filed,
+	// this rule is not applicable for the VM.
+	results, err := r.Valid.Find(vm)
+	if err != nil {
+		return false
 	}
-	return ok, err
+	return results.Len() > 0
 }
 
 func ParseRules(data []byte) ([]Rule, error) {

--- a/internal/template-validator/validation/rules_test.go
+++ b/internal/template-validator/validation/rules_test.go
@@ -4,6 +4,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"kubevirt.io/ssp-operator/internal/template-validator/validation/path"
 	"kubevirt.io/ssp-operator/internal/template-validator/validation/test-utils"
 )
 
@@ -21,8 +22,8 @@ var _ = Describe("Rules", func() {
 		It("Should parse a single rule", func() {
 			text := `[{
             "name": "core-limits",
-            "valid": "spec.domain.cpu.cores",
-            "path": "spec.domain.cpu.cores",
+            "valid": "jsonpath::spec.domain.cpu.cores",
+            "path": "jsonpath::spec.domain.cpu.cores",
             "rule": "integer",
             "message": "cpu cores must be limited",
             "min": 1,
@@ -37,15 +38,15 @@ var _ = Describe("Rules", func() {
 		It("Should parse multiple rules", func() {
 			text := `[{
             "name": "core-limits",
-            "valid": "spec.domain.cpu.cores",
-            "path": "spec.domain.cpu.cores",
+            "valid": "jsonpath::spec.domain.cpu.cores",
+            "path": "jsonpath::spec.domain.cpu.cores",
             "rule": "integer",
             "message": "cpu cores must be limited",
             "min": 1,
             "max": 8
 	  }, {
             "name": "supported-bus",
-            "path": "spec.devices.disks[*].type",
+            "path": "jsonpath::spec.devices.disks[*].type",
             "rule": "enum",
             "message": "the disk bus type must be one of the supported values",
             "values": ["virtio", "scsi"]
@@ -60,10 +61,10 @@ var _ = Describe("Rules", func() {
 			r := Rule{
 				Rule:    IntegerRule,
 				Name:    "EnoughMemory",
-				Path:    "jsonpath::.spec.domain.resources.requests.memory",
+				Path:    *path.NewOrPanic("jsonpath::.spec.domain.resources.requests.memory"),
 				Message: "Memory size not specified",
-				Valid:   "jsonpath::.spec.domain.resources.requests.memory",
-				Min:     64 * 1024 * 1024,
+				Valid:   path.NewOrPanic("jsonpath::.spec.domain.resources.requests.memory"),
+				Min:     &path.IntOrPath{Int: 64 * 1024 * 1024},
 			}
 			ok, err := r.IsAppliableOn(vm)
 
@@ -75,10 +76,10 @@ var _ = Describe("Rules", func() {
 			r := Rule{
 				Rule:    IntegerRule,
 				Name:    "EnoughMemory",
-				Path:    "jsonpath::.spec.domain.resources.requests.memory",
+				Path:    *path.NewOrPanic("jsonpath::.spec.domain.resources.requests.memory"),
 				Message: "Memory size not specified",
-				Valid:   "jsonpath::.spec.domain.this.path.does.not.exist",
-				Min:     64 * 1024 * 1024,
+				Valid:   path.NewOrPanic("jsonpath::.spec.domain.this.path.does.not.exist"),
+				Min:     &path.IntOrPath{Int: 64 * 1024 * 1024},
 			}
 			ok, err := r.IsAppliableOn(vm)
 

--- a/internal/template-validator/validation/rules_test.go
+++ b/internal/template-validator/validation/rules_test.go
@@ -66,10 +66,7 @@ var _ = Describe("Rules", func() {
 				Valid:   path.NewOrPanic("jsonpath::.spec.domain.resources.requests.memory"),
 				Min:     &path.IntOrPath{Int: 64 * 1024 * 1024},
 			}
-			ok, err := r.IsAppliableOn(vm)
-
-			Expect(err).To(Not(HaveOccurred()))
-			Expect(ok).To(BeTrue())
+			Expect(r.IsAppliableOn(vm)).To(BeTrue())
 		})
 		It("Should NOT apply on a NOT relevant VM", func() {
 			vm := test_utils.NewVMCirros()
@@ -81,10 +78,7 @@ var _ = Describe("Rules", func() {
 				Valid:   path.NewOrPanic("jsonpath::.spec.domain.this.path.does.not.exist"),
 				Min:     &path.IntOrPath{Int: 64 * 1024 * 1024},
 			}
-			ok, err := r.IsAppliableOn(vm)
-
-			Expect(err).To(Not(HaveOccurred()))
-			Expect(ok).To(BeFalse())
+			Expect(r.IsAppliableOn(vm)).To(BeFalse())
 		})
 
 	})

--- a/internal/template-validator/validation/rules_test.go
+++ b/internal/template-validator/validation/rules_test.go
@@ -3,6 +3,8 @@ package validation
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	"kubevirt.io/ssp-operator/internal/template-validator/validation/test-utils"
 )
 
 var _ = Describe("Rules", func() {
@@ -54,7 +56,7 @@ var _ = Describe("Rules", func() {
 			Expect(len(rules)).To(Equal(2))
 		})
 		It("Should apply on a relevant VM", func() {
-			vm := NewVMCirros()
+			vm := test_utils.NewVMCirros()
 			r := Rule{
 				Rule:    IntegerRule,
 				Name:    "EnoughMemory",
@@ -69,7 +71,7 @@ var _ = Describe("Rules", func() {
 			Expect(ok).To(BeTrue())
 		})
 		It("Should NOT apply on a NOT relevant VM", func() {
-			vm := NewVMCirros()
+			vm := test_utils.NewVMCirros()
 			r := Rule{
 				Rule:    IntegerRule,
 				Name:    "EnoughMemory",

--- a/internal/template-validator/validation/rules_test.go
+++ b/internal/template-validator/validation/rules_test.go
@@ -56,7 +56,7 @@ var _ = Describe("Rules", func() {
 		It("Should apply on a relevant VM", func() {
 			vm := NewVMCirros()
 			r := Rule{
-				Rule:    "integer",
+				Rule:    IntegerRule,
 				Name:    "EnoughMemory",
 				Path:    "jsonpath::.spec.domain.resources.requests.memory",
 				Message: "Memory size not specified",
@@ -71,7 +71,7 @@ var _ = Describe("Rules", func() {
 		It("Should NOT apply on a NOT relevant VM", func() {
 			vm := NewVMCirros()
 			r := Rule{
-				Rule:    "integer",
+				Rule:    IntegerRule,
 				Name:    "EnoughMemory",
 				Path:    "jsonpath::.spec.domain.resources.requests.memory",
 				Message: "Memory size not specified",

--- a/internal/template-validator/validation/specialized.go
+++ b/internal/template-validator/validation/specialized.go
@@ -29,6 +29,29 @@ import (
 	k6tv1 "kubevirt.io/client-go/api/v1"
 )
 
+type RuleType string
+
+const (
+	IntegerRule RuleType = "integer"
+	StringRule  RuleType = "string"
+	EnumRule    RuleType = "enum"
+	RegexRule   RuleType = "regex"
+)
+
+func (r RuleType) IsValid() bool {
+	switch r {
+	case IntegerRule:
+		fallthrough
+	case StringRule:
+		fallthrough
+	case EnumRule:
+		fallthrough
+	case RegexRule:
+		return true
+	}
+	return false
+}
+
 type RuleApplier interface {
 	Apply(vm, ref *k6tv1.VirtualMachine) (bool, error)
 	String() string
@@ -41,13 +64,13 @@ var ErrNoValuesFound = errors.New("no values were found")
 // or the limits to enforce.
 func (r *Rule) Specialize(vm, ref *k6tv1.VirtualMachine) (RuleApplier, error) {
 	switch r.Rule {
-	case "integer":
+	case IntegerRule:
 		return NewIntRule(r, vm, ref)
-	case "string":
+	case StringRule:
 		return NewStringRule(r, vm, ref)
-	case "enum":
+	case EnumRule:
 		return NewEnumRule(r, vm, ref)
-	case "regex":
+	case RegexRule:
 		return NewRegexRule(r)
 	}
 	return nil, fmt.Errorf("usupported rule: %s", r.Rule)

--- a/internal/template-validator/validation/specialized_test.go
+++ b/internal/template-validator/validation/specialized_test.go
@@ -6,7 +6,9 @@ import (
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	kubevirtv1 "kubevirt.io/client-go/api/v1"
+
 	k6tobjs "kubevirt.io/ssp-operator/internal/template-validator/kubevirtjobs"
+	"kubevirt.io/ssp-operator/internal/template-validator/validation/test-utils"
 )
 
 var _ = Describe("Specialized", func() {
@@ -18,7 +20,7 @@ var _ = Describe("Specialized", func() {
 		)
 
 		BeforeEach(func() {
-			vmCirros = NewVMCirros()
+			vmCirros = test_utils.NewVMCirros()
 			vmRef = k6tobjs.NewDefaultVirtualMachine()
 		})
 
@@ -99,7 +101,7 @@ var _ = Describe("Specialized", func() {
 		)
 
 		BeforeEach(func() {
-			vmCirros = NewVMCirros()
+			vmCirros = test_utils.NewVMCirros()
 			vmRef = k6tobjs.NewDefaultVirtualMachine()
 		})
 

--- a/internal/template-validator/validation/specialized_test.go
+++ b/internal/template-validator/validation/specialized_test.go
@@ -8,6 +8,7 @@ import (
 	kubevirtv1 "kubevirt.io/client-go/api/v1"
 
 	k6tobjs "kubevirt.io/ssp-operator/internal/template-validator/kubevirtjobs"
+	"kubevirt.io/ssp-operator/internal/template-validator/validation/path"
 	"kubevirt.io/ssp-operator/internal/template-validator/validation/test-utils"
 )
 
@@ -28,10 +29,10 @@ var _ = Describe("Specialized", func() {
 			r := Rule{
 				Rule:    IntegerRule,
 				Name:    "EnoughMemory",
-				Path:    "jsonpath::.spec.domain.resources.requests.memory",
+				Path:    *path.NewOrPanic("jsonpath::.spec.domain.resources.requests.memory"),
 				Message: "Memory size not specified",
-				Min:     64 * 1024 * 1024,
-				Max:     512 * 1024 * 1024,
+				Min:     &path.IntOrPath{Int: 64 * 1024 * 1024},
+				Max:     &path.IntOrPath{Int: 512 * 1024 * 1024},
 			}
 			expectRuleApplicationSuccess(&r, vmCirros, vmRef)
 		})
@@ -40,10 +41,10 @@ var _ = Describe("Specialized", func() {
 			r := Rule{
 				Rule:      StringRule,
 				Name:      "HasChipset",
-				Path:      "jsonpath::.spec.domain.machine.type",
+				Path:      *path.NewOrPanic("jsonpath::.spec.domain.machine.type"),
 				Message:   "machine type must be specified",
-				MinLength: 1,
-				MaxLength: 32,
+				MinLength: &path.IntOrPath{Int: 1},
+				MaxLength: &path.IntOrPath{Int: 32},
 			}
 			expectRuleApplicationSuccess(&r, vmCirros, vmRef)
 		})
@@ -52,9 +53,9 @@ var _ = Describe("Specialized", func() {
 			r := Rule{
 				Rule:    EnumRule,
 				Name:    "SupportedChipset",
-				Path:    "jsonpath::.spec.domain.machine.type",
+				Path:    *path.NewOrPanic("jsonpath::.spec.domain.machine.type"),
 				Message: "machine type must be a supported value",
-				Values:  []string{"q35", "440fx"},
+				Values:  []path.StringOrPath{{Str: "q35"}, {Str: "440fx"}},
 			}
 			expectRuleApplicationSuccess(&r, vmCirros, vmRef)
 		})
@@ -63,9 +64,9 @@ var _ = Describe("Specialized", func() {
 			r := Rule{
 				Rule:    EnumRule,
 				Name:    "SupportedDiskBus",
-				Path:    "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+				Path:    *path.NewOrPanic("jsonpath::.spec.domain.devices.disks[*].disk.bus"),
 				Message: "disk bus must be a supported value",
-				Values:  []string{"virtio", "sata"},
+				Values:  []path.StringOrPath{{Str: "virtio"}, {Str: "sata"}},
 			}
 			expectRuleApplicationSuccess(&r, vmCirros, vmRef)
 		})
@@ -74,7 +75,7 @@ var _ = Describe("Specialized", func() {
 			r := Rule{
 				Rule:    RegexRule,
 				Name:    "SupportedChipset",
-				Path:    "jsonpath::.spec.domain.machine.type",
+				Path:    *path.NewOrPanic("jsonpath::.spec.domain.machine.type"),
 				Message: "machine type must be a supported value",
 				Regex:   "q35|440fx",
 			}
@@ -85,7 +86,7 @@ var _ = Describe("Specialized", func() {
 			r := Rule{
 				Rule:    RegexRule,
 				Name:    "SupportedDiskBus",
-				Path:    "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+				Path:    *path.NewOrPanic("jsonpath::.spec.domain.devices.disks[*].disk.bus"),
 				Message: "disk bus must be a supported value",
 				Regex:   "virtio|sata",
 			}
@@ -109,11 +110,11 @@ var _ = Describe("Specialized", func() {
 			r := Rule{
 				Rule:    "integer-value",
 				Name:    "EnoughMemory",
-				Path:    "jsonpath::.spec.domain.resources.requests.memory",
+				Path:    *path.NewOrPanic("jsonpath::.spec.domain.resources.requests.memory"),
 				Message: "Memory size not specified",
-				Valid:   "jsonpath::.spec.domain.this.path.does.not.exist",
-				Min:     64 * 1024 * 1024,
-				Max:     512 * 1024 * 1024,
+				Valid:   path.NewOrPanic("jsonpath::.spec.domain.this.path.does.not.exist"),
+				Min:     &path.IntOrPath{Int: 64 * 1024 * 1024},
+				Max:     &path.IntOrPath{Int: 512 * 1024 * 1024},
 			}
 
 			ra, err := r.Specialize(vmCirros, vmRef)
@@ -125,20 +126,20 @@ var _ = Describe("Specialized", func() {
 			r1 := Rule{
 				Rule:    IntegerRule,
 				Name:    "EnoughMemory",
-				Path:    "jsonpath::.spec.domain.resources.requests.memory",
+				Path:    *path.NewOrPanic("jsonpath::.spec.domain.resources.requests.memory"),
 				Message: "Memory size not specified",
-				Valid:   "jsonpath::.spec.domain.this.path.does.not.exist",
-				Min:     512 * 1024 * 1024,
+				Valid:   path.NewOrPanic("jsonpath::.spec.domain.this.path.does.not.exist"),
+				Min:     &path.IntOrPath{Int: 512 * 1024 * 1024},
 			}
 			expectRuleApplicationFailure(&r1, vmCirros, vmRef)
 
 			r2 := Rule{
 				Rule:    IntegerRule,
 				Name:    "EnoughMemory",
-				Path:    "jsonpath::.spec.domain.resources.requests.memory",
+				Path:    *path.NewOrPanic("jsonpath::.spec.domain.resources.requests.memory"),
 				Message: "Memory size not specified",
-				Valid:   "jsonpath::.spec.domain.this.path.does.not.exist",
-				Max:     64 * 1024 * 1024,
+				Valid:   path.NewOrPanic("jsonpath::.spec.domain.this.path.does.not.exist"),
+				Max:     &path.IntOrPath{Int: 64 * 1024 * 1024},
 			}
 			expectRuleApplicationFailure(&r2, vmCirros, vmRef)
 		})
@@ -147,18 +148,18 @@ var _ = Describe("Specialized", func() {
 			r1 := Rule{
 				Rule:      StringRule,
 				Name:      "HasChipset",
-				Path:      "jsonpath::.spec.domain.machine.type",
+				Path:      *path.NewOrPanic("jsonpath::.spec.domain.machine.type"),
 				Message:   "machine type must be specified",
-				MinLength: 64,
+				MinLength: &path.IntOrPath{Int: 64},
 			}
 			expectRuleApplicationFailure(&r1, vmCirros, vmRef)
 
 			r2 := Rule{
 				Rule:      StringRule,
 				Name:      "HasChipset",
-				Path:      "jsonpath::.spec.domain.machine.type",
+				Path:      *path.NewOrPanic("jsonpath::.spec.domain.machine.type"),
 				Message:   "machine type must be specified",
-				MaxLength: 1,
+				MaxLength: &path.IntOrPath{Int: 1},
 			}
 			expectRuleApplicationFailure(&r2, vmCirros, vmRef)
 		})
@@ -167,9 +168,9 @@ var _ = Describe("Specialized", func() {
 			r := Rule{
 				Rule:    EnumRule,
 				Name:    "SupportedChipset",
-				Path:    "jsonpath::.spec.domain.machine.type",
+				Path:    *path.NewOrPanic("jsonpath::.spec.domain.machine.type"),
 				Message: "machine type must be a supported value",
-				Values:  []string{"foo", "bar"},
+				Values:  []path.StringOrPath{{Str: "foo"}, {Str: "bar"}},
 			}
 			expectRuleApplicationFailure(&r, vmCirros, vmRef)
 		})
@@ -178,9 +179,9 @@ var _ = Describe("Specialized", func() {
 			r := Rule{
 				Rule:    EnumRule,
 				Name:    "SupportedDiskBus",
-				Path:    "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+				Path:    *path.NewOrPanic("jsonpath::.spec.domain.devices.disks[*].disk.bus"),
 				Message: "disk bus must be a supported value",
-				Values:  []string{"foo", "bar"},
+				Values:  []path.StringOrPath{{Str: "foo"}, {Str: "bar"}},
 			}
 			expectRuleApplicationFailure(&r, vmCirros, vmRef)
 		})
@@ -190,9 +191,9 @@ var _ = Describe("Specialized", func() {
 			r := Rule{
 				Rule:    EnumRule,
 				Name:    "SupportedDiskBus",
-				Path:    "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+				Path:    *path.NewOrPanic("jsonpath::.spec.domain.devices.disks[*].disk.bus"),
 				Message: "disk bus must be a supported value",
-				Values:  []string{"virtio"},
+				Values:  []path.StringOrPath{{Str: "virtio"}},
 			}
 			expectRuleApplicationError(&r, vmCirros, vmRef)
 		})
@@ -201,7 +202,7 @@ var _ = Describe("Specialized", func() {
 			r := Rule{
 				Rule:    RegexRule,
 				Name:    "SupportedChipset",
-				Path:    "jsonpath::.spec.domain.machine.type",
+				Path:    *path.NewOrPanic("jsonpath::.spec.domain.machine.type"),
 				Message: "machine type must be a supported value",
 				Regex:   "\\d[a-z]+\\d\\d",
 			}
@@ -212,7 +213,7 @@ var _ = Describe("Specialized", func() {
 			r := Rule{
 				Rule:    RegexRule,
 				Name:    "SupportedDiskBus",
-				Path:    "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+				Path:    *path.NewOrPanic("jsonpath::.spec.domain.devices.disks[*].disk.bus"),
 				Message: "disk bus must be a supported value",
 				Regex:   "foo|bar",
 			}
@@ -224,7 +225,7 @@ var _ = Describe("Specialized", func() {
 			r := Rule{
 				Rule:    RegexRule,
 				Name:    "SupportedDiskBus",
-				Path:    "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+				Path:    *path.NewOrPanic("jsonpath::.spec.domain.devices.disks[*].disk.bus"),
 				Message: "disk bus must be a supported value",
 				Regex:   "virtio|sata",
 			}
@@ -239,10 +240,10 @@ var _ = Describe("Specialized", func() {
 			r := Rule{
 				Rule:    IntegerRule,
 				Name:    "EnoughMemory",
-				Path:    "jsonpath::.spec.domain.resources.requests.memory",
+				Path:    *path.NewOrPanic("jsonpath::.spec.domain.resources.requests.memory"),
 				Message: "Memory size not specified",
-				Min:     64 * 1024 * 1024,
-				Max:     512 * 1024 * 1024,
+				Min:     &path.IntOrPath{Int: 64 * 1024 * 1024},
+				Max:     &path.IntOrPath{Int: 512 * 1024 * 1024},
 			}
 			ra, err := r.Specialize(vmCirros, vmRef)
 			Expect(err).To(BeNil())
@@ -264,10 +265,10 @@ var _ = Describe("Specialized", func() {
 			r := Rule{
 				Rule:    IntegerRule,
 				Name:    "EnoughMemory",
-				Path:    "jsonpath::.spec.domain.resources.requests.memory",
+				Path:    *path.NewOrPanic("jsonpath::.spec.domain.resources.requests.memory"),
 				Message: "Memory size not specified",
-				Min:     64 * 1024 * 1024,
-				Max:     512 * 1024 * 1024,
+				Min:     &path.IntOrPath{Int: 64 * 1024 * 1024},
+				Max:     &path.IntOrPath{Int: 512 * 1024 * 1024},
 			}
 			ra, err := r.Specialize(vmCirros, vmRef)
 			Expect(err).To(BeNil())
@@ -289,10 +290,10 @@ var _ = Describe("Specialized", func() {
 			r := Rule{
 				Rule:    IntegerRule,
 				Name:    "EnoughMemory",
-				Path:    "jsonpath::.spec.domain.resources.requests.memory",
+				Path:    *path.NewOrPanic("jsonpath::.spec.domain.resources.requests.memory"),
 				Message: "Memory size not specified",
-				Min:     64 * 1024 * 1024,
-				Max:     512 * 1024 * 1024,
+				Min:     &path.IntOrPath{Int: 64 * 1024 * 1024},
+				Max:     &path.IntOrPath{Int: 512 * 1024 * 1024},
 			}
 			ra, err := r.Specialize(vmCirros, vmRef)
 			Expect(err).To(BeNil())

--- a/internal/template-validator/validation/specialized_test.go
+++ b/internal/template-validator/validation/specialized_test.go
@@ -24,7 +24,7 @@ var _ = Describe("Specialized", func() {
 
 		It("Should apply simple integer rules", func() {
 			r := Rule{
-				Rule:    "integer",
+				Rule:    IntegerRule,
 				Name:    "EnoughMemory",
 				Path:    "jsonpath::.spec.domain.resources.requests.memory",
 				Message: "Memory size not specified",
@@ -36,7 +36,7 @@ var _ = Describe("Specialized", func() {
 
 		It("Should apply simple string rules", func() {
 			r := Rule{
-				Rule:      "string",
+				Rule:      StringRule,
 				Name:      "HasChipset",
 				Path:      "jsonpath::.spec.domain.machine.type",
 				Message:   "machine type must be specified",
@@ -48,7 +48,7 @@ var _ = Describe("Specialized", func() {
 
 		It("Should apply simple enum rules", func() {
 			r := Rule{
-				Rule:    "enum",
+				Rule:    EnumRule,
 				Name:    "SupportedChipset",
 				Path:    "jsonpath::.spec.domain.machine.type",
 				Message: "machine type must be a supported value",
@@ -59,7 +59,7 @@ var _ = Describe("Specialized", func() {
 
 		It("Should apply enum rule to multiple values", func() {
 			r := Rule{
-				Rule:    "enum",
+				Rule:    EnumRule,
 				Name:    "SupportedDiskBus",
 				Path:    "jsonpath::.spec.domain.devices.disks[*].disk.bus",
 				Message: "disk bus must be a supported value",
@@ -70,7 +70,7 @@ var _ = Describe("Specialized", func() {
 
 		It("Should apply simple regex rules", func() {
 			r := Rule{
-				Rule:    "regex",
+				Rule:    RegexRule,
 				Name:    "SupportedChipset",
 				Path:    "jsonpath::.spec.domain.machine.type",
 				Message: "machine type must be a supported value",
@@ -81,7 +81,7 @@ var _ = Describe("Specialized", func() {
 
 		It("Should apply regex rule to multiple values", func() {
 			r := Rule{
-				Rule:    "regex",
+				Rule:    RegexRule,
 				Name:    "SupportedDiskBus",
 				Path:    "jsonpath::.spec.domain.devices.disks[*].disk.bus",
 				Message: "disk bus must be a supported value",
@@ -121,7 +121,7 @@ var _ = Describe("Specialized", func() {
 
 		It("Should fail simple integer rules", func() {
 			r1 := Rule{
-				Rule:    "integer",
+				Rule:    IntegerRule,
 				Name:    "EnoughMemory",
 				Path:    "jsonpath::.spec.domain.resources.requests.memory",
 				Message: "Memory size not specified",
@@ -131,7 +131,7 @@ var _ = Describe("Specialized", func() {
 			expectRuleApplicationFailure(&r1, vmCirros, vmRef)
 
 			r2 := Rule{
-				Rule:    "integer",
+				Rule:    IntegerRule,
 				Name:    "EnoughMemory",
 				Path:    "jsonpath::.spec.domain.resources.requests.memory",
 				Message: "Memory size not specified",
@@ -143,7 +143,7 @@ var _ = Describe("Specialized", func() {
 
 		It("Should apply simple string rules", func() {
 			r1 := Rule{
-				Rule:      "string",
+				Rule:      StringRule,
 				Name:      "HasChipset",
 				Path:      "jsonpath::.spec.domain.machine.type",
 				Message:   "machine type must be specified",
@@ -152,7 +152,7 @@ var _ = Describe("Specialized", func() {
 			expectRuleApplicationFailure(&r1, vmCirros, vmRef)
 
 			r2 := Rule{
-				Rule:      "string",
+				Rule:      StringRule,
 				Name:      "HasChipset",
 				Path:      "jsonpath::.spec.domain.machine.type",
 				Message:   "machine type must be specified",
@@ -163,7 +163,7 @@ var _ = Describe("Specialized", func() {
 
 		It("Should apply simple enum rules", func() {
 			r := Rule{
-				Rule:    "enum",
+				Rule:    EnumRule,
 				Name:    "SupportedChipset",
 				Path:    "jsonpath::.spec.domain.machine.type",
 				Message: "machine type must be a supported value",
@@ -174,7 +174,7 @@ var _ = Describe("Specialized", func() {
 
 		It("Should apply enum rule to multiple values", func() {
 			r := Rule{
-				Rule:    "enum",
+				Rule:    EnumRule,
 				Name:    "SupportedDiskBus",
 				Path:    "jsonpath::.spec.domain.devices.disks[*].disk.bus",
 				Message: "disk bus must be a supported value",
@@ -186,7 +186,7 @@ var _ = Describe("Specialized", func() {
 		It("Should error enum rule if values do not exist", func() {
 			vmCirros.Spec.Template.Spec.Domain.Devices.Disks = nil
 			r := Rule{
-				Rule:    "enum",
+				Rule:    EnumRule,
 				Name:    "SupportedDiskBus",
 				Path:    "jsonpath::.spec.domain.devices.disks[*].disk.bus",
 				Message: "disk bus must be a supported value",
@@ -197,7 +197,7 @@ var _ = Describe("Specialized", func() {
 
 		It("Should apply simple regex rules", func() {
 			r := Rule{
-				Rule:    "regex",
+				Rule:    RegexRule,
 				Name:    "SupportedChipset",
 				Path:    "jsonpath::.spec.domain.machine.type",
 				Message: "machine type must be a supported value",
@@ -208,7 +208,7 @@ var _ = Describe("Specialized", func() {
 
 		It("Should apply regex rule to multiple values", func() {
 			r := Rule{
-				Rule:    "regex",
+				Rule:    RegexRule,
 				Name:    "SupportedDiskBus",
 				Path:    "jsonpath::.spec.domain.devices.disks[*].disk.bus",
 				Message: "disk bus must be a supported value",
@@ -220,7 +220,7 @@ var _ = Describe("Specialized", func() {
 		It("Should error regex rule if values do not exist", func() {
 			vmCirros.Spec.Template.Spec.Domain.Devices.Disks = nil
 			r := Rule{
-				Rule:    "regex",
+				Rule:    RegexRule,
 				Name:    "SupportedDiskBus",
 				Path:    "jsonpath::.spec.domain.devices.disks[*].disk.bus",
 				Message: "disk bus must be a supported value",
@@ -235,7 +235,7 @@ var _ = Describe("Specialized", func() {
 			}
 
 			r := Rule{
-				Rule:    "integer",
+				Rule:    IntegerRule,
 				Name:    "EnoughMemory",
 				Path:    "jsonpath::.spec.domain.resources.requests.memory",
 				Message: "Memory size not specified",
@@ -260,7 +260,7 @@ var _ = Describe("Specialized", func() {
 			}
 
 			r := Rule{
-				Rule:    "integer",
+				Rule:    IntegerRule,
 				Name:    "EnoughMemory",
 				Path:    "jsonpath::.spec.domain.resources.requests.memory",
 				Message: "Memory size not specified",
@@ -285,7 +285,7 @@ var _ = Describe("Specialized", func() {
 			}
 
 			r := Rule{
-				Rule:    "integer",
+				Rule:    IntegerRule,
 				Name:    "EnoughMemory",
 				Path:    "jsonpath::.spec.domain.resources.requests.memory",
 				Message: "Memory size not specified",

--- a/internal/template-validator/validation/test-utils/utils.go
+++ b/internal/template-validator/validation/test-utils/utils.go
@@ -1,4 +1,4 @@
-package validation
+package test_utils
 
 import (
 	"bytes"

--- a/internal/template-validator/webhooks/admission_test.go
+++ b/internal/template-validator/webhooks/admission_test.go
@@ -11,6 +11,7 @@ import (
 
 	"kubevirt.io/ssp-operator/internal/template-validator/labels"
 	"kubevirt.io/ssp-operator/internal/template-validator/validation"
+	"kubevirt.io/ssp-operator/internal/template-validator/validation/path"
 )
 
 var _ = Describe("Admission", func() {
@@ -48,10 +49,10 @@ var _ = Describe("Admission", func() {
 		It("should set default sockets", func() {
 			rules := []validation.Rule{{
 				Name:    "test-sockets-default",
-				Path:    "jsonpath::.spec.domain.cpu.sockets",
+				Path:    *path.NewOrPanic("jsonpath::.spec.domain.cpu.sockets"),
 				Rule:    "integer",
 				Message: "invalid number of sockets",
-				Min:     1,
+				Min:     &path.IntOrPath{Int: 1},
 			}}
 
 			causes := ValidateVm(rules, &vm)
@@ -61,10 +62,10 @@ var _ = Describe("Admission", func() {
 		It("should set default cores", func() {
 			rules := []validation.Rule{{
 				Name:    "test-cores-default",
-				Path:    "jsonpath::.spec.domain.cpu.cores",
+				Path:    *path.NewOrPanic("jsonpath::.spec.domain.cpu.cores"),
 				Rule:    "integer",
 				Message: "invalid number of cores",
-				Min:     1,
+				Min:     &path.IntOrPath{Int: 1},
 			}}
 
 			causes := ValidateVm(rules, &vm)
@@ -74,10 +75,10 @@ var _ = Describe("Admission", func() {
 		It("should set default threads", func() {
 			rules := []validation.Rule{{
 				Name:    "test-threads-default",
-				Path:    "jsonpath::.spec.domain.cpu.threads",
+				Path:    *path.NewOrPanic("jsonpath::.spec.domain.cpu.threads"),
 				Rule:    "integer",
 				Message: "invalid number of threads",
-				Min:     1,
+				Min:     &path.IntOrPath{Int: 1},
 			}}
 
 			causes := ValidateVm(rules, &vm)
@@ -90,6 +91,7 @@ var _ = Describe("Admission", func() {
 			ruleName := "vmRule"
 			rules, err := json.Marshal([]validation.Rule{{
 				Name: ruleName,
+				Path: *path.NewOrPanic("jsonpath::.test.path"),
 			}})
 			Expect(err).ToNot(HaveOccurred())
 
@@ -108,6 +110,7 @@ var _ = Describe("Admission", func() {
 
 			Expect(len(vmRules)).To(Equal(1))
 			Expect(vmRules[0].Name).To(Equal(ruleName))
+			Expect(vmRules[0].Path.Expr()).To(Equal(".test.path"))
 		})
 	})
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR contains these code changes:
- Created `RuleType` type to emulate enum.
- Split `validation.Path` struct into 2 structs `Path` and `Results`
- `Rule` struct uses specific types instead of generic `string` and `interface{}`

**Release note**:
```release-note
None
```
