### PR TITLE
[release-v0.13] Add predicates to only watch relevant resource changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
 # Build the manager binary
 FROM registry.access.redhat.com/ubi8/ubi-minimal as builder
 
-RUN microdnf install -y make golang-1.16.* which && microdnf clean all
+RUN microdnf install -y make tar gzip which && microdnf clean all
+
+RUN curl -L https://go.dev/dl/go1.16.15.linux-amd64.tar.gz | tar -C /usr/local -xzf -
+ENV PATH=$PATH:/usr/local/go/bin
 
 # Consume required variables so we can work with make
 ARG IMG_REPOSITORY

--- a/controllers/ssp_controller.go
+++ b/controllers/ssp_controller.go
@@ -46,6 +46,7 @@ import (
 	ssp "kubevirt.io/ssp-operator/api/v1beta1"
 	"kubevirt.io/ssp-operator/internal/common"
 	handler_hook "kubevirt.io/ssp-operator/internal/controller/handler-hook"
+	"kubevirt.io/ssp-operator/internal/controller/predicates"
 	"kubevirt.io/ssp-operator/internal/operands"
 )
 
@@ -632,23 +633,19 @@ func handleError(request *common.Request, errParam error, logger logr.Logger) (c
 
 func watchSspResource(bldr *ctrl.Builder) {
 	// Predicate is used to only reconcile on these changes to the SSP resource:
-	// - any change in spec - checked with generation
+	// - changes in spec, labels and annotations - using relevantChangesPredicate()
 	// - deletion timestamp - to trigger cleanup when SSP CR is being deleted
-	// - labels or annotations - to detect if reconciliation should be paused or unpaused
 	// - finalizers - to trigger reconciliation after initialization
 	//
 	// Importantly, the reconciliation is not triggered on status change.
-	// Otherwise it would cause a reconciliation loop.
-	pred := predicate.Funcs{UpdateFunc: func(event event.UpdateEvent) bool {
-		oldObj := event.ObjectOld
-		newObj := event.ObjectNew
-		return newObj.GetGeneration() != oldObj.GetGeneration() ||
-			!newObj.GetDeletionTimestamp().Equal(oldObj.GetDeletionTimestamp()) ||
-			!reflect.DeepEqual(newObj.GetLabels(), oldObj.GetLabels()) ||
-			!reflect.DeepEqual(newObj.GetAnnotations(), oldObj.GetAnnotations()) ||
-			!reflect.DeepEqual(newObj.GetFinalizers(), oldObj.GetFinalizers())
-
-	}}
+	// Otherwise, it would cause a reconciliation loop.
+	pred := predicate.Or(
+		relevantChangesPredicate(),
+		predicate.Funcs{UpdateFunc: func(event event.UpdateEvent) bool {
+			return !event.ObjectNew.GetDeletionTimestamp().Equal(event.ObjectOld.GetDeletionTimestamp()) ||
+				!reflect.DeepEqual(event.ObjectNew.GetFinalizers(), event.ObjectOld.GetFinalizers())
+		}},
+	)
 
 	bldr.For(&ssp.SSP{}, builder.WithPredicates(pred))
 }
@@ -679,19 +676,42 @@ func watchClusterResources(builder *ctrl.Builder, sspOperands []operands.Operand
 	)
 }
 
