### PR TITLE
Add initial controller to watch missing CRDs

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -23,7 +23,9 @@ rules:
   resources:
   - customresourcedefinitions
   verbs:
+  - get
   - list
+  - watch
 - apiGroups:
   - apps
   resources:

--- a/controllers/crd_controller.go
+++ b/controllers/crd_controller.go
@@ -1,0 +1,101 @@
+package controllers
+
+import (
+	"context"
+	"sync"
+
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	"kubevirt.io/ssp-operator/controllers/finishable"
+)
+
+// +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch
+
+func CreateCrdController(mgr controllerruntime.Manager, requiredCrds []string) (finishable.Controller, error) {
+	crds := make(map[string]bool, len(requiredCrds))
+	for _, crd := range requiredCrds {
+		crds[crd] = false
+	}
+
+	reconciler := &waitForCrds{
+		client: mgr.GetClient(),
+		crds:   crds,
+	}
+
+	initCtrl, err := finishable.NewController("init-controller", mgr, reconciler)
+	if err != nil {
+		return nil, err
+	}
+
+	err = initCtrl.Watch(&source.Kind{Type: &extv1.CustomResourceDefinition{}}, &handler.EnqueueRequestForObject{})
+	if err != nil {
+		return nil, err
+	}
+
+	return initCtrl, nil
+}
+
+type waitForCrds struct {
+	client client.Client
+
+	lock sync.RWMutex
+	crds map[string]bool
+}
+
+var _ finishable.Reconciler = &waitForCrds{}
+
+func (w *waitForCrds) Reconcile(ctx context.Context, request reconcile.Request) (finishable.Result, error) {
+	crdExists := true
+	crd := &extv1.CustomResourceDefinition{}
+	err := w.client.Get(ctx, request.NamespacedName, crd)
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return finishable.Result{}, err
+		}
+		crdExists = false
+	}
+
+	// If CRD is being deleted, we treat it as not existing.
+	if !crd.GetDeletionTimestamp().IsZero() {
+		crdExists = false
+	}
+
+	key := request.NamespacedName.Name
+	if w.isCrdRequired(key) {
+		w.setCrdExists(key, crdExists)
+	}
+
+	return finishable.Result{Finished: w.allCrdsExist()}, nil
+}
+
+func (w *waitForCrds) isCrdRequired(key string) bool {
+	w.lock.RLock()
+	defer w.lock.RUnlock()
+
+	_, exists := w.crds[key]
+	return exists
+}
+
+func (w *waitForCrds) setCrdExists(key string, val bool) {
+	w.lock.Lock()
+	defer w.lock.Unlock()
+
+	w.crds[key] = val
+}
+
+func (w *waitForCrds) allCrdsExist() bool {
+	w.lock.RLock()
+	defer w.lock.RUnlock()
+
+	allExist := true
+	for _, exists := range w.crds {
+		allExist = allExist && exists
+	}
+	return allExist
+}

