### PR TITLE
Enable changing of namespace during run of ssp operator

### DIFF
--- a/api/v1beta1/ssp_webhook.go
+++ b/api/v1beta1/ssp_webhook.go
@@ -85,13 +85,6 @@ func (r *SSP) ValidateCreate() error {
 func (r *SSP) ValidateUpdate(old runtime.Object) error {
 	ssplog.Info("validate update", "name", r.Name)
 
-	oldSsp := old.(*SSP)
-	if r.Spec.CommonTemplates.Namespace != oldSsp.Spec.CommonTemplates.Namespace {
-		return fmt.Errorf("commonTemplates.namespace cannot be changed. Attempting to change from: %v to %v",
-			oldSsp.Spec.CommonTemplates.Namespace,
-			r.Spec.CommonTemplates.Namespace)
-	}
-
 	if err := validatePlacement(r); err != nil {
 		return errors.Wrap(err, "placement api validation error")
 	}

--- a/api/v1beta1/ssp_webhook_test.go
+++ b/api/v1beta1/ssp_webhook_test.go
@@ -119,7 +119,7 @@ var _ = Describe("SSP Validation", func() {
 		})
 	})
 
-	It("should not allow update of commonTemplates.namespace", func() {
+	It("should allow update of commonTemplates.namespace", func() {
 		oldSsp := &SSP{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-ssp",
@@ -136,8 +136,7 @@ var _ = Describe("SSP Validation", func() {
 		newSsp.Spec.CommonTemplates.Namespace = "new-ns"
 
 		err := newSsp.ValidateUpdate(oldSsp)
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("commonTemplates.namespace cannot be changed."))
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	Context("DataImportCronTemplates", func() {

--- a/tests/webhook_test.go
+++ b/tests/webhook_test.go
@@ -157,14 +157,6 @@ var _ = Describe("Validation webhook", func() {
 			strategy.RevertToOriginalSspCr()
 		})
 
-		It("[test_id:6057] should fail to update commonTemplates.namespace", func() {
-			originalNs := foundSsp.Spec.CommonTemplates.Namespace
-			foundSsp.Spec.CommonTemplates.Namespace = originalNs + "-updated"
-			err := apiClient.Update(ctx, foundSsp)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("commonTemplates.namespace cannot be changed."))
-		})
-
 		Context("Placement API validation", func() {
 			It("[test_id:5990]should succeed with valid template-validator placement fields", func() {
 				foundSsp.Spec.TemplateValidator.Placement = &placementAPIValidationValidPlacement


### PR DESCRIPTION
**What this PR does / why we need it**:
Enable changing of namespace during run of ssp operator
/cc @akrejcir @rnetser 

**Which issue(s) this PR fixes**: 
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1958085

**Special notes for your reviewer**:

**Release note**:
```
Enable changing of namespace during run of ssp operator
```
Signed-off-by: Karel Šimon <ksimon@redhat.com>
