### PR TITLE
DataSources: Set app labels only when auto-update is disabled

### DIFF
--- a/internal/operands/data-sources/reconcile.go
+++ b/internal/operands/data-sources/reconcile.go
@@ -386,7 +386,6 @@ func reconcileDataSources(dataSourceInfos []dataSourceInfo, request *common.Requ
 func reconcileDataSource(dsInfo dataSourceInfo, request *common.Request) (common.ReconcileResult, error) {
 	return common.CreateOrUpdate(request).
 		ClusterResource(dsInfo.dataSource).
-		WithAppLabels(operandName, operandComponent).
 		Options(common.ReconcileOptions{AlwaysCallUpdateFunc: true}).
 		UpdateFunc(func(newRes, foundRes client.Object) {
 			if dsInfo.autoUpdateEnabled {
@@ -395,6 +394,8 @@ func reconcileDataSource(dsInfo dataSourceInfo, request *common.Request) (common
 				}
 				foundRes.GetLabels()[dataImportCronLabel] = dsInfo.dataImportCronName
 			} else {
+				// Only set app labels if DIC does not exist
+				common.AddAppLabels(request.Instance, operandName, operandComponent, foundRes)
 				delete(foundRes.GetLabels(), dataImportCronLabel)
 			}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
When auto-update is enabled, CDI will set the app labels.

**Release note**:
```release-note
None
```
