### PR TITLE
Add predicates to only watch relevant resource changes

### DIFF
--- a/internal/controller/predicates/predicates.go
+++ b/internal/controller/predicates/predicates.go
@@ -1,0 +1,36 @@
+package predicates
+
+import (
+	"reflect"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+type SpecChangedPredicate struct {
+	predicate.Funcs
+}
+
+func (p SpecChangedPredicate) Update(e event.UpdateEvent) bool {
+	newSpec, exists := getSpec(e.ObjectNew)
+	if !exists {
+		return true
+	}
+
+	oldSpec, exists := getSpec(e.ObjectOld)
+	if !exists {
+		return true
+	}
+
+	return !reflect.DeepEqual(newSpec, oldSpec)
+}
+
+func getSpec(obj client.Object) (interface{}, bool) {
+	val := reflect.ValueOf(obj).Elem()
+	specVal := val.FieldByName("Spec")
+	if !specVal.IsValid() {
+		return nil, false
+	}
+	return specVal.Interface(), true
+}

--- a/internal/controller/predicates/predicates_test.go
+++ b/internal/controller/predicates/predicates_test.go
@@ -1,0 +1,69 @@
+package predicates
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	v1 "k8s.io/api/rbac/v1"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	sspv1beta1 "kubevirt.io/ssp-operator/api/v1beta1"
+)
+
+var _ = Describe("SpecChangedPredicate", func() {
+	It("Should be false if spec is the same", func() {
+		obj := &sspv1beta1.SSP{
+			Spec: sspv1beta1.SSPSpec{
+				TemplateValidator: sspv1beta1.TemplateValidator{
+					Replicas: pointer.Int32(1),
+				},
+			},
+		}
+
+		updateEvent := event.UpdateEvent{
+			ObjectOld: obj,
+			ObjectNew: obj.DeepCopy(),
+		}
+
+		Expect(SpecChangedPredicate{}.Update(updateEvent)).To(BeFalse())
+	})
+
+	It("Shuld be true if spec is different", func() {
+		obj := &sspv1beta1.SSP{
+			Spec: sspv1beta1.SSPSpec{
+				TemplateValidator: sspv1beta1.TemplateValidator{
+					Replicas: pointer.Int32(1),
+				},
+			},
+		}
+
+		newObj := obj.DeepCopy()
+		newObj.Spec.TemplateValidator.Replicas = pointer.Int32(2)
+
+		updateEvent := event.UpdateEvent{
+			ObjectOld: obj,
+			ObjectNew: newObj,
+		}
+
+		Expect(SpecChangedPredicate{}.Update(updateEvent)).To(BeTrue())
+	})
+
+	It("Should be true is spec does not exist", func() {
+		obj := &v1.Role{}
+
+		updateEvent := event.UpdateEvent{
+			ObjectOld: obj,
+			ObjectNew: obj.DeepCopy(),
+		}
+
+		Expect(SpecChangedPredicate{}.Update(updateEvent)).To(BeTrue())
+	})
+})
+
+func TestPredicates(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Predicates Suite")
+}

--- a/internal/operands/common-templates/reconcile.go
+++ b/internal/operands/common-templates/reconcile.go
@@ -35,9 +35,9 @@ func init() {
 	utilruntime.Must(templatev1.Install(common.Scheme))
 }
 