--- a/controllers/finishable/finishable.go
+++ b/controllers/finishable/finishable.go
@@ -1,0 +1,84 @@
+package finishable
+
+import (
+	"context"
+
+	ctrl "sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+// Reconciler interface extends reconcile.Reconciler interface
+// with the option to stop the reconciliation.
+type Reconciler interface {
+	Reconcile(context.Context, reconcile.Request) (Result, error)
+}
+
+type Controller interface {
+	manager.Runnable
+
+	Watch(src source.Source, eventhandler handler.EventHandler, predicates ...predicate.Predicate) error
+}
+
+type Result struct {
+	reconcile.Result
+	Finished bool
+}
+
+type wrapper struct {
+	reconciler Reconciler
+	stopFunc   func()
+}
+
+var _ reconcile.Reconciler = &wrapper{}
+
+func (w *wrapper) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	res, err := w.reconciler.Reconcile(ctx, request)
+	if res.Finished {
+		w.stopFunc()
+	}
+	return res.Result, err
+}
+
+type controller struct {
+	reconcilerWrapper *wrapper
+	innerController   ctrl.Controller
+}
+
+var _ Controller = &controller{}
+
+func (c *controller) Watch(src source.Source, eventhandler handler.EventHandler, predicates ...predicate.Predicate) error {
+	return c.innerController.Watch(src, eventhandler, predicates...)
+}
+
+func (c *controller) Start(ctx context.Context) error {
+	innerCtx, innerCtxCancel := context.WithCancel(ctx)
+	// Using defer here in case the fllowing innerController.Start()
+	// will end with an error. In that case the context would not be closed.
+	// Closing a context multiple times is supported.
+	defer innerCtxCancel()
+
+	c.reconcilerWrapper.stopFunc = innerCtxCancel
+
+	return c.innerController.Start(innerCtx)
+}
+
+// NewController returns a controller that can be stopped from the Reconciler implementation.
+func NewController(name string, mgr manager.Manager, reconciler Reconciler) (Controller, error) {
+	wrap := &wrapper{reconciler: reconciler}
+
+	innerController, err := ctrl.NewUnmanaged(name, mgr, ctrl.Options{
+		Reconciler: wrap,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &controller{
+		reconcilerWrapper: wrap,
+		innerController:   innerController,
+	}, nil
+}

--- a/controllers/setup.go
+++ b/controllers/setup.go
@@ -1,0 +1,89 @@
+package controllers
+
+import (
+	"context"
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"path/filepath"
+
+	"kubevirt.io/ssp-operator/internal/operands"
+	"kubevirt.io/ssp-operator/internal/operands/common-templates"
+	"kubevirt.io/ssp-operator/internal/operands/data-sources"
+	"kubevirt.io/ssp-operator/internal/operands/metrics"
+	"kubevirt.io/ssp-operator/internal/operands/node-labeller"
+	"kubevirt.io/ssp-operator/internal/operands/template-validator"
+	"sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+func CreateAndSetupReconciler(mgr controllerruntime.Manager) error {
+	templatesFile := filepath.Join(templateBundleDir, "common-templates-"+common_templates.Version+".yaml")
+	templatesBundle, err := common_templates.ReadTemplates(templatesFile)
+	if err != nil {
+		return err
+	}
+
+	sspOperands := []operands.Operand{
+		metrics.New(),
+		template_validator.New(),
+		common_templates.New(templatesBundle),
+		data_sources.New(),
+		node_labeller.New(),
+	}
+
+	var requiredCrds []string
+	for i := range sspOperands {
+		requiredCrds = append(requiredCrds, sspOperands[i].RequiredCrds()...)
+	}
+
+	// Check if all needed CRDs exist
+	crdList := &extv1.CustomResourceDefinitionList{}
+	err = mgr.GetAPIReader().List(context.TODO(), crdList)
+	if err != nil {
+		return err
+	}
+
+	reconciler := NewSspReconciler(mgr.GetClient(), sspOperands)
+
+	if requiredCrdsExist(requiredCrds, crdList.Items) {
+		// No need to start CRD controller
+		return reconciler.setupController(mgr)
+	}
+
+	mgr.GetLogger().Info("Required CRDs do not exist. Waiting until they are installed.",
+		"required_crds", requiredCrds,
+	)
+
+	crdController, err := CreateCrdController(mgr, requiredCrds)
+	if err != nil {
+		return err
+	}
+
+	return mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
+		// First start the CRD controller
+		err := crdController.Start(ctx)
+		if err != nil {
+			return err
+		}
+
+		mgr.GetLogger().Info("Required CRDs were installed, starting SSP operator.")
+
+		// Clear variable, so it can be garbage collected
+		crdController = nil
+
+		// After it is finished, add the SSP controller to the manager
+		return reconciler.setupController(mgr)
+	}))
+}
+
+func requiredCrdsExist(required []string, foundCrds []extv1.CustomResourceDefinition) bool {
+OuterLoop:
+	for i := range required {
+		for j := range foundCrds {
+			if required[i] == foundCrds[j].Name {
+				continue OuterLoop
+			}
+		}
+		return false
+	}
+	return true
+}

--- a/data/olm-catalog/ssp-operator.clusterserviceversion.yaml
+++ b/data/olm-catalog/ssp-operator.clusterserviceversion.yaml
@@ -67,7 +67,9 @@ spec:
           resources:
           - customresourcedefinitions
           verbs:
+          - get
           - list
+          - watch
         - apiGroups:
           - apps
           resources:

--- a/internal/common/scheme.go
+++ b/internal/common/scheme.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -15,5 +16,6 @@ var (
 
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(Scheme))
+	utilruntime.Must(extv1.AddToScheme(Scheme))
 	utilruntime.Must(sspv1beta1.AddToScheme(Scheme))
 }

