### PR TITLE
Add new column

### DIFF
--- a/api/v1beta1/ssp_types.go
+++ b/api/v1beta1/ssp_types.go
@@ -95,6 +95,7 @@ type SSPStatus struct {
 // +kubebuilder:subresource:status
 
 // SSP is the Schema for the ssps API
+// +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase"
 type SSP struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/config/crd/bases/ssp.kubevirt.io_ssps.yaml
+++ b/config/crd/bases/ssp.kubevirt.io_ssps.yaml
@@ -16,7 +16,11 @@ spec:
     singular: ssp
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: SSP is the Schema for the ssps API

--- a/vendor/kubevirt.io/ssp-operator/api/v1beta1/ssp_types.go
+++ b/vendor/kubevirt.io/ssp-operator/api/v1beta1/ssp_types.go
@@ -95,6 +95,7 @@ type SSPStatus struct {
 // +kubebuilder:subresource:status
 
 // SSP is the Schema for the ssps API
+// +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase"
 type SSP struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
**What this PR does / why we need it**:

When 'oc get ssp' command is executed,
that the '.status.phase' field will be displayed.

**Which issue(s) this PR fixes**: 
Fixes # https://github.com/kubevirt/ssp-operator/issues/322

**Release note**:
```
Print column Phase when getting SSP objects by 'oc get ssp' command.
```
Signed-off-by: Ondrej Pokorny <opokorny@redhat.com>
