### PR TITLE
Parse VM from Template using Unstructured

### DIFF
--- a/internal/template-bundle/bundle_test.go
+++ b/internal/template-bundle/bundle_test.go
@@ -20,7 +20,7 @@ var _ = Describe("Template bundle", func() {
 
 	It("should correctly read templates", func() {
 		templates := testBundle.Templates
-		Expect(templates).To(HaveLen(2))
+		Expect(templates).To(HaveLen(3))
 
 		templ1 := templates[0]
 		Expect(templ1.Name).To(Equal("centos8-server-medium"))
@@ -31,6 +31,11 @@ var _ = Describe("Template bundle", func() {
 		Expect(templ2.Name).To(Equal("windows10-desktop-medium"))
 		Expect(templ2.Annotations).To(HaveKey("name.os.template.kubevirt.io/win10"))
 		Expect(templ2.Objects).To(HaveLen(1))
+
+		templ3 := templates[2]
+		Expect(templ3.Name).To(Equal("rhel8-saphana-tiny"))
+		Expect(templ3.Annotations).To(HaveKey("name.os.template.kubevirt.io/rhel8.4"))
+		Expect(templ3.Objects).To(HaveLen(1))
 	})
 
 	It("should create DataSources", func() {

--- a/internal/template-bundle/template-bundle-test.yaml
+++ b/internal/template-bundle/template-bundle-test.yaml
@@ -302,3 +302,208 @@ parameters:
   - name: SRC_PVC_NAMESPACE
     description: Namespace of the DataSource
     value: kubevirt-os-images
+---
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: rhel8-saphana-tiny
+  annotations:
+    openshift.io/display-name: "Red Hat Enterprise Linux 8.4 VM for SAP HANA workloads"
+    description: >-
+      Template for Red Hat Enterprise Linux 8.4 for SAP HANA workloads.
+      Please consult the SAP HANA guide for node setup requirements.
+    tags: "hidden,kubevirt,virtualmachine,linux,rhel,sap,hana"
+    iconClass: "icon-rhel"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    name.os.template.kubevirt.io/rhel8.4: Red Hat Enterprise Linux 8.0 or higher
+  labels:
+    os.template.kubevirt.io/rhel8.4: "true"
+    workload.template.kubevirt.io/saphana: "true"
+    flavor.template.kubevirt.io/tiny: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.18.1"
+objects:
+  - apiVersion: kubevirt.io/v1
+    kind: VirtualMachine
+    metadata:
+      labels:
+        vm.kubevirt.io/template: rhel8-saphana-tiny
+        vm.kubevirt.io/template.version: "v0.18.1"
+        vm.kubevirt.io/template.revision: "4"
+        app: ${NAME}
+      name: ${NAME}
+      annotations:
+        vm.kubevirt.io/validations: |
+          [
+             {
+               "name": "minimal-required-memory",
+               "path": "jsonpath::.spec.domain.resources.requests.memory",
+               "rule": "integer",
+               "message": "This VM requires more memory.",
+               "min": 1610612736
+             }
+          ]
+    spec:
+      dataVolumeTemplates:
+        - apiVersion: cdi.kubevirt.io/v1beta1
+          kind: DataVolume
+          metadata:
+            name: ${NAME}
+          spec:
+            storage:
+              resources:
+                requests:
+                  storage: 50Gi
+            source:
+              registry:
+                url: ${SRC_CONTAINERDISK}
+                pullMethod: node
+      running: false
+      template:
+        metadata:
+          annotations:
+            vm.kubevirt.io/os: "rhel8"
+            vm.kubevirt.io/workload: "saphana"
+            vm.kubevirt.io/flavor: "tiny"
+          labels:
+            kubevirt.io/domain: ${NAME}
+            kubevirt.io/size: tiny
+        spec:
+          hostname: ${NAME}
+          domain:
+            ioThreadsPolicy: auto
+            cpu:
+              cores: ${{CPU_CORES}}
+              threads: ${{CPU_THREADS}}
+              sockets: ${{CPU_SOCKETS}}
+              model: host-passthrough
+              isolateEmulatorThread: true
+              dedicatedCpuPlacement: true
+              features:
+                - name: "invtsc"
+                  policy: "require"
+              numa:
+                guestMappingPassthrough : {}
+            devices:
+              blockMultiQueue: true
+              networkInterfaceMultiqueue: true
+              disks:
+                - disk:
+                    bus: virtio
+                  dedicatedIOThread: true
+                  name: ${NAME}
+                - disk:
+                    bus: virtio
+                  name: cloudinitdisk
+                - disk:
+                    bus: virtio
+                  name: downwardmetrics
+              interfaces:
+                - masquerade: {}
+                  name: default
+                  model: virtio
+                - name: sriov-net1
+                  sriov: {}
+                  model: virtio
+                - name: sriov-net2
+                  sriov: {}
+                  model: virtio
+                - name: sriov-net3
+                  sriov: {}
+                  model: virtio
+            machine:
+              type: ""
+            resources:
+              requests:
+                memory: ${MEMORY_OVERHEAD}
+            memory:
+              guest: ${MEMORY}
+              hugepages:
+                pageSize: ${HUGEPAGES_PAGE_SIZE}
+          terminationGracePeriodSeconds: 3600
+          volumes:
+            - dataVolume:
+                name: ${NAME}
+              name: ${NAME}
+            - cloudInitNoCloud:
+                userData: |-
+                  #cloud-config
+                  user: cloud-user
+                  password: ${CLOUD_USER_PASSWORD}
+                  chpasswd: { expire: False }
+              name: cloudinitdisk
+            - downwardMetrics: {}
+              name: downwardmetrics
+          networks:
+            - name: default
+              pod: {}
+            - multus:
+                networkName: ${SRIOV_NETWORK_NAME1}
+              name: sriov-net1
+            - multus:
+                networkName: ${SRIOV_NETWORK_NAME2}
+              name: sriov-net2
+            - multus:
+                networkName: ${SRIOV_NETWORK_NAME3}
+              name: sriov-net3
+          nodeSelector:
+            kubernetes.io/hostname: ${TARGET_NODE_NAME}
+parameters:
+  - description: Name for the new VM
+    displayName: Name
+    name: NAME
+    required: true
+  - description: Name of the node where this VM needs to run
+    displayName: Target Node
+    name: TARGET_NODE_NAME
+    required: true
+  - description: Amount of memory
+    displayName: Memory
+    name: MEMORY
+    value: 24Gi
+  - description: Amount of memory overhead for qemu
+    displayName: Memory Overhead
+    name: MEMORY_OVERHEAD
+    value: 44Gi
+  - description: Amount of cores
+    displayName: CPU Cores
+    name: CPU_CORES
+    value: "4"
+  - description: Amount of threads
+    displayName: CPU Threads
+    name: CPU_THREADS
+    value: "1"
+  - description: Amount of sockets
+    displayName: CPU Sockets
+    name: CPU_SOCKETS
+    value: "1"
+  - description: Name of the SR-IOV network1
+    displayName: SR-IOV network1
+    name: SRIOV_NETWORK_NAME1
+    value: "default/sriov-net1"
+  - description: Name of the SR-IOV network2
+    displayName: SR-IOV network2
+    name: SRIOV_NETWORK_NAME2
+    value: "default/sriov-net2"
+  - description: Name of the SR-IOV network3
+    displayName: SR-IOV network3
+    name: SRIOV_NETWORK_NAME3
+    value: "default/sriov-net3"
+  - description: Page size of huge pages
+    displayName: Huge page size
+    name: HUGEPAGES_PAGE_SIZE
+    value: "1Gi"
+  - name: SRC_CONTAINERDISK
+    description: Name of the source container disk to import
+    displayName: Source container disk
+    value: "docker://registry.access.redhat.com/rhel8/rhel-guest-image:8.4.0"
+  - description: Randomized password for the cloud-init user cloud-user
+    displayName: Cloud user password
+    from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+    generate: expression
+    name: CLOUD_USER_PASSWORD


### PR DESCRIPTION
**What this PR does / why we need it**:
Parsing the VM template directly into `VirtualMachine` object may not always succeed, because the template can have parameters in places where the `VirtualMachine` definition does not allow strings.

This patch parses the template into `Unstructured` object.

**Release note**:
```release-note
None
```