-func watchResources(builder *ctrl.Builder, handler handler.EventHandler, sspOperands []operands.Operand, watchTypesFunc func(operands.Operand) []client.Object, hookFunc handler_hook.HookFunc) {
-	watchedTypes := make(map[reflect.Type]struct{})
+func watchResources(ctrlBuilder *ctrl.Builder, handler handler.EventHandler, sspOperands []operands.Operand, watchTypesFunc func(operands.Operand) []operands.WatchType, hookFunc handler_hook.HookFunc) {
+	// Deduplicate watches
+	watchedTypes := make(map[reflect.Type]operands.WatchType)
 	for _, operand := range sspOperands {
-		for _, t := range watchTypesFunc(operand) {
-			if _, ok := watchedTypes[reflect.TypeOf(t)]; ok {
-				continue
+		for _, watchType := range watchTypesFunc(operand) {
+			key := reflect.TypeOf(watchType.Object)
+			// If at least one watchType wants to watch full object,
+			// then the stored watchType should also watch full object.
+			if wt, ok := watchedTypes[key]; ok {
+				watchType.WatchFullObject = watchType.WatchFullObject || wt.WatchFullObject
 			}
-
-			builder.Watches(
-				&source.Kind{Type: t},
-				handler_hook.New(handler, hookFunc),
-			)
-			watchedTypes[reflect.TypeOf(t)] = struct{}{}
+			watchedTypes[key] = watchType
 		}
 	}
+
+	for _, watchType := range watchedTypes {
+		var predicates []predicate.Predicate
+		if !watchType.WatchFullObject {
+			predicates = []predicate.Predicate{relevantChangesPredicate()}
+		}
+
+		ctrlBuilder.Watches(
+			&source.Kind{Type: watchType.Object},
+			handler_hook.New(handler, hookFunc),
+			builder.WithPredicates(predicates...),
+		)
+	}
+}
+
+// relevantChangesPredicate is used to only reconcile on certain changes to watched resources
+// - any change in spec
+// - labels or annotations - to detect if necessary labels or annotations were modified or removed
+func relevantChangesPredicate() predicate.Predicate {
+	return predicate.Or(
+		predicate.LabelChangedPredicate{},
+		predicate.AnnotationChangedPredicate{},
+		predicates.SpecChangedPredicate{},
+	)
 }

--- a/internal/controller/handler-hook/handler_hook.go
+++ b/internal/controller/handler-hook/handler_hook.go
@@ -1,0 +1,78 @@
+package handler_hook
+
+import (
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/util/workqueue"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
+)
+
+type HookFunc func(request ctrl.Request, obj client.Object)
+
+func New(wrapped handler.EventHandler, hookFunc HookFunc) handler.EventHandler {
+	return &hook{
+		inner:    wrapped,
+		hookFunc: hookFunc,
+	}
+}
+
+type hook struct {
+	inner    handler.EventHandler
+	hookFunc HookFunc
+}
+
+var _ handler.EventHandler = &hook{}
+
+func (h *hook) Create(event event.CreateEvent, queue workqueue.RateLimitingInterface) {
+	h.inner.Create(event, &queueHook{queue, func(request ctrl.Request) {
+		h.hookFunc(request, event.Object)
+	}})
+}
+
+func (h *hook) Update(event event.UpdateEvent, queue workqueue.RateLimitingInterface) {
+	h.inner.Update(event, &queueHook{queue, func(request ctrl.Request) {
+		h.hookFunc(request, event.ObjectNew)
+	}})
+}
+
+func (h *hook) Delete(event event.DeleteEvent, queue workqueue.RateLimitingInterface) {
+	h.inner.Delete(event, &queueHook{queue, func(request ctrl.Request) {
+		h.hookFunc(request, event.Object)
+	}})
+}
+
+func (h *hook) Generic(event event.GenericEvent, queue workqueue.RateLimitingInterface) {
+	h.inner.Generic(event, &queueHook{queue, func(request ctrl.Request) {
+		h.hookFunc(request, event.Object)
+	}})
+}
+
+var _ inject.Scheme = &hook{}
+
+// The EnqueueRequestForOwner handler implements this interface.
+func (h *hook) InjectScheme(scheme *runtime.Scheme) error {
+	_, err := inject.SchemeInto(scheme, h.inner)
+	return err
+}
+
+var _ inject.Mapper = &hook{}
+
+// The EnqueueRequestForOwner handler implements this interface.
+func (h *hook) InjectMapper(mapper meta.RESTMapper) error {
+	_, err := inject.MapperInto(mapper, h.inner)
+	return err
+}
+
+type queueHook struct {
+	workqueue.RateLimitingInterface
+	closure func(request ctrl.Request)
+}
+
+func (q *queueHook) Add(item interface{}) {
+	q.closure(item.(ctrl.Request))
+	q.RateLimitingInterface.Add(item)
+}

--- a/internal/controller/predicates/predicates.go
+++ b/internal/controller/predicates/predicates.go
@@ -1,0 +1,36 @@
+package predicates
+
+import (
+	"reflect"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+type SpecChangedPredicate struct {
+	predicate.Funcs
+}
+
+func (p SpecChangedPredicate) Update(e event.UpdateEvent) bool {
+	newSpec, exists := getSpec(e.ObjectNew)
+	if !exists {
+		return true
+	}
+
+	oldSpec, exists := getSpec(e.ObjectOld)
+	if !exists {
+		return true
+	}
+
+	return !reflect.DeepEqual(newSpec, oldSpec)
+}
+
+func getSpec(obj client.Object) (interface{}, bool) {
+	val := reflect.ValueOf(obj).Elem()
+	specVal := val.FieldByName("Spec")
+	if !specVal.IsValid() {
+		return nil, false
+	}
+	return specVal.Interface(), true
+}

--- a/internal/controller/predicates/predicates_test.go
+++ b/internal/controller/predicates/predicates_test.go
@@ -1,0 +1,69 @@
+package predicates
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	v1 "k8s.io/api/rbac/v1"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	sspv1beta1 "kubevirt.io/ssp-operator/api/v1beta1"
+)
+
+var _ = Describe("SpecChangedPredicate", func() {
+	It("Should be false if spec is the same", func() {
+		obj := &sspv1beta1.SSP{
+			Spec: sspv1beta1.SSPSpec{
+				TemplateValidator: sspv1beta1.TemplateValidator{
+					Replicas: pointer.Int32(1),
+				},
+			},
+		}
+
+		updateEvent := event.UpdateEvent{
+			ObjectOld: obj,
+			ObjectNew: obj.DeepCopy(),
+		}
+
+		Expect(SpecChangedPredicate{}.Update(updateEvent)).To(BeFalse())
+	})
+
+	It("Shuld be true if spec is different", func() {
+		obj := &sspv1beta1.SSP{
+			Spec: sspv1beta1.SSPSpec{
+				TemplateValidator: sspv1beta1.TemplateValidator{
+					Replicas: pointer.Int32(1),
+				},
+			},
+		}
+
+		newObj := obj.DeepCopy()
+		newObj.Spec.TemplateValidator.Replicas = pointer.Int32(2)
+
+		updateEvent := event.UpdateEvent{
+			ObjectOld: obj,
+			ObjectNew: newObj,
+		}
+
+		Expect(SpecChangedPredicate{}.Update(updateEvent)).To(BeTrue())
+	})
+
+	It("Should be true is spec does not exist", func() {
+		obj := &v1.Role{}
+
+		updateEvent := event.UpdateEvent{
+			ObjectOld: obj,
+			ObjectNew: obj.DeepCopy(),
+		}
+
+		Expect(SpecChangedPredicate{}.Update(updateEvent)).To(BeTrue())
+	})
+})
+
+func TestPredicates(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Predicates Suite")
+}

--- a/internal/operands/common-templates/reconcile.go
+++ b/internal/operands/common-templates/reconcile.go
@@ -31,9 +31,9 @@ func init() {
 	utilruntime.Must(templatev1.Install(common.Scheme))
 }
 
-func WatchClusterTypes() []client.Object {
-	return []client.Object{
-		&templatev1.Template{},
+func WatchClusterTypes() []operands.WatchType {
+	return []operands.WatchType{
+		{Object: &templatev1.Template{}},
 	}
 }
 
@@ -61,11 +61,11 @@ const (
 	operandComponent = common.AppComponentTemplating
 )
 
-func (c *commonTemplates) WatchClusterTypes() []client.Object {
+func (c *commonTemplates) WatchClusterTypes() []operands.WatchType {
 	return WatchClusterTypes()
 }
 
-func (c *commonTemplates) WatchTypes() []client.Object {
+func (c *commonTemplates) WatchTypes() []operands.WatchType {
 	return nil
 }
 

--- a/internal/operands/data-sources/reconcile.go
+++ b/internal/operands/data-sources/reconcile.go
@@ -38,14 +38,15 @@ func init() {
 	utilruntime.Must(cdiv1beta1.AddToScheme(common.Scheme))
 }
 
-func WatchClusterTypes() []client.Object {
-	return []client.Object{
-		&rbac.ClusterRole{},
-		&rbac.Role{},
-		&rbac.RoleBinding{},
-		&core.Namespace{},
-		&cdiv1beta1.DataSource{},
-		&cdiv1beta1.DataImportCron{},
+func WatchClusterTypes() []operands.WatchType {
+	return []operands.WatchType{
+		{Object: &rbac.ClusterRole{}},
+		{Object: &rbac.Role{}},
+		{Object: &rbac.RoleBinding{}},
+		{Object: &core.Namespace{}},
+		// Need to watch status of DataSource to notice if referenced PVC was deleted.
+		{Object: &cdiv1beta1.DataSource{}, WatchFullObject: true},
+		{Object: &cdiv1beta1.DataImportCron{}},
 	}
 }
 
@@ -65,11 +66,11 @@ func (d *dataSources) Name() string {
 	return operandName
 }
 
-func (d *dataSources) WatchTypes() []client.Object {
+func (d *dataSources) WatchTypes() []operands.WatchType {
 	return nil
 }
 
-func (d *dataSources) WatchClusterTypes() []client.Object {
+func (d *dataSources) WatchClusterTypes() []operands.WatchType {
 	return WatchClusterTypes()
 }
 

--- a/internal/operands/metrics/reconcile.go
+++ b/internal/operands/metrics/reconcile.go
@@ -16,8 +16,10 @@ func init() {
 	utilruntime.Must(promv1.AddToScheme(common.Scheme))
 }
 
-func WatchTypes() []client.Object {
-	return []client.Object{&promv1.PrometheusRule{}}
+func WatchTypes() []operands.WatchType {
+	return []operands.WatchType{
+		{Object: &promv1.PrometheusRule{}},
+	}
 }
 
 type metrics struct{}
@@ -26,11 +28,11 @@ func (m *metrics) Name() string {
 	return operandName
 }
 
-func (m *metrics) WatchTypes() []client.Object {
+func (m *metrics) WatchTypes() []operands.WatchType {
 	return WatchTypes()
 }
 
-func (m *metrics) WatchClusterTypes() []client.Object {
+func (m *metrics) WatchClusterTypes() []operands.WatchType {
 	return nil
 }
 

--- a/internal/operands/node-labeller/reconcile.go
+++ b/internal/operands/node-labeller/reconcile.go
@@ -36,19 +36,19 @@ func init() {
 	utilruntime.Must(secv1.Install(common.Scheme))
 }
 
-func WatchTypes() []client.Object {
-	return []client.Object{
-		&v1.ServiceAccount{},
-		&v1.ConfigMap{},
-		&apps.DaemonSet{},
+func WatchTypes() []operands.WatchType {
+	return []operands.WatchType{
+		{Object: &v1.ServiceAccount{}},
+		{Object: &v1.ConfigMap{}},
+		{Object: &apps.DaemonSet{}, WatchFullObject: true},
 	}
 }
 
-func WatchClusterTypes() []client.Object {
-	return []client.Object{
-		&rbac.ClusterRole{},
-		&rbac.ClusterRoleBinding{},
-		&secv1.SecurityContextConstraints{},
+func WatchClusterTypes() []operands.WatchType {
+	return []operands.WatchType{
+		{Object: &rbac.ClusterRole{}},
+		{Object: &rbac.ClusterRoleBinding{}},
+		{Object: &secv1.SecurityContextConstraints{}},
 	}
 }
 
@@ -58,11 +58,11 @@ func (nl *nodeLabeller) Name() string {
 	return operandName
 }
 
-func (nl *nodeLabeller) WatchTypes() []client.Object {
+func (nl *nodeLabeller) WatchTypes() []operands.WatchType {
 	return WatchTypes()
 }
 
-func (nl *nodeLabeller) WatchClusterTypes() []client.Object {
+func (nl *nodeLabeller) WatchClusterTypes() []operands.WatchType {
 	return WatchClusterTypes()
 }
 

--- a/internal/operands/operand.go
+++ b/internal/operands/operand.go
@@ -8,10 +8,10 @@ import (
 
 type Operand interface {
 	// WatchTypes returns a slice of namespaced resources, that the operator should watch.
-	WatchTypes() []client.Object
+	WatchTypes() []WatchType
 
 	// WatchClusterTypes returns a slice of cluster resources, that the operator should watch.
-	WatchClusterTypes() []client.Object
+	WatchClusterTypes() []WatchType
 
 	// RequiredCrds returns names of CRDs, that need to be installed for the operand to work.
 	RequiredCrds() []string
@@ -25,4 +25,13 @@ type Operand interface {
 
 	// Name returns the name of the operand
 	Name() string
+}
+
+type WatchType struct {
+	Object client.Object
+
+	// WatchFullObject specifies if the operator should watch for any changes in the full object.
+	// Otherwise, only these changes in spec, labels, and annotations.
+	// If an object does not have spec field, the full object is watched by default.
+	WatchFullObject bool
 }

--- a/internal/operands/template-validator/reconcile.go
+++ b/internal/operands/template-validator/reconcile.go
@@ -24,19 +24,19 @@ import (
 // +kubebuilder:rbac:groups=template.openshift.io,resources=templates,verbs=get;list;watch
 // +kubebuilder:rbac:groups=kubevirt.io,resources=virtualmachines,verbs=get;list;watch
 
-func WatchTypes() []client.Object {
-	return []client.Object{
-		&v1.ServiceAccount{},
-		&v1.Service{},
-		&apps.Deployment{},
+func WatchTypes() []operands.WatchType {
+	return []operands.WatchType{
+		{Object: &v1.ServiceAccount{}},
+		{Object: &v1.Service{}},
+		{Object: &apps.Deployment{}, WatchFullObject: true},
 	}
 }
 
-func WatchClusterTypes() []client.Object {
-	return []client.Object{
-		&rbac.ClusterRole{},
-		&rbac.ClusterRoleBinding{},
-		&admission.ValidatingWebhookConfiguration{},
+func WatchClusterTypes() []operands.WatchType {
+	return []operands.WatchType{
+		{Object: &rbac.ClusterRole{}},
+		{Object: &rbac.ClusterRoleBinding{}},
+		{Object: &admission.ValidatingWebhookConfiguration{}},
 	}
 }
 
@@ -46,11 +46,11 @@ func (t *templateValidator) Name() string {
 	return operandName
 }
 
-func (t *templateValidator) WatchTypes() []client.Object {
+func (t *templateValidator) WatchTypes() []operands.WatchType {
 	return WatchTypes()
 }
 
-func (t *templateValidator) WatchClusterTypes() []client.Object {
+func (t *templateValidator) WatchClusterTypes() []operands.WatchType {
 	return WatchClusterTypes()
 }
 

--- a/tests/cleanup_test.go
+++ b/tests/cleanup_test.go
@@ -11,6 +11,7 @@ import (
 
 	sspv1beta1 "kubevirt.io/ssp-operator/api/v1beta1"
 	"kubevirt.io/ssp-operator/internal/common"
+	"kubevirt.io/ssp-operator/internal/operands"
 	common_templates "kubevirt.io/ssp-operator/internal/operands/common-templates"
 	"kubevirt.io/ssp-operator/internal/operands/metrics"
 	nodelabeller "kubevirt.io/ssp-operator/internal/operands/node-labeller"
@@ -27,8 +28,8 @@ var _ = Describe("Cleanup", func() {
 	})
 
 	It("[test_id:7394] should cleanup all deployed resources when SSP is deleted", func() {
-		var allResourceTypes []client.Object
-		for _, f := range []func() []client.Object{
+		var allWatchTypes []operands.WatchType
+		for _, f := range []func() []operands.WatchType{
 			common_templates.WatchClusterTypes,
 			data_sources.WatchClusterTypes,
 			metrics.WatchTypes,
@@ -37,7 +38,7 @@ var _ = Describe("Cleanup", func() {
 			template_validator.WatchTypes,
 			template_validator.WatchClusterTypes,
 		} {
-			allResourceTypes = append(allResourceTypes, f()...)
+			allWatchTypes = append(allWatchTypes, f()...)
 		}
 
 		ssp := getSsp()
@@ -46,8 +47,8 @@ var _ = Describe("Cleanup", func() {
 		waitForDeletion(client.ObjectKeyFromObject(ssp), &sspv1beta1.SSP{})
 
 		// Check that all deployed resources were deleted
-		for _, resource := range allResourceTypes {
-			gvk, err := apiutil.GVKForObject(resource, testScheme)
+		for _, watchType := range allWatchTypes {
+			gvk, err := apiutil.GVKForObject(watchType.Object, testScheme)
 			Expect(err).ToNot(HaveOccurred())
 
 			list := &unstructured.UnstructuredList{}

--- a/validator.Dockerfile
+++ b/validator.Dockerfile
@@ -1,6 +1,9 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal as builder
 
-RUN microdnf install -y golang-1.16.* && microdnf clean all
+RUN microdnf install -y make tar gzip which && microdnf clean all
+
+RUN curl -L https://go.dev/dl/go1.16.15.linux-amd64.tar.gz | tar -C /usr/local -xzf -
+ENV PATH=$PATH:/usr/local/go/bin
 
 ARG VERSION=latest
 ARG COMPONENT="kubevirt-template-validator"


### PR DESCRIPTION
**What this PR does / why we need it**:
Some changes in a resource are not relevant for the reconcile function. Mainly changes in `.status` field.
This change adds a predicate to filter out these changes.

**Special notes for your reviewer**:
This is a backport of 2 PRs:
- https://github.com/kubevirt/ssp-operator/pull/351
- https://github.com/kubevirt/ssp-operator/pull/361

**Release note**:
```release-note
None
```
