### PR TITLE
Increase golang version to 1.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Build the manager binary
 FROM registry.access.redhat.com/ubi8/ubi-minimal as builder
 
-RUN microdnf install -y make golang-1.15.* which && microdnf clean all
+RUN microdnf install -y make golang-1.16.* which && microdnf clean all
 
 # Consume required variables so we can work with make
 ARG IMG_REPOSITORY

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module kubevirt.io/ssp-operator
 
-go 1.15
+go 1.16
 
 require (
 	github.com/blang/semver/v4 v4.0.0

--- a/validator.Dockerfile
+++ b/validator.Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal as builder
 
-RUN microdnf install -y golang-1.15.* && microdnf clean all
+RUN microdnf install -y golang-1.16.* && microdnf clean all
 
 ARG VERSION=latest
 ARG COMPONENT="kubevirt-template-validator"


### PR DESCRIPTION
**What this PR does / why we need it**:
The `golang-1.16` package is now available in `ubi8/ubi-minimal` image.


**Release note**:
```release-note
Increased Golang version to 1.16
```
