### PR TITLE
Update github actions to use golang 1.18

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -9,10 +9,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - name: Install Golang 1.17
+    - name: Install Golang 1.18
       uses: actions/setup-go@v2
       with:
-        go-version: '1.17'
+        go-version: '1.18'
 
     - name: Checkout code
       uses: actions/checkout@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,10 +9,10 @@ jobs:
     name: Upload Release Asset
     runs-on: ubuntu-latest
     steps:
-      - name: Install Golang 1.17
+      - name: Install Golang 1.18
         uses: actions/setup-go@v2
         with:
-          go-version: '1.17'
+          go-version: '1.18'
 
       - name: Checkout code
         uses: actions/checkout@v2


### PR DESCRIPTION
**What this PR does / why we need it**:
Update github actions to use golang 1.18

**Release note**:
```release-note
None
```
