### PR TITLE
change ACTIONS_TOKEN to secrets.GITHUB_TOKEN

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
         id: get_release
         uses: bruceadams/get-release@v1.2.2
         env:
-          GITHUB_TOKEN: ${{ secrets.ACTIONS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish operator image and generate release assets
         run: |
@@ -30,7 +30,7 @@ jobs:
         id: upload-crd-asset 
         uses: actions/upload-release-asset@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.ACTIONS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.get_release.outputs.upload_url }}
           asset_path: ./_out/olm-crds.yaml
@@ -41,7 +41,7 @@ jobs:
         id: upload-csv-asset 
         uses: actions/upload-release-asset@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.ACTIONS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.get_release.outputs.upload_url }}
           asset_path: ./_out/olm-ssp-operator.clusterserviceversion.yaml
@@ -52,7 +52,7 @@ jobs:
         id: upload-operator-asset 
         uses: actions/upload-release-asset@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.ACTIONS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.get_release.outputs.upload_url }}
           asset_path: ./_out/ssp-operator.yaml


### PR DESCRIPTION
**What this PR does / why we need it**:
change ACTIONS_TOKEN to secrets.GITHUB_TOKEN
with this change github actions will use one time token, which is
created and deleted during action run.
More info here: https://docs.github.com/en/actions/security-guides/automatic-token-authentication
**Special notes for your reviewer**:

**Release note**:
```
NONE
```
Signed-off-by: Karel Šimon <ksimon@redhat.com>
