### PR TITLE
Do not create DataImportCron if DataSource points to an existing PVC

### DIFF
--- a/api/v1beta1/ssp_types.go
+++ b/api/v1beta1/ssp_types.go
@@ -73,7 +73,7 @@ type DataImportCronTemplate struct {
 }
 
 // AsDataImportCron converts the DataImportCronTemplate to a cdiv1beta1.DataImportCron
-func (t DataImportCronTemplate) AsDataImportCron() cdiv1beta1.DataImportCron {
+func (t *DataImportCronTemplate) AsDataImportCron() cdiv1beta1.DataImportCron {
 	return cdiv1beta1.DataImportCron{
 		ObjectMeta: t.ObjectMeta,
 		Spec:       t.Spec,

--- a/controllers/setup.go
+++ b/controllers/setup.go
@@ -50,7 +50,7 @@ func CreateAndSetupReconciler(mgr controllerruntime.Manager) error {
 		return err
 	}
 
-	reconciler := NewSspReconciler(mgr.GetClient(), infrastructureTopology, sspOperands)
+	reconciler := NewSspReconciler(mgr.GetClient(), mgr.GetAPIReader(), infrastructureTopology, sspOperands)
 
 	if requiredCrdsExist(requiredCrds, crdList.Items) {
 		// No need to start CRD controller

--- a/internal/common/request.go
+++ b/internal/common/request.go
@@ -13,12 +13,13 @@ import (
 
 type Request struct {
 	reconcile.Request
-	Client       client.Client
-	Context      context.Context
-	Instance     *ssp.SSP
-	Logger       logr.Logger
-	VersionCache VersionCache
-	TopologyMode osconfv1.TopologyMode
+	Client         client.Client
+	UncachedReader client.Reader
+	Context        context.Context
+	Instance       *ssp.SSP
+	Logger         logr.Logger
+	VersionCache   VersionCache
+	TopologyMode   osconfv1.TopologyMode
 }
 
 func (r *Request) IsSingleReplicaTopologyMode() bool {

--- a/internal/common/resource.go
+++ b/internal/common/resource.go
@@ -36,6 +36,12 @@ type ReconcileResult struct {
 	OperationResult OperationResult
 }
 
+func (r *ReconcileResult) IsSuccess() bool {
+	return r.Status.Progressing == nil &&
+		r.Status.NotAvailable == nil &&
+		r.Status.Degraded == nil
+}
+
 type CleanupResult struct {
 	Resource client.Object
 	Deleted  bool
@@ -170,7 +176,7 @@ func (r *reconcileBuilder) Reconcile() (ReconcileResult, error) {
 	}
 	if res == OperationResultDeleted || !found.GetDeletionTimestamp().IsZero() {
 		r.request.VersionCache.RemoveObj(found)
-		return resourceDeletedResult(r.resource, res), nil
+		return ResourceDeletedResult(r.resource, res), nil
 	}
 
 	r.request.VersionCache.Add(found)
@@ -397,7 +403,7 @@ func isResourceOwned(request *Request, expectedObj, foundObj client.Object) (boo
 	return false, nil
 }
 
-func resourceDeletedResult(resource client.Object, res OperationResult) ReconcileResult {
+func ResourceDeletedResult(resource client.Object, res OperationResult) ReconcileResult {
 	message := "Resource is being deleted."
 	return ReconcileResult{
 		Status: ResourceStatus{

--- a/internal/operands/data-sources/reconcile.go
+++ b/internal/operands/data-sources/reconcile.go
@@ -3,6 +3,7 @@ package data_sources
 import (
 	"fmt"
 
+	"github.com/operator-framework/operator-lib/handler"
 	core "k8s.io/api/core/v1"
 	rbac "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -89,38 +90,81 @@ func (d *dataSources) Reconcile(request *common.Request) ([]common.ReconcileResu
 		reconcileEditRole,
 	}
 
-	funcs = append(funcs, reconcileDataSources(d.sources, request.Instance.Spec.CommonTemplates.DataImportCronTemplates)...)
-
-	dataImportCronFuncs, err := reconcileDataImportCrons(request)
+	dsAndCrons, err := d.getManagedDataSourcesAndCrons(request)
 	if err != nil {
 		return nil, err
 	}
-	funcs = append(funcs, dataImportCronFuncs...)
 
-	return common.CollectResourceStatus(request, funcs...)
+	dsFuncs, err := reconcileDataSources(dsAndCrons.managedDataSources,
+		dsAndCrons.transitioningDataSources,
+		request)
+	if err != nil {
+		return nil, err
+	}
+	funcs = append(funcs, dsFuncs...)
+
+	results, err := common.CollectResourceStatus(request, funcs...)
+	if err != nil {
+		return nil, err
+	}
+
+	var allSucceeded = true
+	for i := range results {
+		if !results[i].IsSuccess() {
+			allSucceeded = false
+			break
+		}
+	}
+
+	// DataImportCrons can be reconciled only after all resources successfully reconciled.
+	if !allSucceeded {
+		return results, nil
+	}
+
+	dicFuncs, err := reconcileDataImportCrons(dsAndCrons.dataImportCrons, request)
+	if err != nil {
+		return nil, err
+	}
+
+	return common.CollectResourceStatus(request, dicFuncs...)
 }
 
 func (d *dataSources) Cleanup(request *common.Request) ([]common.CleanupResult, error) {
-	objects := []client.Object{
-		newGoldenImagesNS(ssp.GoldenImagesNSname),
-		newViewRole(ssp.GoldenImagesNSname),
-		newViewRoleBinding(ssp.GoldenImagesNSname),
-		newEditRole(),
+	ownedCrons, err := listAllOwnedDataImportCrons(request)
+	if err != nil {
+		return nil, err
 	}
 
+	results := []common.CleanupResult{}
+	allDataImportCronsDeleted := true
+	for i := range ownedCrons {
+		result, err := common.Cleanup(request, &ownedCrons[i])
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, result)
+		if !result.Deleted {
+			allDataImportCronsDeleted = false
+		}
+	}
+
+	// The rest of the objects will be deleted when all DataImportCrons are deleted.
+	if !allDataImportCronsDeleted {
+		return results, nil
+	}
+
+	objects := []client.Object{}
 	for i := range d.sources {
 		ds := d.sources[i]
 		ds.Namespace = ssp.GoldenImagesNSname
 		objects = append(objects, &ds)
 	}
 
-	ownedCrons, err := listAllOwnedDataImportCrons(request)
-	if err != nil {
-		return nil, err
-	}
-	for i := range ownedCrons {
-		objects = append(objects, &ownedCrons[i])
-	}
+	objects = append(objects,
+		newGoldenImagesNS(ssp.GoldenImagesNSname),
+		newViewRole(ssp.GoldenImagesNSname),
+		newViewRoleBinding(ssp.GoldenImagesNSname),
+		newEditRole())
 
 	return common.DeleteAll(request, objects...)
 }
@@ -169,78 +213,257 @@ func reconcileEditRole(request *common.Request) (common.ReconcileResult, error) 
 		Reconcile()
 }
 
-func reconcileDataSources(dataSources []cdiv1beta1.DataSource, crons []ssp.DataImportCronTemplate) []common.ReconcileFunc {
-	managedDataSources := map[string]struct{}{}
-	for i := range crons {
-		managedDataSources[crons[i].Spec.ManagedDataSource] = struct{}{}
-	}
-
-	funcs := make([]common.ReconcileFunc, 0, len(dataSources))
-	for i := range dataSources {
-		dataSource := dataSources[i] // Make a local copy
-		_, isManaged := managedDataSources[dataSource.Name]
-		funcs = append(funcs, func(request *common.Request) (common.ReconcileResult, error) {
-			dataSource.Namespace = ssp.GoldenImagesNSname
-			return common.CreateOrUpdate(request).
-				ClusterResource(&dataSource).
-				WithAppLabels(operandName, operandComponent).
-				UpdateFunc(func(newRes, foundRes client.Object) {
-					newDataSource := newRes.(*cdiv1beta1.DataSource)
-					foundDataSource := foundRes.(*cdiv1beta1.DataSource)
-
-					if isManaged {
-						// The source.pvc is set by a DataImportCron,
-						// and the operator must not overwrite it
-						if foundDataSource.Spec.Source.PVC != nil {
-							newDataSource.Spec.Source.PVC = foundDataSource.Spec.Source.PVC
-						}
-					}
-
-					foundDataSource.Spec = newDataSource.Spec
-				}).
-				Reconcile()
-		})
-	}
-	return funcs
+type dataSourcesAndCrons struct {
+	managedDataSources       []cdiv1beta1.DataSource
+	transitioningDataSources []cdiv1beta1.DataSource
+	dataImportCrons          []cdiv1beta1.DataImportCron
 }
 
-func reconcileDataImportCrons(request *common.Request) ([]common.ReconcileFunc, error) {
-	crons := map[string]cdiv1beta1.DataImportCron{}
-	for _, template := range request.Instance.Spec.CommonTemplates.DataImportCronTemplates {
-		crons[template.Name] = template.AsDataImportCron()
+func (d *dataSources) getManagedDataSourcesAndCrons(request *common.Request) (dataSourcesAndCrons, error) {
+	cronTemplates := request.Instance.Spec.CommonTemplates.DataImportCronTemplates
+	cronByDataSourceName := make(map[string]*ssp.DataImportCronTemplate, len(cronTemplates))
+	for i := range cronTemplates {
+		cron := &cronTemplates[i]
+		cronByDataSourceName[cron.Spec.ManagedDataSource] = cron
 	}
 
-	var funcs []common.ReconcileFunc
+	// DataSources managed by the SSP operator
+	var managedDataSources []cdiv1beta1.DataSource
+	var transitioningDataSources []cdiv1beta1.DataSource
+	for _, dataSource := range d.sources {
+		dataSource.Namespace = ssp.GoldenImagesNSname
+		managedState, err := dataSourceManaged(&dataSource, cronByDataSourceName, request)
+		if err != nil {
+			return dataSourcesAndCrons{}, err
+		}
+		switch managedState {
+		case managedDataSource:
+			managedDataSources = append(managedDataSources, dataSource)
+		case transitioningDataSource:
+			transitioningDataSources = append(transitioningDataSources, dataSource)
+		}
+	}
 
-	for _, cronLoopVar := range crons {
-		cron := cronLoopVar // Make a local copy
-		cron.Namespace = ssp.GoldenImagesNSname
+	for i := range managedDataSources {
+		delete(cronByDataSourceName, managedDataSources[i].GetName())
+	}
+
+	managedDataImportCrons := make([]cdiv1beta1.DataImportCron, 0, len(cronByDataSourceName))
+	for _, cronTemplate := range cronByDataSourceName {
+		managedDataImportCrons = append(managedDataImportCrons, cronTemplate.AsDataImportCron())
+	}
+
+	return dataSourcesAndCrons{
+		managedDataSources:       managedDataSources,
+		transitioningDataSources: transitioningDataSources,
+		dataImportCrons:          managedDataImportCrons,
+	}, nil
+}
+
+type dataSourceState string
+
+const (
+	// DataSource is managed by SSP operator
+	managedDataSource dataSourceState = "managedDataSource"
+
+	// DataSource is transitioning to not managed by SSP
+	transitioningDataSource dataSourceState = "transitioningDataSource"
+
+	// DataSource is not managed by SSP
+	unmanagedDataSource dataSourceState = "unmanagedDataSource"
+)
+
+func dataSourceManaged(dataSource *cdiv1beta1.DataSource, cronByDataSourceName map[string]*ssp.DataImportCronTemplate, request *common.Request) (dataSourceState, error) {
+	_, cronExists := cronByDataSourceName[dataSource.GetName()]
+	if !cronExists {
+		// If DataImportCron does not exist for this DataSource, SSP needs to reconcile it.
+		return managedDataSource, nil
+	}
+
+	// Check existing data source. The Get call uses cache.
+	foundDataSource := &cdiv1beta1.DataSource{}
+	err := request.Client.Get(request.Context, client.ObjectKeyFromObject(dataSource), foundDataSource)
+	if errors.IsNotFound(err) {
+		// Checking if PVC exists. This is an unchanged API call, but it is only called when DataSource
+		// does not exist, and there is a small number of DataSources reconciled by this operator.
+		err := request.UncachedReader.Get(request.Context, client.ObjectKey{
+			Name:      dataSource.Spec.Source.PVC.Name,
+			Namespace: dataSource.Spec.Source.PVC.Namespace,
+		}, &core.PersistentVolumeClaim{})
+		if errors.IsNotFound(err) {
+			// Referenced PVC does not exist. DataSource will be managed by DataImportCron.
+			return unmanagedDataSource, nil
+		}
+		if err != nil {
+			return "", err
+		}
+
+		// PVC referenced by this DataSource exists. DataSource is managed by SSP operator.
+		return managedDataSource, nil
+	}
+	if err != nil {
+		return "", err
+	}
+
+	const dicLabel = "cdi.kubevirt.io/dataImportCron"
+	if _, labelExists := foundDataSource.GetLabels()[dicLabel]; labelExists {
+		var isOwnedBySsp = common.CheckOwnerAnnotation(foundDataSource, request.Instance)
+		if isOwnedBySsp {
+			// This case happens when the label is added to a DataSource with existing PVC
+			return transitioningDataSource, nil
+		}
+		// This DataSource is managed by a DataImportCron
+		return unmanagedDataSource, nil
+	}
+
+	dsReadyCondition := getDataSourceReadyCondition(foundDataSource)
+	if dsReadyCondition != nil && dsReadyCondition.Status != core.ConditionTrue {
+		// DataSource is currently not managed by a DataImportCron,
+		// but it does not refer to an existing PVC. DataImportCron will manage it.
+		return transitioningDataSource, nil
+	}
+
+	// DataSource is currently not managed by a DataImportCron,
+	// and it refers to an existing PVC. SSP will manage it.
+	return managedDataSource, nil
+}
+
+func reconcileDataSources(managedDataSources []cdiv1beta1.DataSource, transitioningDataSources []cdiv1beta1.DataSource, request *common.Request) ([]common.ReconcileFunc, error) {
+	ownedDataSources, err := listAllOwnedDataSources(request)
+	if err != nil {
+		return nil, err
+	}
+
+	dsNames := make(map[string]struct{}, len(managedDataSources)+len(transitioningDataSources))
+
+	var funcs []common.ReconcileFunc
+	for i := range managedDataSources {
+		dataSource := managedDataSources[i] // Make a local copy
 		funcs = append(funcs, func(request *common.Request) (common.ReconcileResult, error) {
-			return common.CreateOrUpdate(request).
-				ClusterResource(&cron).
-				WithAppLabels(operandName, operandComponent).
-				UpdateFunc(func(newRes, foundRes client.Object) {
-					foundRes.(*cdiv1beta1.DataImportCron).Spec = newRes.(*cdiv1beta1.DataImportCron).Spec
-				}).
-				ImmutableSpec(func(resource client.Object) interface{} {
-					return resource.(*cdiv1beta1.DataImportCron).Spec
-				}).
-				Reconcile()
+			return reconcileDataSource(&dataSource, request)
+		})
+		dsNames[dataSource.GetName()] = struct{}{}
+	}
+
+	for i := range transitioningDataSources {
+		dataSource := transitioningDataSources[i] // Make a local copy
+		funcs = append(funcs, func(request *common.Request) (common.ReconcileResult, error) {
+			foundDataSource := &cdiv1beta1.DataSource{}
+			err := request.Client.Get(request.Context, client.ObjectKeyFromObject(&dataSource), foundDataSource)
+			if err != nil && !errors.IsNotFound(err) {
+				return common.ReconcileResult{}, err
+			}
+
+			result := common.ReconcileResult{
+				Resource:        &dataSource,
+				OperationResult: common.OperationResultNone,
+			}
+
+			if common.CheckOwnerAnnotation(foundDataSource, request.Instance) {
+				delete(foundDataSource.GetAnnotations(), handler.TypeAnnotation)
+				delete(foundDataSource.GetAnnotations(), handler.NamespacedNameAnnotation)
+				err := request.Client.Update(request.Context, foundDataSource)
+				if err != nil && !errors.IsNotFound(err) {
+					return common.ReconcileResult{}, err
+				}
+				result.OperationResult = common.OperationResultUpdated
+			}
+
+			return result, nil
+		})
+		dsNames[dataSource.GetName()] = struct{}{}
+	}
+
+	// Remove owned DataSources that are not in the 'managedDataSources' or 'transitioningDataSources'
+	for i := range ownedDataSources {
+		if _, isUsed := dsNames[ownedDataSources[i].GetName()]; isUsed {
+			continue
+		}
+
+		dataSource := ownedDataSources[i] // Make local copy
+		dataSource.Namespace = ssp.GoldenImagesNSname
+		funcs = append(funcs, func(request *common.Request) (common.ReconcileResult, error) {
+			if !dataSource.GetDeletionTimestamp().IsZero() {
+				return common.ResourceDeletedResult(&dataSource, common.OperationResultDeleted), nil
+			}
+
+			err := request.Client.Delete(request.Context, &dataSource)
+			if errors.IsNotFound(err) {
+				return common.ReconcileResult{
+					Resource: &dataSource,
+				}, nil
+			}
+			if err != nil {
+				request.Logger.Error(err, fmt.Sprintf("Error deleting \"%s\": %s", dataSource.GetName(), err))
+				return common.ReconcileResult{}, err
+			}
+
+			return common.ResourceDeletedResult(&dataSource, common.OperationResultDeleted), nil
 		})
 	}
 
+	return funcs, nil
+}
+
+func reconcileDataSource(dataSource *cdiv1beta1.DataSource, request *common.Request) (common.ReconcileResult, error) {
+	return common.CreateOrUpdate(request).
+		ClusterResource(dataSource).
+		WithAppLabels(operandName, operandComponent).
+		UpdateFunc(func(newRes, foundRes client.Object) {
+			foundRes.(*cdiv1beta1.DataSource).Spec = newRes.(*cdiv1beta1.DataSource).Spec
+		}).
+		Reconcile()
+}
+
+func getDataSourceReadyCondition(dataSource *cdiv1beta1.DataSource) *cdiv1beta1.DataSourceCondition {
+	for i := range dataSource.Status.Conditions {
+		condition := &dataSource.Status.Conditions[i]
+		if condition.Type == cdiv1beta1.DataSourceReady {
+			return condition
+		}
+	}
+	return nil
+}
+
+func reconcileDataImportCron(dataImportCron *cdiv1beta1.DataImportCron, request *common.Request) (common.ReconcileResult, error) {
+	return common.CreateOrUpdate(request).
+		ClusterResource(dataImportCron).
+		WithAppLabels(operandName, operandComponent).
+		UpdateFunc(func(newRes, foundRes client.Object) {
+			foundRes.(*cdiv1beta1.DataImportCron).Spec = newRes.(*cdiv1beta1.DataImportCron).Spec
+		}).
+		ImmutableSpec(func(resource client.Object) interface{} {
+			return resource.(*cdiv1beta1.DataImportCron).Spec
+		}).
+		Reconcile()
+}
+
+func reconcileDataImportCrons(dataImportCrons []cdiv1beta1.DataImportCron, request *common.Request) ([]common.ReconcileFunc, error) {
 	ownedCrons, err := listAllOwnedDataImportCrons(request)
 	if err != nil {
 		return nil, err
 	}
 
+	cronNames := make(map[string]struct{}, len(dataImportCrons))
+
+	var funcs []common.ReconcileFunc
+	for i := range dataImportCrons {
+		cron := dataImportCrons[i] // Make a local copy
+		cron.Namespace = ssp.GoldenImagesNSname
+		funcs = append(funcs, func(request *common.Request) (common.ReconcileResult, error) {
+			return reconcileDataImportCron(&cron, request)
+		})
+		cronNames[cron.GetName()] = struct{}{}
+	}
+
+	// Remove owned DataImportCrons that are not in the 'dataImportCrons' parameter
 	for i := range ownedCrons {
-		cron := ownedCrons[i]
-		if _, isUsed := crons[cron.GetName()]; isUsed {
+		if _, isUsed := cronNames[ownedCrons[i].GetName()]; isUsed {
 			continue
 		}
 
-		// Unused DataImportCrons will be removed
+		cron := ownedCrons[i] // Make local copy
+		cron.Namespace = ssp.GoldenImagesNSname
 		funcs = append(funcs, func(request *common.Request) (common.ReconcileResult, error) {
 			err := request.Client.Delete(request.Context, &cron)
 			if err != nil && !errors.IsNotFound(err) {
@@ -254,6 +477,23 @@ func reconcileDataImportCrons(request *common.Request) ([]common.ReconcileFunc, 
 	}
 
 	return funcs, nil
+}
+
+func listAllOwnedDataSources(request *common.Request) ([]cdiv1beta1.DataSource, error) {
+	foundDataSources := &cdiv1beta1.DataSourceList{}
+	err := request.Client.List(request.Context, foundDataSources, client.InNamespace(ssp.GoldenImagesNSname))
+	if err != nil {
+		return nil, err
+	}
+
+	owned := make([]cdiv1beta1.DataSource, 0, len(foundDataSources.Items))
+	for _, item := range foundDataSources.Items {
+		if !common.CheckOwnerAnnotation(&item, request.Instance) {
+			continue
+		}
+		owned = append(owned, item)
+	}
+	return owned, nil
 }
 
 func listAllOwnedDataImportCrons(request *common.Request) ([]cdiv1beta1.DataImportCron, error) {

--- a/internal/template-bundle/bundle.go
+++ b/internal/template-bundle/bundle.go
@@ -58,6 +58,8 @@ func readTemplates(filename string) ([]templatev1.Template, error) {
 }
 
 func extractDataSources(templates []templatev1.Template) ([]cdiv1beta1.DataSource, error) {
+	uniqueNames := map[string]struct{}{}
+
 	var dataSources []cdiv1beta1.DataSource
 	for i := range templates {
 		template := &templates[i]
@@ -80,7 +82,11 @@ func extractDataSources(templates []templatev1.Template) ([]cdiv1beta1.DataSourc
 			continue
 		}
 
-		dataSources = append(dataSources, createDataSource(name, namespace))
+		namespacedName := namespace + "/" + name
+		if _, duplicateName := uniqueNames[namespacedName]; !duplicateName {
+			dataSources = append(dataSources, createDataSource(name, namespace))
+			uniqueNames[namespacedName] = struct{}{}
+		}
 	}
 
 	return dataSources, nil

--- a/internal/template-bundle/bundle_test.go
+++ b/internal/template-bundle/bundle_test.go
@@ -20,22 +20,32 @@ var _ = Describe("Template bundle", func() {
 
 	It("should correctly read templates", func() {
 		templates := testBundle.Templates
-		Expect(templates).To(HaveLen(3))
+		Expect(templates).To(HaveLen(4))
 
-		templ1 := templates[0]
-		Expect(templ1.Name).To(Equal("centos-stream8-server-medium"))
-		Expect(templ1.Annotations).To(HaveKey("name.os.template.kubevirt.io/centos-stream8"))
-		Expect(templ1.Objects).To(HaveLen(1))
-
-		templ2 := templates[1]
-		Expect(templ2.Name).To(Equal("windows10-desktop-medium"))
-		Expect(templ2.Annotations).To(HaveKey("name.os.template.kubevirt.io/win10"))
-		Expect(templ2.Objects).To(HaveLen(1))
-
-		templ3 := templates[2]
-		Expect(templ3.Name).To(Equal("rhel8-saphana-tiny"))
-		Expect(templ3.Annotations).To(HaveKey("name.os.template.kubevirt.io/rhel8.4"))
-		Expect(templ3.Objects).To(HaveLen(1))
+		{
+			templ := templates[0]
+			Expect(templ.Name).To(Equal("centos-stream8-server-medium"))
+			Expect(templ.Annotations).To(HaveKey("name.os.template.kubevirt.io/centos-stream8"))
+			Expect(templ.Objects).To(HaveLen(1))
+		}
+		{
+			templ := templates[1]
+			Expect(templ.Name).To(Equal("centos-stream8-desktop-large"))
+			Expect(templ.Annotations).To(HaveKey("name.os.template.kubevirt.io/centos-stream8"))
+			Expect(templ.Objects).To(HaveLen(1))
+		}
+		{
+			templ := templates[2]
+			Expect(templ.Name).To(Equal("windows10-desktop-medium"))
+			Expect(templ.Annotations).To(HaveKey("name.os.template.kubevirt.io/win10"))
+			Expect(templ.Objects).To(HaveLen(1))
+		}
+		{
+			templ := templates[3]
+			Expect(templ.Name).To(Equal("rhel8-saphana-tiny"))
+			Expect(templ.Annotations).To(HaveKey("name.os.template.kubevirt.io/rhel8.4"))
+			Expect(templ.Objects).To(HaveLen(1))
+		}
 	})
 
 	It("should create DataSources", func() {

--- a/internal/template-bundle/template-bundle-test.yaml
+++ b/internal/template-bundle/template-bundle-test.yaml
@@ -132,6 +132,142 @@ parameters:
     generate: expression
     name: CLOUD_USER_PASSWORD
 ---
+# Source: dist/templates/centos-stream8-desktop-large.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: centos-stream8-desktop-large
+  annotations:
+    openshift.io/display-name: "CentOS Stream 8 VM"
+    description: >-
+      Template for CentOS Stream 8 VM or newer.
+      A PVC with the CentOS Stream disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,linux,centosstream"
+    iconClass: "icon-centos"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/centos-stream8: CentOS Stream 8 or higher
+  labels:
+    os.template.kubevirt.io/centos-stream8: "true"
+    workload.template.kubevirt.io/desktop: "true"
+    flavor.template.kubevirt.io/large: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.19.1"
+objects:
+  - apiVersion: kubevirt.io/v1
+    kind: VirtualMachine
+    metadata:
+      name: ${NAME}
+      labels:
+        vm.kubevirt.io/template: centos-stream8-desktop-large
+        vm.kubevirt.io/template.version: "v0.19.1"
+        vm.kubevirt.io/template.revision: "1"
+        app: ${NAME}
+      annotations:
+        vm.kubevirt.io/validations: |
+          [
+            {
+              "name": "minimal-required-memory",
+              "path": "jsonpath::.spec.domain.resources.requests.memory",
+              "rule": "integer",
+              "message": "This VM requires more memory.",
+              "min": 1610612736
+            }
+          ]
+    spec:
+      dataVolumeTemplates:
+        - apiVersion: cdi.kubevirt.io/v1beta1
+          kind: DataVolume
+          metadata:
+            name: ${NAME}
+          spec:
+            storage:
+              resources:
+                requests:
+                  storage: 30Gi
+            sourceRef:
+              kind: DataSource
+              name: ${SRC_PVC_NAME}
+              namespace: ${SRC_PVC_NAMESPACE}
+      running: false
+      template:
+        metadata:
+          annotations:
+            vm.kubevirt.io/os: "centos-stream8"
+            vm.kubevirt.io/workload: "desktop"
+            vm.kubevirt.io/flavor: "large"
+          labels:
+            kubevirt.io/domain: ${NAME}
+            kubevirt.io/size: large
+        spec:
+          domain:
+            cpu:
+              sockets: 2
+              cores: 1
+              threads: 1
+            resources:
+              requests:
+                memory: 8Gi
+            devices:
+              rng: {}
+              networkInterfaceMultiqueue: true
+              inputs:
+                - type: tablet
+                  bus: virtio
+                  name: tablet
+              disks:
+                - disk:
+                    bus: virtio
+                  name: ${NAME}
+                - disk:
+                    bus: virtio
+                  name: cloudinitdisk
+              interfaces:
+                - masquerade: {}
+                  name: default
+          terminationGracePeriodSeconds: 180
+          networks:
+            - name: default
+              pod: {}
+          volumes:
+            - dataVolume:
+                name: ${NAME}
+              name: ${NAME}
+            - cloudInitNoCloud:
+                userData: |-
+                  #cloud-config
+                  user: centos
+                  password: ${CLOUD_USER_PASSWORD}
+                  chpasswd: { expire: False }
+              name: cloudinitdisk
+parameters:
+  - description: VM name
+    from: 'centos-stream8-[a-z0-9]{16}'
+    generate: expression
+    name: NAME
+  - name: SRC_PVC_NAME
+    description: Name of the DataSource to clone
+    value: 'centos-stream8'
+  - name: SRC_PVC_NAMESPACE
+    description: Namespace of the DataSource
+    value: kubevirt-os-images
+  - description: Randomized password for the cloud-init user centos
+    from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+    generate: expression
+    name: CLOUD_USER_PASSWORD
+---
 # Source: dist/templates/windows10-desktop-medium.yaml
 apiVersion: template.openshift.io/v1
 kind: Template

--- a/internal/test-utils/test_utils.go
+++ b/internal/test-utils/test_utils.go
@@ -10,12 +10,12 @@ import (
 
 func ExpectResourceExists(resource client.Object, request common.Request) {
 	key := client.ObjectKeyFromObject(resource)
-	Expect(request.Client.Get(request.Context, key, resource)).ToNot(HaveOccurred())
+	ExpectWithOffset(1, request.Client.Get(request.Context, key, resource)).ToNot(HaveOccurred())
 }
 
 func ExpectResourceNotExists(resource client.Object, request common.Request) {
 	key := client.ObjectKeyFromObject(resource)
 	err := request.Client.Get(request.Context, key, resource)
-	Expect(err).To(HaveOccurred())
-	Expect(errors.IsNotFound(err)).To(BeTrue())
+	ExpectWithOffset(1, err).To(HaveOccurred())
+	ExpectWithOffset(1, errors.IsNotFound(err)).To(BeTrue())
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
If a DataSource points to an existing PVC, it will be created and reconciled by the SSP operator.
If the PVC does not exist, the operator will instead create and reconcile DataImportCron,

This allows users to create their own golden image PVCs, and they will have higher priority
than auto updated images.

**Release note**:
```release-note
DataImportCrons are only created for DataSources that do not point to an existing PVC.
```
