### PR TITLE
Add "name" labels to deployments and pods

### DIFF
--- a/config/manager/manager.template.yaml
+++ b/config/manager/manager.template.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: kubevirt
   labels:
     control-plane: ssp-operator
+    name: ssp-operator
 spec:
   selector:
     matchLabels:
@@ -14,6 +15,7 @@ spec:
     metadata:
       labels:
         control-plane: ssp-operator
+        name: ssp-operator
         prometheus.kubevirt.io: ""
     spec:
       serviceAccountName: ssp-operator

--- a/data/olm-catalog/ssp-operator.clusterserviceversion.yaml
+++ b/data/olm-catalog/ssp-operator.clusterserviceversion.yaml
@@ -342,6 +342,7 @@ spec:
             metadata:
               labels:
                 control-plane: ssp-operator
+                name: ssp-operator
                 prometheus.kubevirt.io: ""
             spec:
               containers:

--- a/internal/operands/template-validator/resources.go
+++ b/internal/operands/template-validator/resources.go
@@ -40,12 +40,6 @@ func commonLabels() map[string]string {
 	}
 }
 
-func podLabels() map[string]string {
-	labels := commonLabels()
-	labels[PrometheusLabel] = ""
-	return labels
-}
-
 func getTemplateValidatorImage() string {
 	return common.EnvOrDefault(common.TemplateValidatorImageKey, defaultTemplateValidatorImage)
 }
@@ -127,12 +121,16 @@ func newDeployment(namespace string, replicas int32, image string) *apps.Deploym
 	const certMountPath = "/etc/webhook/certs"
 	trueVal := true
 
+	podLabels := commonLabels()
+	podLabels[PrometheusLabel] = ""
+	podLabels["name"] = DeploymentName
+
 	return &apps.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      DeploymentName,
 			Namespace: namespace,
 			Labels: map[string]string{
-				"name": VirtTemplateValidator,
+				"name": DeploymentName,
 			},
 		},
 		Spec: apps.DeploymentSpec{
@@ -143,7 +141,7 @@ func newDeployment(namespace string, replicas int32, image string) *apps.Deploym
 			Template: core.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:   VirtTemplateValidator,
-					Labels: podLabels(),
+					Labels: podLabels,
 				},
 				Spec: core.PodSpec{
 					ServiceAccountName: ServiceAccountName,


### PR DESCRIPTION
**What this PR does / why we need it**:
Added `name` label to `ssp-operator`, and `virt-template-validator` deployments and pods.

**Which issue(s) this PR fixes**: 
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1998656

**Release note**:
```release-note
None
```
