### PR TITLE
Improve SSPCommonTemplatesModificationReverted Alert

### DIFF
--- a/internal/operands/common-templates/reconcile.go
+++ b/internal/operands/common-templates/reconcile.go
@@ -91,6 +91,7 @@ func (c *commonTemplates) Reconcile(request *common.Request) ([]common.Reconcile
 	upgradingNow := isUpgradingNow(request)
 	for _, r := range reconcileTemplatesResults {
 		if !upgradingNow && (r.OperationResult == controllerutil.OperationResultUpdated) {
+			request.Logger.V(1).Info(fmt.Sprintf("Changes reverted in common template: %s", r.Resource.GetName()))
 			CommonTemplatesRestored.Inc()
 		}
 	}

--- a/internal/operands/metrics/resources.go
+++ b/internal/operands/metrics/resources.go
@@ -99,7 +99,7 @@ func newPrometheusRule(namespace string) *promv1.PrometheusRule {
 						{
 							Alert: "SSPCommonTemplatesModificationReverted",
 							Expr:  intstr.FromString("kubevirt_ssp_total_restored_common_templates > 0"),
-							For:   "5m",
+							For:   "0m",
 							Annotations: map[string]string{
 								"summary":     "Common Templates manual modifications were reverted by the operator",
 								"runbook_url": "https://kubevirt.io/monitoring/runbooks/SSPCommonTemplatesModificationReverted",


### PR DESCRIPTION
Alert changed to fire right away without pending.
Add a log line to know which template was reverted.

Signed-off-by: borod108 <boris.od@gmail.com>

```release-note
SSPCommonTemplatesModificationReverted chnaged to fire without a delay.
Added log line "Changes reverted in common template: <template name>" to see which template was reverted.
```