### PR TITLE
Add total_restored_common_templates metrics

### DIFF
--- a/internal/common/resource_test.go
+++ b/internal/common/resource_test.go
@@ -156,7 +156,7 @@ var _ = Describe("Create or update resource", func() {
 	})
 })
 
-func createOrUpdateTestResource(request *Request) (ResourceStatus, error) {
+func createOrUpdateTestResource(request *Request) (ReconcileResult, error) {
 	return CreateOrUpdate(request).
 		NamespacedResource(newTestResource(namespace)).
 		UpdateFunc(func(expected, found client.Object) {

--- a/internal/operands/metrics/reconcile.go
+++ b/internal/operands/metrics/reconcile.go
@@ -30,7 +30,7 @@ func (m *metrics) WatchClusterTypes() []client.Object {
 	return nil
 }
 
-func (m *metrics) Reconcile(request *common.Request) ([]common.ResourceStatus, error) {
+func (m *metrics) Reconcile(request *common.Request) ([]common.ReconcileResult, error) {
 	return common.CollectResourceStatus(request,
 		reconcilePrometheusRule,
 	)
@@ -51,7 +51,7 @@ const (
 	operandComponent = common.AppComponentMonitoring
 )
 
-func reconcilePrometheusRule(request *common.Request) (common.ResourceStatus, error) {
+func reconcilePrometheusRule(request *common.Request) (common.ReconcileResult, error) {
 	return common.CreateOrUpdate(request).
 		NamespacedResource(newPrometheusRule(request.Namespace)).
 		WithAppLabels(operandName, operandComponent).

--- a/internal/operands/node-labeller/reconcile.go
+++ b/internal/operands/node-labeller/reconcile.go
@@ -60,8 +60,8 @@ func (nl *nodeLabeller) WatchClusterTypes() []client.Object {
 }
 
 //Reconsile deletes all node-labeller component, because labeller is migrated into kubevirt core.
-func (nl *nodeLabeller) Reconcile(request *common.Request) ([]common.ResourceStatus, error) {
-	returnResults := make([]common.ResourceStatus, 0)
+func (nl *nodeLabeller) Reconcile(request *common.Request) ([]common.ReconcileResult, error) {
+	returnResults := make([]common.ReconcileResult, 0)
 	for _, obj := range []controllerutil.Object{
 		newClusterRole(),
 		newServiceAccount(request.Namespace),
@@ -74,9 +74,9 @@ func (nl *nodeLabeller) Reconcile(request *common.Request) ([]common.ResourceSta
 
 		if err != nil && !errors.IsNotFound(err) {
 			request.Logger.Error(err, fmt.Sprintf("Error deleting \"%s\": %s", obj.GetName(), err))
-			return []common.ResourceStatus{}, err
+			return []common.ReconcileResult{}, err
 		}
-		returnResults = append(returnResults, common.ResourceStatus{})
+		returnResults = append(returnResults, common.ReconcileResult{})
 	}
 	return returnResults, nil
 }
@@ -107,7 +107,7 @@ const (
 	operandComponent = common.AppComponentSchedule
 )
 
-func reconcileClusterRole(request *common.Request) (common.ResourceStatus, error) {
+func reconcileClusterRole(request *common.Request) (common.ReconcileResult, error) {
 	return common.CreateOrUpdate(request).
 		ClusterResource(newClusterRole()).
 		WithAppLabels(operandName, operandComponent).
@@ -117,14 +117,14 @@ func reconcileClusterRole(request *common.Request) (common.ResourceStatus, error
 		Reconcile()
 }
 
-func reconcileServiceAccount(request *common.Request) (common.ResourceStatus, error) {
+func reconcileServiceAccount(request *common.Request) (common.ReconcileResult, error) {
 	return common.CreateOrUpdate(request).
 		NamespacedResource(newServiceAccount(request.Namespace)).
 		WithAppLabels(operandName, operandComponent).
 		Reconcile()
 }
 
-func reconcileClusterRoleBinding(request *common.Request) (common.ResourceStatus, error) {
+func reconcileClusterRoleBinding(request *common.Request) (common.ReconcileResult, error) {
 	return common.CreateOrUpdate(request).
 		ClusterResource(newClusterRoleBinding(request.Namespace)).
 		WithAppLabels(operandName, operandComponent).
@@ -137,7 +137,7 @@ func reconcileClusterRoleBinding(request *common.Request) (common.ResourceStatus
 		Reconcile()
 }
 
-func reconcileConfigMap(request *common.Request) (common.ResourceStatus, error) {
+func reconcileConfigMap(request *common.Request) (common.ReconcileResult, error) {
 	return common.CreateOrUpdate(request).
 		NamespacedResource(newConfigMap(request.Namespace)).
 		WithAppLabels(operandName, operandComponent).
@@ -147,14 +147,14 @@ func reconcileConfigMap(request *common.Request) (common.ResourceStatus, error) 
 		Reconcile()
 }
 
-func reconcileDaemonSet(request *common.Request) (common.ResourceStatus, error) {
+func reconcileDaemonSet(request *common.Request) (common.ReconcileResult, error) {
 	daemonSet := newDaemonSet(request.Namespace)
 	status, err := createOrUpdateDaemonSet(request, daemonSet)
 
 	return status, err
 }
 
-func createOrUpdateDaemonSet(request *common.Request, daemonSet *apps.DaemonSet) (common.ResourceStatus, error) {
+func createOrUpdateDaemonSet(request *common.Request, daemonSet *apps.DaemonSet) (common.ReconcileResult, error) {
 	return common.CreateOrUpdate(request).
 		NamespacedResource(daemonSet).
 		WithAppLabels(operandName, operandComponent).
@@ -177,7 +177,7 @@ func createOrUpdateDaemonSet(request *common.Request, daemonSet *apps.DaemonSet)
 		Reconcile()
 }
 
-func reconcileSecurityContextConstraint(request *common.Request) (common.ResourceStatus, error) {
+func reconcileSecurityContextConstraint(request *common.Request) (common.ReconcileResult, error) {
 	return common.CreateOrUpdate(request).
 		ClusterResource(newSecurityContextConstraint(request.Namespace)).
 		WithAppLabels(operandName, operandComponent).

--- a/internal/operands/operand.go
+++ b/internal/operands/operand.go
@@ -14,7 +14,7 @@ type Operand interface {
 	WatchClusterTypes() []client.Object
 
 	// Reconcile creates and updates resources.
-	Reconcile(*common.Request) ([]common.ResourceStatus, error)
+	Reconcile(*common.Request) ([]common.ReconcileResult, error)
 
 	// Cleanup removes any created cluster resources.
 	// They don't use owner references, so the garbage collector will not remove them.

--- a/internal/operands/template-validator/reconcile.go
+++ b/internal/operands/template-validator/reconcile.go
@@ -2,6 +2,7 @@ package template_validator
 
 import (
 	"fmt"
+
 	admission "k8s.io/api/admissionregistration/v1"
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -46,7 +47,7 @@ func (t *templateValidator) WatchClusterTypes() []client.Object {
 	}
 }
 
-func (t *templateValidator) Reconcile(request *common.Request) ([]common.ResourceStatus, error) {
+func (t *templateValidator) Reconcile(request *common.Request) ([]common.ReconcileResult, error) {
 	return common.CollectResourceStatus(request,
 		reconcileClusterRole,
 		reconcileServiceAccount,
@@ -83,7 +84,7 @@ const (
 	operandComponent = common.AppComponentTemplating
 )
 
-func reconcileClusterRole(request *common.Request) (common.ResourceStatus, error) {
+func reconcileClusterRole(request *common.Request) (common.ReconcileResult, error) {
 	return common.CreateOrUpdate(request).
 		ClusterResource(newClusterRole()).
 		WithAppLabels(operandName, operandComponent).
@@ -93,14 +94,14 @@ func reconcileClusterRole(request *common.Request) (common.ResourceStatus, error
 		Reconcile()
 }
 
-func reconcileServiceAccount(request *common.Request) (common.ResourceStatus, error) {
+func reconcileServiceAccount(request *common.Request) (common.ReconcileResult, error) {
 	return common.CreateOrUpdate(request).
 		NamespacedResource(newServiceAccount(request.Namespace)).
 		WithAppLabels(operandName, operandComponent).
 		Reconcile()
 }
 
-func reconcileClusterRoleBinding(request *common.Request) (common.ResourceStatus, error) {
+func reconcileClusterRoleBinding(request *common.Request) (common.ReconcileResult, error) {
 	return common.CreateOrUpdate(request).
 		ClusterResource(newClusterRoleBinding(request.Namespace)).
 		WithAppLabels(operandName, operandComponent).
@@ -113,7 +114,7 @@ func reconcileClusterRoleBinding(request *common.Request) (common.ResourceStatus
 		Reconcile()
 }
 
-func reconcileService(request *common.Request) (common.ResourceStatus, error) {
+func reconcileService(request *common.Request) (common.ReconcileResult, error) {
 	return common.CreateOrUpdate(request).
 		NamespacedResource(newService(request.Namespace)).
 		WithAppLabels(operandName, operandComponent).
@@ -129,7 +130,7 @@ func reconcileService(request *common.Request) (common.ResourceStatus, error) {
 		Reconcile()
 }
 
-func reconcileDeployment(request *common.Request) (common.ResourceStatus, error) {
+func reconcileDeployment(request *common.Request) (common.ReconcileResult, error) {
 	validatorSpec := request.Instance.Spec.TemplateValidator
 	image := getTemplateValidatorImage()
 	if image == "" {
@@ -175,7 +176,7 @@ func addPlacementFields(deployment *apps.Deployment, nodePlacement *lifecycleapi
 	podSpec.Tolerations = nodePlacement.Tolerations
 }
 
-func reconcileValidatingWebhook(request *common.Request) (common.ResourceStatus, error) {
+func reconcileValidatingWebhook(request *common.Request) (common.ReconcileResult, error) {
 	return common.CreateOrUpdate(request).
 		ClusterResource(newValidatingWebhook(request.Namespace)).
 		WithAppLabels(operandName, operandComponent).

--- a/internal/operands/template-validator/reconcile_test.go
+++ b/internal/operands/template-validator/reconcile_test.go
@@ -141,7 +141,7 @@ var _ = Describe("Template validator operand", func() {
 	})
 
 	It("should report status", func() {
-		statuses, err := operand.Reconcile(&request)
+		reconcileResults, err := operand.Reconcile(&request)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Set status for deployment
@@ -154,19 +154,19 @@ var _ = Describe("Template validator operand", func() {
 			deployment.Status.UnavailableReplicas = replicas
 		})
 
-		statuses, err = operand.Reconcile(&request)
+		reconcileResults, err = operand.Reconcile(&request)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Only deployment should be progressing
-		for _, status := range statuses {
-			if _, ok := status.Resource.(*apps.Deployment); ok {
-				Expect(status.NotAvailable).ToNot(BeNil())
-				Expect(status.Progressing).ToNot(BeNil())
-				Expect(status.Degraded).ToNot(BeNil())
+		for _, reconcileResult := range reconcileResults {
+			if _, ok := reconcileResult.Resource.(*apps.Deployment); ok {
+				Expect(reconcileResult.Status.NotAvailable).ToNot(BeNil())
+				Expect(reconcileResult.Status.Progressing).ToNot(BeNil())
+				Expect(reconcileResult.Status.Degraded).ToNot(BeNil())
 			} else {
-				Expect(status.NotAvailable).To(BeNil())
-				Expect(status.Progressing).To(BeNil())
-				Expect(status.Degraded).To(BeNil())
+				Expect(reconcileResult.Status.NotAvailable).To(BeNil())
+				Expect(reconcileResult.Status.Progressing).To(BeNil())
+				Expect(reconcileResult.Status.Degraded).To(BeNil())
 			}
 		}
 
@@ -178,14 +178,14 @@ var _ = Describe("Template validator operand", func() {
 			deployment.Status.UnavailableReplicas = 0
 		})
 
-		statuses, err = operand.Reconcile(&request)
+		reconcileResults, err = operand.Reconcile(&request)
 		Expect(err).ToNot(HaveOccurred())
 
 		// All resources should be available
-		for _, status := range statuses {
-			Expect(status.NotAvailable).To(BeNil())
-			Expect(status.Progressing).To(BeNil())
-			Expect(status.Degraded).To(BeNil())
+		for _, reconcileResult := range reconcileResults {
+			Expect(reconcileResult.Status.NotAvailable).To(BeNil())
+			Expect(reconcileResult.Status.Progressing).To(BeNil())
+			Expect(reconcileResult.Status.Degraded).To(BeNil())
 		}
 	})
 })

--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ import (
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
+	common_templates "kubevirt.io/ssp-operator/internal/operands/common-templates"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -64,6 +65,7 @@ const (
 
 func runPrometheusServer(metricsAddr string) {
 	setupLog.Info("Starting Prometheus metrics endpoint server with TLS")
+	metrics.Registry.MustRegister(common_templates.CommonTemplatesRestored)
 	handler := promhttp.HandlerFor(metrics.Registry, promhttp.HandlerOpts{})
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", handler)


### PR DESCRIPTION
Add a metric that increases when a common template is updated during
the reconcile step of the common_templates operand.

Signed-off-by: borod108 <boris.od@gmail.com>

```release-note
Added metric named total_restored_common_templates that counts the number of common templates updated during reconcile.
```
