### PR TITLE
Remove `GoldenImagesNSname` constant from `api` submodule

### DIFF
--- a/api/v1beta1/constants.go
+++ b/api/v1beta1/constants.go
@@ -1,5 +1,0 @@
-package v1beta1
-
-const (
-	GoldenImagesNSname = "kubevirt-os-images"
-)

--- a/internal/constants.go
+++ b/internal/constants.go
@@ -1,0 +1,5 @@
+package internal
+
+const (
+	GoldenImagesNamespace = "kubevirt-os-images"
+)

--- a/internal/operands/data-sources/reconcile_test.go
+++ b/internal/operands/data-sources/reconcile_test.go
@@ -18,6 +18,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	ssp "kubevirt.io/ssp-operator/api/v1beta1"
+	"kubevirt.io/ssp-operator/internal"
 	"kubevirt.io/ssp-operator/internal/common"
 	"kubevirt.io/ssp-operator/internal/operands"
 	. "kubevirt.io/ssp-operator/internal/test-utils"
@@ -77,19 +78,19 @@ var _ = Describe("Data-Sources operand", func() {
 	It("should create golden-images namespace", func() {
 		_, err := operand.Reconcile(&request)
 		Expect(err).ToNot(HaveOccurred())
-		ExpectResourceExists(newGoldenImagesNS(ssp.GoldenImagesNSname), request)
+		ExpectResourceExists(newGoldenImagesNS(internal.GoldenImagesNamespace), request)
 	})
 
 	It("should create view role", func() {
 		_, err := operand.Reconcile(&request)
 		Expect(err).ToNot(HaveOccurred())
-		ExpectResourceExists(newViewRole(ssp.GoldenImagesNSname), request)
+		ExpectResourceExists(newViewRole(internal.GoldenImagesNamespace), request)
 	})
 
 	It("should create view role binding", func() {
 		_, err := operand.Reconcile(&request)
 		Expect(err).ToNot(HaveOccurred())
-		ExpectResourceExists(newViewRoleBinding(ssp.GoldenImagesNSname), request)
+		ExpectResourceExists(newViewRoleBinding(internal.GoldenImagesNamespace), request)
 	})
 
 	It("should create edit role", func() {
@@ -134,7 +135,7 @@ var _ = Describe("Data-Sources operand", func() {
 				createdDataImportCron := cdiv1beta1.DataImportCron{}
 				err = request.Client.Get(request.Context, client.ObjectKey{
 					Name:      cronTemplate.GetName(),
-					Namespace: ssp.GoldenImagesNSname,
+					Namespace: internal.GoldenImagesNamespace,
 				}, &createdDataImportCron)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(createdDataImportCron.Spec).To(Equal(cronTemplate.Spec))
@@ -145,7 +146,7 @@ var _ = Describe("Data-Sources operand", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				cron := cronTemplate.AsDataImportCron()
-				cron.Namespace = ssp.GoldenImagesNSname
+				cron.Namespace = internal.GoldenImagesNamespace
 				ExpectResourceExists(&cron, request)
 
 				request.Instance.Spec.CommonTemplates.DataImportCronTemplates = nil
@@ -161,7 +162,7 @@ var _ = Describe("Data-Sources operand", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				cron := cronTemplate.AsDataImportCron()
-				cron.Namespace = ssp.GoldenImagesNSname
+				cron.Namespace = internal.GoldenImagesNamespace
 				ExpectResourceExists(&cron, request)
 
 				// Update DataSource to simulate CDI
@@ -213,7 +214,7 @@ var _ = Describe("Data-Sources operand", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				cron := cronTemplate.AsDataImportCron()
-				cron.Namespace = ssp.GoldenImagesNSname
+				cron.Namespace = internal.GoldenImagesNamespace
 				ExpectResourceNotExists(&cron, request)
 			})
 
@@ -222,7 +223,7 @@ var _ = Describe("Data-Sources operand", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				cron := cronTemplate.AsDataImportCron()
-				cron.Namespace = ssp.GoldenImagesNSname
+				cron.Namespace = internal.GoldenImagesNamespace
 				ExpectResourceNotExists(&cron, request)
 
 				foundDs := &cdiv1beta1.DataSource{}
@@ -247,7 +248,7 @@ var _ = Describe("Data-Sources operand", func() {
 			cron := &cdiv1beta1.DataImportCron{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-cron",
-					Namespace: ssp.GoldenImagesNSname,
+					Namespace: internal.GoldenImagesNamespace,
 				},
 				Spec: cdiv1beta1.DataImportCronSpec{},
 			}
@@ -272,26 +273,26 @@ func getDataSources() []cdiv1beta1.DataSource {
 	return []cdiv1beta1.DataSource{{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name1,
-			Namespace: ssp.GoldenImagesNSname,
+			Namespace: internal.GoldenImagesNamespace,
 		},
 		Spec: cdiv1beta1.DataSourceSpec{
 			Source: cdiv1beta1.DataSourceSource{
 				PVC: &cdiv1beta1.DataVolumeSourcePVC{
 					Name:      name1,
-					Namespace: ssp.GoldenImagesNSname,
+					Namespace: internal.GoldenImagesNamespace,
 				},
 			},
 		},
 	}, {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name2,
-			Namespace: ssp.GoldenImagesNSname,
+			Namespace: internal.GoldenImagesNamespace,
 		},
 		Spec: cdiv1beta1.DataSourceSpec{
 			Source: cdiv1beta1.DataSourceSource{
 				PVC: &cdiv1beta1.DataVolumeSourcePVC{
 					Name:      name2,
-					Namespace: ssp.GoldenImagesNSname,
+					Namespace: internal.GoldenImagesNamespace,
 				},
 			},
 		},

--- a/tests/dataSources_test.go
+++ b/tests/dataSources_test.go
@@ -19,6 +19,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	ssp "kubevirt.io/ssp-operator/api/v1beta1"
+	"kubevirt.io/ssp-operator/internal"
 	"kubevirt.io/ssp-operator/internal/common"
 	data_sources "kubevirt.io/ssp-operator/internal/operands/data-sources"
 )
@@ -43,7 +44,7 @@ var _ = Describe("DataSources", func() {
 		expectedLabels = expectedLabelsFor("data-sources", common.AppComponentTemplating)
 		viewRole = testResource{
 			Name:           data_sources.ViewRoleName,
-			Namespace:      ssp.GoldenImagesNSname,
+			Namespace:      internal.GoldenImagesNamespace,
 			Resource:       &rbac.Role{},
 			ExpectedLabels: expectedLabels,
 			UpdateFunc: func(role *rbac.Role) {
@@ -55,7 +56,7 @@ var _ = Describe("DataSources", func() {
 		}
 		viewRoleBinding = testResource{
 			Name:           data_sources.ViewRoleName,
-			Namespace:      ssp.GoldenImagesNSname,
+			Namespace:      internal.GoldenImagesNamespace,
 			Resource:       &rbac.RoleBinding{},
 			ExpectedLabels: expectedLabels,
 			UpdateFunc: func(roleBinding *rbac.RoleBinding) {
@@ -78,14 +79,14 @@ var _ = Describe("DataSources", func() {
 			},
 		}
 		goldenImageNS = testResource{
-			Name:           ssp.GoldenImagesNSname,
+			Name:           internal.GoldenImagesNamespace,
 			Resource:       &core.Namespace{},
 			ExpectedLabels: expectedLabels,
 			Namespace:      "",
 		}
 		dataSource = testResource{
 			Name:           dataSourceName,
-			Namespace:      ssp.GoldenImagesNSname,
+			Namespace:      internal.GoldenImagesNamespace,
 			Resource:       &cdiv1beta1.DataSource{},
 			ExpectedLabels: expectedLabels,
 			UpdateFunc: func(ds *cdiv1beta1.DataSource) {
@@ -197,7 +198,7 @@ var _ = Describe("DataSources", func() {
 						Groups: sasGroup,
 						ResourceAttributes: &authv1.ResourceAttributes{
 							Verb:      "get",
-							Namespace: ssp.GoldenImagesNSname,
+							Namespace: internal.GoldenImagesNamespace,
 							Version:   core.SchemeGroupVersion.Version,
 							Resource:  "namespaces",
 						},
@@ -208,7 +209,7 @@ var _ = Describe("DataSources", func() {
 						Groups: sasGroup,
 						ResourceAttributes: &authv1.ResourceAttributes{
 							Verb:      "list",
-							Namespace: ssp.GoldenImagesNSname,
+							Namespace: internal.GoldenImagesNamespace,
 							Version:   core.SchemeGroupVersion.Version,
 							Resource:  "namespaces",
 						},
@@ -219,7 +220,7 @@ var _ = Describe("DataSources", func() {
 						Groups: sasGroup,
 						ResourceAttributes: &authv1.ResourceAttributes{
 							Verb:      "watch",
-							Namespace: ssp.GoldenImagesNSname,
+							Namespace: internal.GoldenImagesNamespace,
 							Version:   core.SchemeGroupVersion.Version,
 							Resource:  "namespaces",
 						},
@@ -232,7 +233,7 @@ var _ = Describe("DataSources", func() {
 						Groups: sasGroup,
 						ResourceAttributes: &authv1.ResourceAttributes{
 							Verb:      "get",
-							Namespace: ssp.GoldenImagesNSname,
+							Namespace: internal.GoldenImagesNamespace,
 							Group:     cdiv1beta1.SchemeGroupVersion.Group,
 							Version:   cdiv1beta1.SchemeGroupVersion.Version,
 							Resource:  "datavolumes",
@@ -244,7 +245,7 @@ var _ = Describe("DataSources", func() {
 						Groups: sasGroup,
 						ResourceAttributes: &authv1.ResourceAttributes{
 							Verb:      "list",
-							Namespace: ssp.GoldenImagesNSname,
+							Namespace: internal.GoldenImagesNamespace,
 							Group:     cdiv1beta1.SchemeGroupVersion.Group,
 							Version:   cdiv1beta1.SchemeGroupVersion.Version,
 							Resource:  "datavolumes",
@@ -256,7 +257,7 @@ var _ = Describe("DataSources", func() {
 						Groups: sasGroup,
 						ResourceAttributes: &authv1.ResourceAttributes{
 							Verb:      "watch",
-							Namespace: ssp.GoldenImagesNSname,
+							Namespace: internal.GoldenImagesNamespace,
 							Group:     cdiv1beta1.SchemeGroupVersion.Group,
 							Version:   cdiv1beta1.SchemeGroupVersion.Version,
 							Resource:  "datavolumes",
@@ -268,7 +269,7 @@ var _ = Describe("DataSources", func() {
 						Groups: sasGroup,
 						ResourceAttributes: &authv1.ResourceAttributes{
 							Verb:        "create",
-							Namespace:   ssp.GoldenImagesNSname,
+							Namespace:   internal.GoldenImagesNamespace,
 							Group:       cdiv1beta1.SchemeGroupVersion.Group,
 							Version:     cdiv1beta1.SchemeGroupVersion.Version,
 							Resource:    "datavolumes",
@@ -284,7 +285,7 @@ var _ = Describe("DataSources", func() {
 						Groups: sasGroup,
 						ResourceAttributes: &authv1.ResourceAttributes{
 							Verb:      "delete",
-							Namespace: ssp.GoldenImagesNSname,
+							Namespace: internal.GoldenImagesNamespace,
 							Group:     cdiv1beta1.SchemeGroupVersion.Group,
 							Version:   cdiv1beta1.SchemeGroupVersion.Version,
 							Resource:  "datavolumes",
@@ -296,7 +297,7 @@ var _ = Describe("DataSources", func() {
 						Groups: sasGroup,
 						ResourceAttributes: &authv1.ResourceAttributes{
 							Verb:      "create",
-							Namespace: ssp.GoldenImagesNSname,
+							Namespace: internal.GoldenImagesNamespace,
 							Group:     cdiv1beta1.SchemeGroupVersion.Group,
 							Version:   cdiv1beta1.SchemeGroupVersion.Version,
 							Resource:  "datavolumes",
@@ -311,7 +312,7 @@ var _ = Describe("DataSources", func() {
 						Groups: sasGroup,
 						ResourceAttributes: &authv1.ResourceAttributes{
 							Verb:      "get",
-							Namespace: ssp.GoldenImagesNSname,
+							Namespace: internal.GoldenImagesNamespace,
 							Version:   core.SchemeGroupVersion.Version,
 							Resource:  "persistentvolumeclaims",
 						},
@@ -324,7 +325,7 @@ var _ = Describe("DataSources", func() {
 						Groups: sasGroup,
 						ResourceAttributes: &authv1.ResourceAttributes{
 							Verb:      "create",
-							Namespace: ssp.GoldenImagesNSname,
+							Namespace: internal.GoldenImagesNamespace,
 							Version:   core.SchemeGroupVersion.Version,
 							Resource:  "persistentvolumeclaims",
 						},
@@ -335,7 +336,7 @@ var _ = Describe("DataSources", func() {
 						Groups: sasGroup,
 						ResourceAttributes: &authv1.ResourceAttributes{
 							Verb:      "delete",
-							Namespace: ssp.GoldenImagesNSname,
+							Namespace: internal.GoldenImagesNamespace,
 							Version:   core.SchemeGroupVersion.Version,
 							Resource:  "persistentvolumeclaims",
 						},
@@ -346,7 +347,7 @@ var _ = Describe("DataSources", func() {
 						Groups: sasGroup,
 						ResourceAttributes: &authv1.ResourceAttributes{
 							Verb:      "create",
-							Namespace: ssp.GoldenImagesNSname,
+							Namespace: internal.GoldenImagesNamespace,
 							Version:   core.SchemeGroupVersion.Version,
 							Resource:  "pods",
 						},
@@ -360,7 +361,7 @@ var _ = Describe("DataSources", func() {
 						Groups: sasGroup,
 						ResourceAttributes: &authv1.ResourceAttributes{
 							Verb:      "get",
-							Namespace: ssp.GoldenImagesNSname,
+							Namespace: internal.GoldenImagesNamespace,
 							Group:     cdiv1beta1.SchemeGroupVersion.Group,
 							Version:   cdiv1beta1.SchemeGroupVersion.Version,
 							Resource:  "datasources",
@@ -372,7 +373,7 @@ var _ = Describe("DataSources", func() {
 						Groups: sasGroup,
 						ResourceAttributes: &authv1.ResourceAttributes{
 							Verb:      "list",
-							Namespace: ssp.GoldenImagesNSname,
+							Namespace: internal.GoldenImagesNamespace,
 							Group:     cdiv1beta1.SchemeGroupVersion.Group,
 							Version:   cdiv1beta1.SchemeGroupVersion.Version,
 							Resource:  "datasources",
@@ -384,7 +385,7 @@ var _ = Describe("DataSources", func() {
 						Groups: sasGroup,
 						ResourceAttributes: &authv1.ResourceAttributes{
 							Verb:      "watch",
-							Namespace: ssp.GoldenImagesNSname,
+							Namespace: internal.GoldenImagesNamespace,
 							Group:     cdiv1beta1.SchemeGroupVersion.Group,
 							Version:   cdiv1beta1.SchemeGroupVersion.Version,
 							Resource:  "datasources",
@@ -399,7 +400,7 @@ var _ = Describe("DataSources", func() {
 						Groups: sasGroup,
 						ResourceAttributes: &authv1.ResourceAttributes{
 							Verb:      "delete",
-							Namespace: ssp.GoldenImagesNSname,
+							Namespace: internal.GoldenImagesNamespace,
 							Group:     cdiv1beta1.SchemeGroupVersion.Group,
 							Version:   cdiv1beta1.SchemeGroupVersion.Version,
 							Resource:  "datasources",
@@ -411,7 +412,7 @@ var _ = Describe("DataSources", func() {
 						Groups: sasGroup,
 						ResourceAttributes: &authv1.ResourceAttributes{
 							Verb:      "create",
-							Namespace: ssp.GoldenImagesNSname,
+							Namespace: internal.GoldenImagesNamespace,
 							Group:     cdiv1beta1.SchemeGroupVersion.Group,
 							Version:   cdiv1beta1.SchemeGroupVersion.Version,
 							Resource:  "datasources",
@@ -426,7 +427,7 @@ var _ = Describe("DataSources", func() {
 						Groups: sasGroup,
 						ResourceAttributes: &authv1.ResourceAttributes{
 							Verb:      "get",
-							Namespace: ssp.GoldenImagesNSname,
+							Namespace: internal.GoldenImagesNamespace,
 							Group:     cdiv1beta1.SchemeGroupVersion.Group,
 							Version:   cdiv1beta1.SchemeGroupVersion.Version,
 							Resource:  "dataimportcrons",
@@ -438,7 +439,7 @@ var _ = Describe("DataSources", func() {
 						Groups: sasGroup,
 						ResourceAttributes: &authv1.ResourceAttributes{
 							Verb:      "list",
-							Namespace: ssp.GoldenImagesNSname,
+							Namespace: internal.GoldenImagesNamespace,
 							Group:     cdiv1beta1.SchemeGroupVersion.Group,
 							Version:   cdiv1beta1.SchemeGroupVersion.Version,
 							Resource:  "dataimportcrons",
@@ -450,7 +451,7 @@ var _ = Describe("DataSources", func() {
 						Groups: sasGroup,
 						ResourceAttributes: &authv1.ResourceAttributes{
 							Verb:      "watch",
-							Namespace: ssp.GoldenImagesNSname,
+							Namespace: internal.GoldenImagesNamespace,
 							Group:     cdiv1beta1.SchemeGroupVersion.Group,
 							Version:   cdiv1beta1.SchemeGroupVersion.Version,
 							Resource:  "dataimportcrons",
@@ -465,7 +466,7 @@ var _ = Describe("DataSources", func() {
 						Groups: sasGroup,
 						ResourceAttributes: &authv1.ResourceAttributes{
 							Verb:      "delete",
-							Namespace: ssp.GoldenImagesNSname,
+							Namespace: internal.GoldenImagesNamespace,
 							Group:     cdiv1beta1.SchemeGroupVersion.Group,
 							Version:   cdiv1beta1.SchemeGroupVersion.Version,
 							Resource:  "dataimportcrons",
@@ -477,7 +478,7 @@ var _ = Describe("DataSources", func() {
 						Groups: sasGroup,
 						ResourceAttributes: &authv1.ResourceAttributes{
 							Verb:      "create",
-							Namespace: ssp.GoldenImagesNSname,
+							Namespace: internal.GoldenImagesNamespace,
 							Group:     cdiv1beta1.SchemeGroupVersion.Group,
 							Version:   cdiv1beta1.SchemeGroupVersion.Version,
 							Resource:  "dataimportcrons",
@@ -506,7 +507,7 @@ var _ = Describe("DataSources", func() {
 					editObj = &rbac.RoleBinding{
 						ObjectMeta: metav1.ObjectMeta{
 							GenerateName: "test-edit-",
-							Namespace:    ssp.GoldenImagesNSname,
+							Namespace:    internal.GoldenImagesNamespace,
 						},
 						Subjects: []rbac.Subject{{
 							Kind:      "ServiceAccount",
@@ -534,7 +535,7 @@ var _ = Describe("DataSources", func() {
 						&authv1.SubjectAccessReviewSpec{
 							ResourceAttributes: &authv1.ResourceAttributes{
 								Verb:      "create",
-								Namespace: ssp.GoldenImagesNSname,
+								Namespace: internal.GoldenImagesNamespace,
 								Version:   core.SchemeGroupVersion.Version,
 								Resource:  "persistentvolumeclaims",
 							},
@@ -543,7 +544,7 @@ var _ = Describe("DataSources", func() {
 						&authv1.SubjectAccessReviewSpec{
 							ResourceAttributes: &authv1.ResourceAttributes{
 								Verb:      "delete",
-								Namespace: ssp.GoldenImagesNSname,
+								Namespace: internal.GoldenImagesNamespace,
 								Version:   core.SchemeGroupVersion.Version,
 								Resource:  "persistentvolumeclaims",
 							},
@@ -552,7 +553,7 @@ var _ = Describe("DataSources", func() {
 						&authv1.SubjectAccessReviewSpec{
 							ResourceAttributes: &authv1.ResourceAttributes{
 								Verb:      "get",
-								Namespace: ssp.GoldenImagesNSname,
+								Namespace: internal.GoldenImagesNamespace,
 								Group:     cdiv1beta1.SchemeGroupVersion.Group,
 								Version:   cdiv1beta1.SchemeGroupVersion.Version,
 								Resource:  "datavolumes",
@@ -562,7 +563,7 @@ var _ = Describe("DataSources", func() {
 						&authv1.SubjectAccessReviewSpec{
 							ResourceAttributes: &authv1.ResourceAttributes{
 								Verb:      "create",
-								Namespace: ssp.GoldenImagesNSname,
+								Namespace: internal.GoldenImagesNamespace,
 								Group:     cdiv1beta1.SchemeGroupVersion.Group,
 								Version:   cdiv1beta1.SchemeGroupVersion.Version,
 								Resource:  "datavolumes",
@@ -572,7 +573,7 @@ var _ = Describe("DataSources", func() {
 						&authv1.SubjectAccessReviewSpec{
 							ResourceAttributes: &authv1.ResourceAttributes{
 								Verb:      "delete",
-								Namespace: ssp.GoldenImagesNSname,
+								Namespace: internal.GoldenImagesNamespace,
 								Group:     cdiv1beta1.SchemeGroupVersion.Group,
 								Version:   cdiv1beta1.SchemeGroupVersion.Version,
 								Resource:  "datavolumes",
@@ -583,7 +584,7 @@ var _ = Describe("DataSources", func() {
 						&authv1.SubjectAccessReviewSpec{
 							ResourceAttributes: &authv1.ResourceAttributes{
 								Verb:      "create",
-								Namespace: ssp.GoldenImagesNSname,
+								Namespace: internal.GoldenImagesNamespace,
 								Group:     cdiv1beta1.SchemeGroupVersion.Group,
 								Version:   cdiv1beta1.SchemeGroupVersion.Version,
 								Resource:  "datasources",
@@ -593,7 +594,7 @@ var _ = Describe("DataSources", func() {
 						&authv1.SubjectAccessReviewSpec{
 							ResourceAttributes: &authv1.ResourceAttributes{
 								Verb:      "delete",
-								Namespace: ssp.GoldenImagesNSname,
+								Namespace: internal.GoldenImagesNamespace,
 								Group:     cdiv1beta1.SchemeGroupVersion.Group,
 								Version:   cdiv1beta1.SchemeGroupVersion.Version,
 								Resource:  "datasources",
@@ -604,7 +605,7 @@ var _ = Describe("DataSources", func() {
 						&authv1.SubjectAccessReviewSpec{
 							ResourceAttributes: &authv1.ResourceAttributes{
 								Verb:      "create",
-								Namespace: ssp.GoldenImagesNSname,
+								Namespace: internal.GoldenImagesNamespace,
 								Group:     cdiv1beta1.SchemeGroupVersion.Group,
 								Version:   cdiv1beta1.SchemeGroupVersion.Version,
 								Resource:  "dataimportcrons",
@@ -614,7 +615,7 @@ var _ = Describe("DataSources", func() {
 						&authv1.SubjectAccessReviewSpec{
 							ResourceAttributes: &authv1.ResourceAttributes{
 								Verb:      "delete",
-								Namespace: ssp.GoldenImagesNSname,
+								Namespace: internal.GoldenImagesNamespace,
 								Group:     cdiv1beta1.SchemeGroupVersion.Group,
 								Version:   cdiv1beta1.SchemeGroupVersion.Version,
 								Resource:  "dataimportcrons",
@@ -625,7 +626,7 @@ var _ = Describe("DataSources", func() {
 					sars := &authv1.SubjectAccessReviewSpec{
 						ResourceAttributes: &authv1.ResourceAttributes{
 							Verb:      "create",
-							Namespace: ssp.GoldenImagesNSname,
+							Namespace: internal.GoldenImagesNamespace,
 							Version:   core.SchemeGroupVersion.Version,
 							Resource:  "pods",
 						},
@@ -781,7 +782,7 @@ var _ = Describe("DataSources", func() {
 
 			dataImportCron = testResource{
 				Name:           cronTemplate.Name,
-				Namespace:      ssp.GoldenImagesNSname,
+				Namespace:      internal.GoldenImagesNamespace,
 				Resource:       &cdiv1beta1.DataImportCron{},
 				ExpectedLabels: expectedLabels,
 			}
@@ -912,7 +913,7 @@ var _ = Describe("DataSources", func() {
 				dataVolume = &cdiv1beta1.DataVolume{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:        dataSourceName,
-						Namespace:   ssp.GoldenImagesNSname,
+						Namespace:   internal.GoldenImagesNamespace,
 						Annotations: commonAnnotations,
 					},
 					Spec: cdiv1beta1.DataVolumeSpec{
@@ -1100,7 +1101,7 @@ var _ = Describe("DataSources", func() {
 				cron = &cdiv1beta1.DataImportCron{
 					ObjectMeta: metav1.ObjectMeta{
 						GenerateName: "test-not-in-ssp",
-						Namespace:    ssp.GoldenImagesNSname,
+						Namespace:    internal.GoldenImagesNamespace,
 						Annotations:  commonAnnotations,
 					},
 					Spec: cdiv1beta1.DataImportCronSpec{

--- a/vendor/kubevirt.io/ssp-operator/api/v1beta1/constants.go
+++ b/vendor/kubevirt.io/ssp-operator/api/v1beta1/constants.go
@@ -1,5 +1,0 @@
-package v1beta1
-
-const (
-	GoldenImagesNSname = "kubevirt-os-images"
-)

--- a/webhooks/ssp_webhook.go
+++ b/webhooks/ssp_webhook.go
@@ -24,6 +24,7 @@ import (
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/pointer"
 	"kubevirt.io/controller-lifecycle-operator-sdk/pkg/sdk/api"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -31,8 +32,8 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	"k8s.io/apimachinery/pkg/runtime"
 	sspv1beta1 "kubevirt.io/ssp-operator/api/v1beta1"
+	"kubevirt.io/ssp-operator/internal"
 )
 
 var ssplog = logf.Log.WithName("ssp-resource")
@@ -167,8 +168,8 @@ func validateDataImportCronTemplates(ssp *sspv1beta1.SSP) error {
 		if cron.Name == "" {
 			return fmt.Errorf("missing name in DataImportCronTemplate")
 		}
-		if len(cron.Namespace) > 0 && cron.Namespace != sspv1beta1.GoldenImagesNSname {
-			return fmt.Errorf("invalid namespace in DataImportCronTemplate %s: must be empty or %s", cron.Name, sspv1beta1.GoldenImagesNSname)
+		if len(cron.Namespace) > 0 && cron.Namespace != internal.GoldenImagesNamespace {
+			return fmt.Errorf("invalid namespace in DataImportCronTemplate %s: must be empty or %s", cron.Name, internal.GoldenImagesNamespace)
 		}
 	}
 	return nil

--- a/webhooks/ssp_webhook_test.go
+++ b/webhooks/ssp_webhook_test.go
@@ -32,6 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	sspv1beta1 "kubevirt.io/ssp-operator/api/v1beta1"
+	"kubevirt.io/ssp-operator/internal"
 )
 
 var _ = Describe("SSP Validation", func() {
@@ -199,8 +200,8 @@ var _ = Describe("SSP Validation", func() {
 			checkExpectedError(err, shouldFail)
 		},
 			table.Entry("no namepsace provided", "", "test-name", false),
-			table.Entry("no name provided", sspv1beta1.GoldenImagesNSname, "", true),
-			table.Entry("golden image namespace provided", sspv1beta1.GoldenImagesNSname, "test-name", false),
+			table.Entry("no name provided", internal.GoldenImagesNamespace, "", true),
+			table.Entry("golden image namespace provided", internal.GoldenImagesNamespace, "test-name", false),
 			table.Entry("invalid namespace provided", "invalid-namespace", "test-name", true),
 		)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The constant is changed when building a downstream image, but the change is not propagated to the `vendor` directory.

This patch moves the constant into `internal` package.

**Release note**:
```release-note
None
```
