### PR TITLE
Fix Alerts firing, metrics missing bug

### DIFF
--- a/config/manager/manager.template.yaml
+++ b/config/manager/manager.template.yaml
@@ -16,7 +16,7 @@ spec:
       labels:
         control-plane: ssp-operator
         name: ssp-operator
-        prometheus.kubevirt.io: ""
+        prometheus.kubevirt.io: "true"
     spec:
       serviceAccountName: ssp-operator
       priorityClassName: system-cluster-critical

--- a/data/olm-catalog/ssp-operator.clusterserviceversion.yaml
+++ b/data/olm-catalog/ssp-operator.clusterserviceversion.yaml
@@ -367,7 +367,7 @@ spec:
               labels:
                 control-plane: ssp-operator
                 name: ssp-operator
-                prometheus.kubevirt.io: ""
+                prometheus.kubevirt.io: "true"
             spec:
               containers:
               - args:

--- a/internal/operands/template-validator/resources.go
+++ b/internal/operands/template-validator/resources.go
@@ -122,7 +122,7 @@ func newDeployment(namespace string, replicas int32, image string) *apps.Deploym
 	trueVal := true
 
 	podLabels := commonLabels()
-	podLabels[PrometheusLabel] = ""
+	podLabels[PrometheusLabel] = "true"
 	podLabels["name"] = DeploymentName
 
 	return &apps.Deployment{


### PR DESCRIPTION
The selector of the kubevirt servicemonitor changed,
as a result the metrics are not picked up by Prometheus,
and the Alert malfunction.
Changing the labels of ssp and operand pods accordingly.

Signed-off-by: borod108 <boris.od@gmail.com>
```release-note
NONE
```