-func WatchClusterTypes() []client.Object {
-	return []client.Object{
-		&templatev1.Template{},
+func WatchClusterTypes() []operands.WatchType {
+	return []operands.WatchType{
+		{Object: &templatev1.Template{}},
 	}
 }
 
@@ -65,11 +65,11 @@ const (
 	operandComponent = common.AppComponentTemplating
 )
 
-func (c *commonTemplates) WatchClusterTypes() []client.Object {
+func (c *commonTemplates) WatchClusterTypes() []operands.WatchType {
 	return WatchClusterTypes()
 }
 
-func (c *commonTemplates) WatchTypes() []client.Object {
+func (c *commonTemplates) WatchTypes() []operands.WatchType {
 	return nil
 }
 

--- a/internal/operands/data-sources/reconcile.go
+++ b/internal/operands/data-sources/reconcile.go
@@ -39,14 +39,15 @@ func init() {
 	utilruntime.Must(cdiv1beta1.AddToScheme(common.Scheme))
 }
 
-func WatchClusterTypes() []client.Object {
-	return []client.Object{
-		&rbac.ClusterRole{},
-		&rbac.Role{},
-		&rbac.RoleBinding{},
-		&core.Namespace{},
-		&cdiv1beta1.DataSource{},
-		&cdiv1beta1.DataImportCron{},
+func WatchClusterTypes() []operands.WatchType {
+	return []operands.WatchType{
+		{Object: &rbac.ClusterRole{}},
+		{Object: &rbac.Role{}},
+		{Object: &rbac.RoleBinding{}},
+		{Object: &core.Namespace{}},
+		// Need to watch status of DataSource to notice if referenced PVC was deleted.
+		{Object: &cdiv1beta1.DataSource{}, WatchFullObject: true},
+		{Object: &cdiv1beta1.DataImportCron{}},
 	}
 }
 
@@ -66,11 +67,11 @@ func (d *dataSources) Name() string {
 	return operandName
 }
 
-func (d *dataSources) WatchTypes() []client.Object {
+func (d *dataSources) WatchTypes() []operands.WatchType {
 	return nil
 }
 
-func (d *dataSources) WatchClusterTypes() []client.Object {
+func (d *dataSources) WatchClusterTypes() []operands.WatchType {
 	return WatchClusterTypes()
 }
 

--- a/internal/operands/metrics/reconcile.go
+++ b/internal/operands/metrics/reconcile.go
@@ -18,17 +18,17 @@ func init() {
 	utilruntime.Must(promv1.AddToScheme(common.Scheme))
 }
 
-func WatchTypes() []client.Object {
-	return []client.Object{
-		&promv1.PrometheusRule{},
-		&promv1.ServiceMonitor{},
+func WatchTypes() []operands.WatchType {
+	return []operands.WatchType{
+		{Object: &promv1.PrometheusRule{}},
+		{Object: &promv1.ServiceMonitor{}},
 	}
 }
 
-func WatchClusterTypes() []client.Object {
-	return []client.Object{
-		&rbac.ClusterRole{},
-		&rbac.ClusterRoleBinding{},
+func WatchClusterTypes() []operands.WatchType {
+	return []operands.WatchType{
+		{Object: &rbac.ClusterRole{}},
+		{Object: &rbac.ClusterRoleBinding{}},
 	}
 }
 
@@ -38,11 +38,11 @@ func (m *metrics) Name() string {
 	return operandName
 }
 
-func (m *metrics) WatchTypes() []client.Object {
+func (m *metrics) WatchTypes() []operands.WatchType {
 	return WatchTypes()
 }
 
-func (m *metrics) WatchClusterTypes() []client.Object {
+func (m *metrics) WatchClusterTypes() []operands.WatchType {
 	return WatchClusterTypes()
 }
 

--- a/internal/operands/node-labeller/reconcile.go
+++ b/internal/operands/node-labeller/reconcile.go
@@ -36,19 +36,19 @@ func init() {
 	utilruntime.Must(secv1.Install(common.Scheme))
 }
 
-func WatchTypes() []client.Object {
-	return []client.Object{
-		&v1.ServiceAccount{},
-		&v1.ConfigMap{},
-		&apps.DaemonSet{},
+func WatchTypes() []operands.WatchType {
+	return []operands.WatchType{
+		{Object: &v1.ServiceAccount{}},
+		{Object: &v1.ConfigMap{}},
+		{Object: &apps.DaemonSet{}, WatchFullObject: true},
 	}
 }
 
-func WatchClusterTypes() []client.Object {
-	return []client.Object{
-		&rbac.ClusterRole{},
-		&rbac.ClusterRoleBinding{},
-		&secv1.SecurityContextConstraints{},
+func WatchClusterTypes() []operands.WatchType {
+	return []operands.WatchType{
+		{Object: &rbac.ClusterRole{}},
+		{Object: &rbac.ClusterRoleBinding{}},
+		{Object: &secv1.SecurityContextConstraints{}},
 	}
 }
 
@@ -58,11 +58,11 @@ func (nl *nodeLabeller) Name() string {
 	return operandName
 }
 
-func (nl *nodeLabeller) WatchTypes() []client.Object {
+func (nl *nodeLabeller) WatchTypes() []operands.WatchType {
 	return WatchTypes()
 }
 
-func (nl *nodeLabeller) WatchClusterTypes() []client.Object {
+func (nl *nodeLabeller) WatchClusterTypes() []operands.WatchType {
 	return WatchClusterTypes()
 }
 

--- a/internal/operands/operand.go
+++ b/internal/operands/operand.go
@@ -8,10 +8,10 @@ import (
 
 type Operand interface {
 	// WatchTypes returns a slice of namespaced resources, that the operator should watch.
-	WatchTypes() []client.Object
+	WatchTypes() []WatchType
 
 	// WatchClusterTypes returns a slice of cluster resources, that the operator should watch.
-	WatchClusterTypes() []client.Object
+	WatchClusterTypes() []WatchType
 
 	// RequiredCrds returns names of CRDs, that need to be installed for the operand to work.
 	RequiredCrds() []string
@@ -25,4 +25,13 @@ type Operand interface {
 
 	// Name returns the name of the operand
 	Name() string
+}
+
+type WatchType struct {
+	Object client.Object
+
+	// WatchFullObject specifies if the operator should watch for any changes in the full object.
+	// Otherwise, only these changes in spec, labels, and annotations.
+	// If an object does not have spec field, the full object is watched by default.
+	WatchFullObject bool
 }

--- a/internal/operands/template-validator/reconcile.go
+++ b/internal/operands/template-validator/reconcile.go
@@ -24,19 +24,19 @@ import (
 // +kubebuilder:rbac:groups=template.openshift.io,resources=templates,verbs=get;list;watch
 // +kubebuilder:rbac:groups=kubevirt.io,resources=virtualmachines,verbs=get;list;watch
 
-func WatchTypes() []client.Object {
-	return []client.Object{
-		&v1.ServiceAccount{},
-		&v1.Service{},
-		&apps.Deployment{},
+func WatchTypes() []operands.WatchType {
+	return []operands.WatchType{
+		{Object: &v1.ServiceAccount{}},
+		{Object: &v1.Service{}},
+		{Object: &apps.Deployment{}, WatchFullObject: true},
 	}
 }
 
-func WatchClusterTypes() []client.Object {
-	return []client.Object{
-		&rbac.ClusterRole{},
-		&rbac.ClusterRoleBinding{},
-		&admission.ValidatingWebhookConfiguration{},
+func WatchClusterTypes() []operands.WatchType {
+	return []operands.WatchType{
+		{Object: &rbac.ClusterRole{}},
+		{Object: &rbac.ClusterRoleBinding{}},
+		{Object: &admission.ValidatingWebhookConfiguration{}},
 	}
 }
 
@@ -46,11 +46,11 @@ func (t *templateValidator) Name() string {
 	return operandName
 }
 
-func (t *templateValidator) WatchTypes() []client.Object {
+func (t *templateValidator) WatchTypes() []operands.WatchType {
 	return WatchTypes()
 }
 
-func (t *templateValidator) WatchClusterTypes() []client.Object {
+func (t *templateValidator) WatchClusterTypes() []operands.WatchType {
 	return WatchClusterTypes()
 }
 

--- a/tests/cleanup_test.go
+++ b/tests/cleanup_test.go
@@ -11,6 +11,7 @@ import (
 
 	sspv1beta1 "kubevirt.io/ssp-operator/api/v1beta1"
 	"kubevirt.io/ssp-operator/internal/common"
+	"kubevirt.io/ssp-operator/internal/operands"
 	common_templates "kubevirt.io/ssp-operator/internal/operands/common-templates"
 	"kubevirt.io/ssp-operator/internal/operands/metrics"
 	nodelabeller "kubevirt.io/ssp-operator/internal/operands/node-labeller"
@@ -27,8 +28,8 @@ var _ = Describe("Cleanup", func() {
 	})
 
 	It("[test_id:7394] should cleanup all deployed resources when SSP is deleted", func() {
-		var allResourceTypes []client.Object
-		for _, f := range []func() []client.Object{
+		var allWatchTypes []operands.WatchType
+		for _, f := range []func() []operands.WatchType{
 			common_templates.WatchClusterTypes,
 			data_sources.WatchClusterTypes,
 			metrics.WatchTypes,
@@ -38,7 +39,7 @@ var _ = Describe("Cleanup", func() {
 			template_validator.WatchTypes,
 			template_validator.WatchClusterTypes,
 		} {
-			allResourceTypes = append(allResourceTypes, f()...)
+			allWatchTypes = append(allWatchTypes, f()...)
 		}
 
 		ssp := getSsp()
@@ -47,8 +48,8 @@ var _ = Describe("Cleanup", func() {
 		waitForDeletion(client.ObjectKeyFromObject(ssp), &sspv1beta1.SSP{})
 
 		// Check that all deployed resources were deleted
-		for _, resource := range allResourceTypes {
-			gvk, err := apiutil.GVKForObject(resource, testScheme)
+		for _, watchType := range allWatchTypes {
+			gvk, err := apiutil.GVKForObject(watchType.Object, testScheme)
 			Expect(err).ToNot(HaveOccurred())
 
 			list := &unstructured.UnstructuredList{}


### PR DESCRIPTION
**What this PR does / why we need it**:
Some changes in a resource are not relevant for the reoconcile function. Mainly changes in `.status` field.
This change adds a predicate to filter out these changes.

**Which issue(s) this PR fixes**: 
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2082912

**Release note**:
```release-note
None
```
