### PR TITLE
Handle error when CR is in conflict

### DIFF
--- a/controllers/ssp_controller.go
+++ b/controllers/ssp_controller.go
@@ -181,8 +181,9 @@ func (r *sspReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res ct
 	sspRequest.Logger.V(1).Info("Updating CR status prior to operand reconciliation...")
 	err = preUpdateStatus(sspRequest)
 	if err != nil {
-		return ctrl.Result{}, err
+		return handleError(sspRequest, err)
 	}
+
 	sspRequest.Logger.V(1).Info("CR status updated")
 
 	sspRequest.Logger.Info("Reconciling operands...")


### PR DESCRIPTION
**What this PR does / why we need it**:

When action on CR is rejected by API server,
dont show the error in log and reenque the request.

**Which issue(s) this PR fixes**: 

Fixes https://github.com/kubevirt/ssp-operator/issues/323

**Release note**:
```
NONE
```
Signed-off-by: Ondrej Pokorny <opokorny@redhat.com>
