### PR TITLE
Fix alert levels

### DIFF
--- a/internal/operands/metrics/resources.go
+++ b/internal/operands/metrics/resources.go
@@ -45,7 +45,7 @@ func newPrometheusRule(namespace string) *promv1.PrometheusRule {
 								"runbook_url": "https://kubevirt.io/monitoring/runbooks/SSPOperatorDown",
 							},
 							Labels: map[string]string{
-								"severity": "Critical",
+								"severity": "critical",
 							},
 						},
 						{
@@ -57,7 +57,7 @@ func newPrometheusRule(namespace string) *promv1.PrometheusRule {
 								"runbook_url": "https://kubevirt.io/monitoring/runbooks/SSPTemplateValidatorDown",
 							},
 							Labels: map[string]string{
-								"severity": "Critical",
+								"severity": "critical",
 							},
 						},
 						{
@@ -73,7 +73,7 @@ func newPrometheusRule(namespace string) *promv1.PrometheusRule {
 								"runbook_url": "https://kubevirt.io/monitoring/runbooks/SSPHighRateRejectedVms",
 							},
 							Labels: map[string]string{
-								"severity": "Warn",
+								"severity": "warning",
 							},
 						},
 					},


### PR DESCRIPTION
Change alert levels in accordance with the conventions.

Signed-off-by: borod108 <boris.od@gmail.com>

```release-note
Alert levels will now be consistent with the general convention. "critical" instead of "Critical" and "warning" instead of "Warn".
```
