### PR TITLE
Fix DataSource reconciliation when DataImportCron template is removed

### DIFF
--- a/tests/misc_test.go
+++ b/tests/misc_test.go
@@ -22,6 +22,7 @@ import (
 var _ = Describe("Observed generation", func() {
 	BeforeEach(func() {
 		strategy.SkipSspUpdateTestsIfNeeded()
+		waitUntilDeployed()
 	})
 
 	AfterEach(func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixed a bug where label `cdi.kubevirt.io/dataImportCron` was not removed from `DataSource` when `DataImportCron` template is removed from SSP CR.

Fixed functional tests, when running with an existing SSP CR.

**Which issue(s) this PR fixes**: 
Fixes bug: https://bugzilla.redhat.com/show_bug.cgi?id=2044398

**Special notes for your reviewer**:

**Release note**:
```release-note
None
```