--- a/internal/operands/common-templates/reconcile.go
+++ b/internal/operands/common-templates/reconcile.go
@@ -72,6 +72,10 @@ func (c *commonTemplates) WatchTypes() []client.Object {
 	return nil
 }
 
+func (c *commonTemplates) RequiredCrds() []string {
+	return nil
+}
+
 func (c *commonTemplates) Reconcile(request *common.Request) ([]common.ReconcileResult, error) {
 	oldTemplateFuncs, err := reconcileOlderTemplates(request)
 	if err != nil {

--- a/internal/operands/data-sources/reconcile.go
+++ b/internal/operands/data-sources/reconcile.go
@@ -67,6 +67,14 @@ func (d *dataSources) WatchClusterTypes() []client.Object {
 	return WatchClusterTypes()
 }
 
+func (d *dataSources) RequiredCrds() []string {
+	return []string{
+		"datavolumes.cdi.kubevirt.io",
+		"datasources.cdi.kubevirt.io",
+		"dataimportcrons.cdi.kubevirt.io",
+	}
+}
+
 func (d *dataSources) Reconcile(request *common.Request) ([]common.ReconcileResult, error) {
 	funcs := []common.ReconcileFunc{
 		reconcileGoldenImagesNS,

--- a/internal/operands/metrics/reconcile.go
+++ b/internal/operands/metrics/reconcile.go
@@ -34,6 +34,10 @@ func (m *metrics) WatchClusterTypes() []client.Object {
 	return nil
 }
 
+func (m *metrics) RequiredCrds() []string {
+	return []string{"prometheusrules.monitoring.coreos.com"}
+}
+
 func (m *metrics) Reconcile(request *common.Request) ([]common.ReconcileResult, error) {
 	return common.CollectResourceStatus(request,
 		reconcilePrometheusRule,

--- a/internal/operands/node-labeller/reconcile.go
+++ b/internal/operands/node-labeller/reconcile.go
@@ -66,6 +66,10 @@ func (nl *nodeLabeller) WatchClusterTypes() []client.Object {
 	return WatchClusterTypes()
 }
 
+func (nl *nodeLabeller) RequiredCrds() []string {
+	return nil
+}
+
 //Reconsile deletes all node-labeller component, because labeller is migrated into kubevirt core.
 func (nl *nodeLabeller) Reconcile(request *common.Request) ([]common.ReconcileResult, error) {
 	// Not using common.DeleteAll(), because these resources

--- a/internal/operands/operand.go
+++ b/internal/operands/operand.go
@@ -13,6 +13,9 @@ type Operand interface {
 	// WatchClusterTypes returns a slice of cluster resources, that the operator should watch.
 	WatchClusterTypes() []client.Object
 
+	// RequiredCrds returns names of CRDs, that need to be installed for the operand to work.
+	RequiredCrds() []string
+
 	// Reconcile creates and updates resources.
 	Reconcile(*common.Request) ([]common.ReconcileResult, error)
 

--- a/internal/operands/template-validator/reconcile.go
+++ b/internal/operands/template-validator/reconcile.go
@@ -54,6 +54,10 @@ func (t *templateValidator) WatchClusterTypes() []client.Object {
 	return WatchClusterTypes()
 }
 
+func (t *templateValidator) RequiredCrds() []string {
+	return nil
+}
+
 func (t *templateValidator) Reconcile(request *common.Request) ([]common.ReconcileResult, error) {
 	return common.CollectResourceStatus(request,
 		reconcileClusterRole,

--- a/main.go
+++ b/main.go
@@ -121,7 +121,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err = controllers.CreateAndSetupSspReconciler(mgr); err != nil {
+	if err = controllers.CreateAndSetupReconciler(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "SSP")
 		os.Exit(1)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
If not all needed CRDs are installed, a controller that watches and waits for CRDs will be started.
When CRDs are installed, the initial controller will exit and the SSP controller will start.

These CRDs are needed:
- `datavolumes.cdi.kubevirt.io`
- `datasources.cdi.kubevirt.io`
- `dataimportcrons.cdi.kubevirt.io`
- `prometheusrules.monitoring.coreos.com` (is installed with OCP)

Without this PR, the SSP controller would fail to watch the resources if their CRDs do not exist, and the application would exit with an error. Which would cause the operator deployment to enter a crash loop.

**Release note**:
```release-note
The operator waits until all needed CRDs are installed.
```
