### PR TITLE
[release-v0.13] `e2e-upgrade-functests` lane tests release from a specified branch

### DIFF
--- a/automation/e2e-upgrade-functests/run.sh
+++ b/automation/e2e-upgrade-functests/run.sh
@@ -5,9 +5,11 @@ set -e
 # It is run from the root of the repository.
 
 # These evn variables are defined by the CI:
+# CI_BRANCH - name of the git branch that CI is testing
 # CI_OPERATOR_IMG - path of the operator image in the local repository accessible on the CI
 # CI_VALIDATOR_IMG - path of the validator image in the local repository accessible on the CI
 
+export RELEASE_BRANCH=${CI_BRANCH}
 export VALIDATOR_IMG=${CI_VALIDATOR_IMG}
 export IMG=${CI_OPERATOR_IMG}
 

--- a/automation/ocp-ci-run-e2e-upgrade-tests.sh
+++ b/automation/ocp-ci-run-e2e-upgrade-tests.sh
@@ -7,8 +7,20 @@ set -e
 # Deploy latest released SSP operator
 NAMESPACE=${1:-kubevirt}
 
-LATEST_SSP_VERSION=$(curl 'https://api.github.com/repos/kubevirt/ssp-operator/releases/latest' | jq '.name' | tr -d '"')
-oc apply -n $NAMESPACE -f "https://github.com/kubevirt/ssp-operator/releases/download/${LATEST_SSP_VERSION}/ssp-operator.yaml"
+if [[ -z ${RELEASE_BRANCH} ]] || [[ ${RELEASE_BRANCH} == "master" ]]
+then
+  # Get the latest release branch
+  RELEASE_BRANCH=$(curl 'https://api.github.com/repos/kubevirt/ssp-operator/branches' |
+    jq '[.[].name | select(startswith("release-v"))] | max_by(ltrimstr("release-v") | split(".") | map(tonumber))' |
+    tr -d '"')
+fi
+
+# GitHub API returns releases sorted by creation time. Latest release is the first.
+LATEST_RELEASED_VERSION=$(curl 'https://api.github.com/repos/kubevirt/ssp-operator/releases' |
+  jq --arg BRANCH "${RELEASE_BRANCH}" '[.[] | select(.target_commitish == $BRANCH) | .name] | .[0]' |
+  tr -d '"')
+
+oc apply -n $NAMESPACE -f "https://github.com/kubevirt/ssp-operator/releases/download/${LATEST_RELEASED_VERSION}/ssp-operator.yaml"
 
 # Wait for deployment to be available, otherwise the validating webhook would reject the SSP CR.
 oc wait --for=condition=Available --timeout=600s -n ${NAMESPACE} deployments/ssp-operator

--- a/hack/validate-no-offensive-lang.sh
+++ b/hack/validate-no-offensive-lang.sh
@@ -3,7 +3,7 @@
 OFFENSIVE_WORDS="black[ -]?list|white[ -]?list|master|slave"
 ALLOW_LIST=".+[:/=]master[a-zA-Z]*/?"
 
-if git grep -inE "${OFFENSIVE_WORDS}" -- ':!vendor' ":!${BASH_SOURCE[0]}" ':!.github/workflows/' | grep -viE "${ALLOW_LIST}"; then
+if git grep -inE "${OFFENSIVE_WORDS}" -- ':!vendor' ':!automation' ":!${BASH_SOURCE[0]}" ':!.github/workflows/' | grep -viE "${ALLOW_LIST}"; then
   echo "Validation failed. Found offensive language"
   exit 1
 fi


### PR DESCRIPTION
**What this PR does / why we need it**:
This patch adds a new parameter for `e2e-upgrade-functests lane`, which specifies the release branch with the latest release.

This is needed when a PR is targeted for a release branch that is not latest. Without this change, the CI would test
downgrade, instead of upgrade.

**Release note**:
```release-note
None
```
