### PR TITLE
Fix csv-generator's invalid YAML output

### DIFF
--- a/hack/csv-generator.go
+++ b/hack/csv-generator.go
@@ -23,7 +23,6 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"strings"
 
 	"github.com/blang/semver/v4"
 	gyaml "github.com/ghodss/yaml"
@@ -289,17 +288,6 @@ func marshallObject(obj interface{}, relatedImages []interface{}, writer io.Writ
 	if err != nil {
 		return err
 	}
-
-	// fix templates by removing unneeded single quotes...
-	s := string(yamlBytes)
-	s = strings.Replace(s, "'{{", "{{", -1)
-	s = strings.Replace(s, "}}'", "}}", -1)
-
-	// fix double quoted strings by removing unneeded single quotes...
-	s = strings.Replace(s, " '\"", " \"", -1)
-	s = strings.Replace(s, "\"'\n", "\"\n", -1)
-
-	yamlBytes = []byte(s)
 
 	_, err = writer.Write([]byte("---\n"))
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
`csv-generator` was doing string operations on YAML document, which could produce invalid YAML. This patch removes these operations.

This was the invalid transformation:
`'DataVolumeContentType options: "kubevirt", "archive"'` -> `'DataVolumeContentType options: "kubevirt", "archive"`

It removed the `'` at the end, making this an invalid string.

**Release note**:
```release-note
None
```
