### PR TITLE
Remove evictionStrategy from VM in SNO

### DIFF
--- a/controllers/setup.go
+++ b/controllers/setup.go
@@ -19,8 +19,13 @@ import (
 )
 
 func CreateAndSetupReconciler(mgr controllerruntime.Manager) error {
+	infrastructureTopology, err := common.GetInfrastructureTopology(mgr.GetAPIReader())
+	if err != nil {
+		return err
+	}
+
 	templatesFile := filepath.Join(templateBundleDir, "common-templates-"+common_templates.Version+".yaml")
-	templatesBundle, err := template_bundle.ReadBundle(templatesFile)
+	templatesBundle, err := template_bundle.ReadBundle(templatesFile, infrastructureTopology, mgr.GetScheme())
 	if err != nil {
 		return err
 	}
@@ -41,11 +46,6 @@ func CreateAndSetupReconciler(mgr controllerruntime.Manager) error {
 	// Check if all needed CRDs exist
 	crdList := &extv1.CustomResourceDefinitionList{}
 	err = mgr.GetAPIReader().List(context.TODO(), crdList)
-	if err != nil {
-		return err
-	}
-
-	infrastructureTopology, err := common.GetInfrastructureTopology(mgr.GetAPIReader())
 	if err != nil {
 		return err
 	}

--- a/internal/template-bundle/bundle_test.go
+++ b/internal/template-bundle/bundle_test.go
@@ -1,6 +1,12 @@
 package template_bundle
 
 import (
+	"github.com/onsi/ginkgo/extensions/table"
+	osconfv1 "github.com/openshift/api/config/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	kubevirtv1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/ssp-operator/internal/common"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
@@ -12,43 +18,56 @@ var _ = Describe("Template bundle", func() {
 		testBundle Bundle
 	)
 
-	BeforeSuite(func() {
+	readBundle := func(topology osconfv1.TopologyMode) {
 		var err error
-		testBundle, err = ReadBundle("template-bundle-test.yaml")
+		testBundle, err = ReadBundle("template-bundle-test.yaml", topology, common.Scheme)
 		Expect(err).ToNot(HaveOccurred())
-	})
+	}
 
-	It("should correctly read templates", func() {
+	table.DescribeTable("should correctly read templates", func(topology osconfv1.TopologyMode) {
+		readBundle(topology)
 		templates := testBundle.Templates
 		Expect(templates).To(HaveLen(4))
 
+		evictionStrategyExpectFun := ExpectEvictionStrategyLiveMigrate
+		if topology == osconfv1.SingleReplicaTopologyMode {
+			evictionStrategyExpectFun = ExpectEvictionStrategyNotPresent
+		}
 		{
 			templ := templates[0]
 			Expect(templ.Name).To(Equal("centos-stream8-server-medium"))
 			Expect(templ.Annotations).To(HaveKey("name.os.template.kubevirt.io/centos-stream8"))
 			Expect(templ.Objects).To(HaveLen(1))
+			evictionStrategyExpectFun(&templ.Objects[0])
 		}
 		{
 			templ := templates[1]
 			Expect(templ.Name).To(Equal("centos-stream8-desktop-large"))
 			Expect(templ.Annotations).To(HaveKey("name.os.template.kubevirt.io/centos-stream8"))
 			Expect(templ.Objects).To(HaveLen(1))
+			evictionStrategyExpectFun(&templ.Objects[0])
 		}
 		{
 			templ := templates[2]
 			Expect(templ.Name).To(Equal("windows10-desktop-medium"))
 			Expect(templ.Annotations).To(HaveKey("name.os.template.kubevirt.io/win10"))
 			Expect(templ.Objects).To(HaveLen(1))
+			evictionStrategyExpectFun(&templ.Objects[0])
 		}
 		{
 			templ := templates[3]
 			Expect(templ.Name).To(Equal("rhel8-saphana-tiny"))
 			Expect(templ.Annotations).To(HaveKey("name.os.template.kubevirt.io/rhel8.4"))
 			Expect(templ.Objects).To(HaveLen(1))
+			evictionStrategyExpectFun(&templ.Objects[0])
 		}
-	})
+	},
+		table.Entry("in HighlyAvailableTopologyMode infrastructure", osconfv1.HighlyAvailableTopologyMode),
+		table.Entry("in SingleReplicaTopologyMode infrastructure", osconfv1.SingleReplicaTopologyMode),
+	)
 
 	It("should create DataSources", func() {
+		readBundle(osconfv1.HighlyAvailableTopologyMode)
 		dataSources := testBundle.DataSources
 		Expect(dataSources).To(HaveLen(2))
 
@@ -65,6 +84,28 @@ var _ = Describe("Template bundle", func() {
 		Expect(ds2.Spec.Source.PVC.Namespace).To(Equal("kubevirt-os-images"))
 	})
 })
+
+func ExpectEvictionStrategyNotPresent(obj *runtime.RawExtension) {
+	vmUnstructured := expectEvictionStrategy(obj)
+	_, found, err := unstructured.NestedFieldNoCopy(vmUnstructured.Object, "spec", "template", "spec", "evictionStrategy")
+	Expect(err).ToNot(HaveOccurred())
+	Expect(found).To(BeFalse())
+}
+
+func ExpectEvictionStrategyLiveMigrate(obj *runtime.RawExtension) {
+	vmUnstructured := expectEvictionStrategy(obj)
+	val, found, err := unstructured.NestedFieldNoCopy(vmUnstructured.Object, "spec", "template", "spec", "evictionStrategy")
+	Expect(err).ToNot(HaveOccurred())
+	Expect(found).To(BeTrue())
+	Expect(val).To(Equal(string(kubevirtv1.EvictionStrategyLiveMigrate)))
+}
+
+func expectEvictionStrategy(obj *runtime.RawExtension) *unstructured.Unstructured {
+	vmUnstructured, isVm, err := decodeToVMUnstructured(obj)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(isVm).To(BeTrue())
+	return vmUnstructured
+}
 
 func TestTemplateBundle(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/internal/template-bundle/bundle_test.go
+++ b/internal/template-bundle/bundle_test.go
@@ -86,21 +86,21 @@ var _ = Describe("Template bundle", func() {
 })
 
 func ExpectEvictionStrategyNotPresent(obj *runtime.RawExtension) {
-	vmUnstructured := expectEvictionStrategy(obj)
+	vmUnstructured := decodeToVMUnstructuredAndExpectSuccess(obj)
 	_, found, err := unstructured.NestedFieldNoCopy(vmUnstructured.Object, "spec", "template", "spec", "evictionStrategy")
 	Expect(err).ToNot(HaveOccurred())
 	Expect(found).To(BeFalse())
 }
 
 func ExpectEvictionStrategyLiveMigrate(obj *runtime.RawExtension) {
-	vmUnstructured := expectEvictionStrategy(obj)
+	vmUnstructured := decodeToVMUnstructuredAndExpectSuccess(obj)
 	val, found, err := unstructured.NestedFieldNoCopy(vmUnstructured.Object, "spec", "template", "spec", "evictionStrategy")
 	Expect(err).ToNot(HaveOccurred())
 	Expect(found).To(BeTrue())
 	Expect(val).To(Equal(string(kubevirtv1.EvictionStrategyLiveMigrate)))
 }
 
-func expectEvictionStrategy(obj *runtime.RawExtension) *unstructured.Unstructured {
+func decodeToVMUnstructuredAndExpectSuccess(obj *runtime.RawExtension) *unstructured.Unstructured {
 	vmUnstructured, isVm, err := decodeToVMUnstructured(obj)
 	Expect(err).ToNot(HaveOccurred())
 	Expect(isVm).To(BeTrue())

--- a/internal/template-bundle/template-bundle-test.yaml
+++ b/internal/template-bundle/template-bundle-test.yaml
@@ -80,6 +80,7 @@ objects:
             kubevirt.io/domain: ${NAME}
             kubevirt.io/size: medium
         spec:
+          evictionStrategy: LiveMigrate
           domain:
             cpu:
               sockets: 1
@@ -212,6 +213,7 @@ objects:
             kubevirt.io/domain: ${NAME}
             kubevirt.io/size: large
         spec:
+          evictionStrategy: LiveMigrate
           domain:
             cpu:
               sockets: 2
@@ -370,6 +372,7 @@ objects:
             kubevirt.io/domain: ${NAME}
             kubevirt.io/size: medium
         spec:
+          evictionStrategy: LiveMigrate
           domain:
             clock:
               utc: {}
@@ -510,6 +513,7 @@ objects:
             kubevirt.io/domain: ${NAME}
             kubevirt.io/size: tiny
         spec:
+          evictionStrategy: LiveMigrate
           hostname: ${NAME}
           domain:
             ioThreadsPolicy: auto


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
In single replica infrastructure having "LiveMigrate" in
`template.spec.evictionStrategy` is wrong, since live migration requires
at least one node in which migrate.
Remove the field only in single node.

**Which issue(s) this PR fixes**: 
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Remove evictionStrategy `LiveMigrate` from template in SNO cluster
```
