### PR TITLE
Delete immutable resources only if immutable part was changed

### DIFF
--- a/internal/operands/common-templates/reconcile.go
+++ b/internal/operands/common-templates/reconcile.go
@@ -11,7 +11,6 @@ import (
 	"k8s.io/apimachinery/pkg/selection"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"kubevirt.io/ssp-operator/internal/common"
 	"kubevirt.io/ssp-operator/internal/operands"
@@ -90,7 +89,7 @@ func (c *commonTemplates) Reconcile(request *common.Request) ([]common.Reconcile
 
 	upgradingNow := isUpgradingNow(request)
 	for _, r := range reconcileTemplatesResults {
-		if !upgradingNow && (r.OperationResult == controllerutil.OperationResultUpdated) {
+		if !upgradingNow && (r.OperationResult == common.OperationResultUpdated) {
 			request.Logger.V(1).Info(fmt.Sprintf("Changes reverted in common template: %s", r.Resource.GetName()))
 			CommonTemplatesRestored.Inc()
 		}

--- a/internal/operands/data-sources/reconcile.go
+++ b/internal/operands/data-sources/reconcile.go
@@ -218,10 +218,12 @@ func reconcileDataImportCrons(request *common.Request) ([]common.ReconcileFunc, 
 		funcs = append(funcs, func(request *common.Request) (common.ReconcileResult, error) {
 			return common.CreateOrUpdate(request).
 				ClusterResource(&cron).
-				SetImmutable(true).
 				WithAppLabels(operandName, operandComponent).
 				UpdateFunc(func(newRes, foundRes client.Object) {
 					foundRes.(*cdiv1beta1.DataImportCron).Spec = newRes.(*cdiv1beta1.DataImportCron).Spec
+				}).
+				ImmutableSpec(func(resource client.Object) interface{} {
+					return resource.(*cdiv1beta1.DataImportCron).Spec
 				}).
 				Reconcile()
 		})


### PR DESCRIPTION
**What this PR does / why we need it**:
Usually only the `.spec` field of resource is immutable, `.metadata` and `.status` can be updated.
With this PR, the resource is only deleted, if `.spec` is changed, otherwise it is updated.


**Which issue(s) this PR fixes**: 
Partially fixes bug: https://bugzilla.redhat.com/show_bug.cgi?id=2037290

**Release note**:
```release-note
None
```
