### PR TITLE
`e2e-upgrade-functests` lane tests release from a specified branch

### DIFF
--- a/hack/validate-no-offensive-lang.sh
+++ b/hack/validate-no-offensive-lang.sh
@@ -3,7 +3,7 @@
 OFFENSIVE_WORDS="black[ -]?list|white[ -]?list|master|slave"
 ALLOW_LIST=".+[:/=]master[a-zA-Z]*/?"
 
-if git grep -inE "${OFFENSIVE_WORDS}" -- ':!vendor' ':!api/vendor' ":!${BASH_SOURCE[0]}" ':!.github/workflows/' | grep -viE "${ALLOW_LIST}"; then
+if git grep -inE "${OFFENSIVE_WORDS}" -- ':!vendor' ':!api/vendor' ':!automation/e2e-upgrade-functests' ":!${BASH_SOURCE[0]}" ':!.github/workflows/' | grep -viE "${ALLOW_LIST}"; then
   echo "Validation failed. Found offensive language"
   exit 1
 fi


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a new parameter for `e2e-upgrade-functests` lane, which specifies the release branch with the latest release.

This is needed when a PR is targeted for a release branch that is not latest. Without this change, the CI would test downgrade, instead of upgrade.

**Release note**:
```release-note
None
```
