### PR TITLE
Change docker commands into podman

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Publish operator image and generate release assets
         run: |
-          docker login -u="${{ secrets.QUAY_BOT }}" -p="${{ secrets.QUAY_PASSWORD }}" quay.io
+          podman login -u="${{ secrets.QUAY_BOT }}" -p="${{ secrets.QUAY_PASSWORD }}" quay.io
           export IMG_TAG="${{ steps.get_release.outputs.tag_name }}"
           export VALIDATOR_IMG_TAG="${{ steps.get_release.outputs.tag_name }}"
           export VERSION="`echo ${{ steps.get_release.outputs.tag_name }} | sed 's/^v//'`"

--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ container-build: unittest bundle
 	mkdir -p data/crd
 	cp bundle/manifests/ssp-operator.clusterserviceversion.yaml data/olm-catalog/ssp-operator.clusterserviceversion.yaml
 	cp bundle/manifests/ssp.kubevirt.io_ssps.yaml data/crd/ssp.kubevirt.io_ssps.yaml
-	docker build -t ${IMG} \
+	podman build -t ${IMG} \
 		--build-arg IMG_REPOSITORY=${IMG_REPOSITORY} \
 		--build-arg IMG_TAG=${IMG_TAG} \
 		--build-arg IMG=${IMG} \
@@ -155,13 +155,13 @@ container-build: unittest bundle
 
 # Push the container image
 container-push:
-	docker push ${IMG}
+	podman push ${IMG}
 
 build-template-validator:
 	./hack/build-template-validator.sh ${VERSION}
 
 build-template-validator-container:
-	docker build -t ${VALIDATOR_IMG} \
+	podman build -t ${VALIDATOR_IMG} \
 		--build-arg IMG_REPOSITORY=${IMG_REPOSITORY} \
 		--build-arg IMG_TAG=${IMG_TAG} \
 		--build-arg IMG=${IMG} \
@@ -171,7 +171,7 @@ build-template-validator-container:
 		. -f validator.Dockerfile
 
 push-template-validator-container:
-	docker push ${VALIDATOR_IMG}
+	podman push ${VALIDATOR_IMG}
 
 # Download controller-gen locally if necessary
 CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
@@ -226,7 +226,7 @@ bundle: operator-sdk manifests kustomize csv-generator manager-envsubst
 # Build the bundle image.
 .PHONY: bundle-build
 bundle-build:
-	docker build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
+	podman build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
 
 .PHONY: release
 release: container-build container-push build-template-validator-container push-template-validator-container bundle build-functests

--- a/hack/config.sh
+++ b/hack/config.sh
@@ -5,11 +5,8 @@ if [ -z ${KUBEVIRT_CRI} ]; then
     if podman ps >/dev/null; then
         KUBEVIRT_CRI=podman
         echo "selecting podman as container runtime"
-    elif docker ps >/dev/null; then
-        KUBEVIRT_CRI=docker
-        echo "selecting docker as container runtime"
     else
-        echo "no working container runtime found. Neither docker nor podman seems to work."
+        echo "no working container runtime found. Podman seems not to work."
         exit 1
     fi
 fi

--- a/tests/e2e-test-csv-generator.sh
+++ b/tests/e2e-test-csv-generator.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-olm_output=$(docker run --rm --entrypoint=/csv-generator quay.io/kubevirt/ssp-operator:latest \
+olm_output=$(podman run --rm --entrypoint=/csv-generator quay.io/kubevirt/ssp-operator:latest \
 --csv-version=9.9.9 --namespace=namespace-test --operator-version=8.8.8  --validator-image=validator-test --dump-crds \
 --operator-image=operator-test)
 
@@ -30,7 +30,7 @@ if [ $(echo $olm_output | grep 'group: ssp.kubevirt.io'| wc -l) -eq 0 ]; then
 fi
 
 #test the case without --dump-crds flag
-olm_output=$(docker run --rm --entrypoint=/csv-generator quay.io/kubevirt/ssp-operator:latest \
+olm_output=$(podman run --rm --entrypoint=/csv-generator quay.io/kubevirt/ssp-operator:latest \
 --csv-version=9.9.9 --namespace=namespace-test --operator-version=8.8.8 --validator-image=validator-test \
 --operator-image=operator-test)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Change docker commands into podman

**Release note**:
```
Removes all docker references and replaces them with podman.
```
Signed-off-by: Ondrej Pokorny <opokorny@redhat.com>
