### PR TITLE
Change operator version to v0.14.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # The value here should be equal to the next version:
 # - next minor version on main branch
 # - next patch version on release branches
-VERSION ?= 0.13.0
+VERSION ?= 0.14.0
 
 #operator-sdk version
 OPERATOR_SDK_VERSION ?= v1.9.0

--- a/data/olm-catalog/ssp-operator.clusterserviceversion.yaml
+++ b/data/olm-catalog/ssp-operator.clusterserviceversion.yaml
@@ -28,7 +28,7 @@ metadata:
     description: Manages KubeVirt addons for Scheduling, Scale, Performance
     operators.operatorframework.io/builder: operator-sdk-v1.8.0+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
-  name: ssp-operator.v0.13.0
+  name: ssp-operator.v0.14.0
   namespace: kubevirt
 spec:
   apiservicedefinitions: {}
@@ -392,7 +392,7 @@ spec:
                 - name: NODE_LABELLER_IMAGE
                 - name: CPU_PLUGIN_IMAGE
                 - name: OPERATOR_VERSION
-                  value: 0.13.0
+                  value: 0.14.0
                 image: quay.io/kubevirt/ssp-operator:latest
                 livenessProbe:
                   httpGet:
@@ -495,7 +495,7 @@ spec:
     matchLabels:
       alm-owner-kubevirt: ssp-operator
       operated-by: ssp-operator
-  version: 0.13.0
+  version: 0.14.0
   webhookdefinitions:
   - admissionReviewVersions:
     - v1


### PR DESCRIPTION

**What this PR does / why we need it**:
Updating the version, because `v0.13.0` was released.

**Release note**:
```release-note
None
```
