### PR TITLE
Re-enable DataImportCronTests

### DIFF
--- a/tests/dataSources_test.go
+++ b/tests/dataSources_test.go
@@ -641,8 +641,7 @@ var _ = Describe("DataSources", func() {
 		})
 	})
 
-	// TODO: add back when https://bugzilla.redhat.com/show_bug.cgi?id=2035008 is fixed
-	PContext("DataImportCron", func() {
+	Context("DataImportCron", func() {
 		const cronSchedule = "* * * * *"
 		var registryURL = "docker://quay.io/kubevirt/cirros-container-disk-demo"
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The bug in CDI that made them fail was fixed.

https://bugzilla.redhat.com/show_bug.cgi?id=2035008


**Release note**:
```release-note
None
```
