### PR TITLE
update validator dockerfile to use golang 1.18

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -202,7 +202,7 @@ TMP_DIR=$$(mktemp -d) ;\
 cd $$TMP_DIR ;\
 go mod init tmp ;\
 echo "Downloading $(2)" ;\
-GOBIN=$(PROJECT_DIR)/bin go install $(2) ;\
+GOFLAGS='' GOBIN=$(PROJECT_DIR)/bin go install $(2) ;\
 rm -rf $$TMP_DIR ;\
 }
 endef

--- a/validator.Dockerfile
+++ b/validator.Dockerfile
@@ -1,6 +1,8 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal as builder
 
-RUN microdnf install -y golang-1.16.* && microdnf clean all
+RUN microdnf install -y make wget tar gzip which && microdnf clean all
+RUN wget https://go.dev/dl/go1.18.1.linux-amd64.tar.gz && tar -C /usr/local -xzf go1.18.1.linux-amd64.tar.gz
+ENV PATH=$PATH:/usr/local/go/bin
 
 ARG VERSION=latest
 ARG COMPONENT="kubevirt-template-validator"


### PR DESCRIPTION
**What this PR does / why we need it**:
update validator dockerfile to use golang 1.18

Signed-off-by: Karel Šimon <ksimon@redhat.com>

**Release note**:
```
NONE
```
