### PR TITLE
README.md: Remove node labeller functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@ Operator that manages Scheduling, Scale and Performance addons for [KubeVirt](ht
 
 The operator deploys and manages resources needed by these four components:
 
-- [Template Validator](https://github.com/kubevirt/ssp-operator/tree/master/internal/template-validator) (You can read more about it here: [Template Validator old repository](https://github.com/kubevirt/kubevirt-template-validator)
-- [Node Labeller](https://github.com/kubevirt/node-labeller)
+- [Template Validator](https://github.com/kubevirt/ssp-operator/tree/master/internal/template-validator) (You can read more about it here: [Template Validator old repository](https://github.com/kubevirt/kubevirt-template-validator))
 - [Common Templates Bundle](https://github.com/kubevirt/common-templates)
 - Metrics rules - Currently it is only a single Prometheus rule containing the count of all running VMs.
 


### PR DESCRIPTION
Node labeller is no longer provided by ssp-operator. It was moved to
kubevirt.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Update README.md to be correct.

**Which issue(s) this PR fixes**: 
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
