### PR TITLE
Add an infra label to each of SSP alerts

### DIFF
--- a/internal/operands/metrics/resources.go
+++ b/internal/operands/metrics/resources.go
@@ -19,6 +19,7 @@ const (
 	componentAlertLabelValue     = "ssp-operator"
 	PrometheusLabelKey           = "prometheus.ssp.kubevirt.io"
 	PrometheusLabelValue         = "true"
+	infraAlertLabelKey           = "infra_alert"
 	PrometheusClusterRoleName    = "prometheus-k8s-ssp"
 	PrometheusServiceAccountName = "prometheus-k8s"
 	MetricsPortName              = "metrics"
@@ -88,6 +89,7 @@ var alertRulesList = []promv1.Rule{
 			severityAlertLabelKey:  "critical",
 			partOfAlertLabelKey:    partOfAlertLabelValue,
 			componentAlertLabelKey: componentAlertLabelValue,
+			infraAlertLabelKey:     "true",
 		},
 	},
 	{
@@ -102,6 +104,7 @@ var alertRulesList = []promv1.Rule{
 			severityAlertLabelKey:  "critical",
 			partOfAlertLabelKey:    partOfAlertLabelValue,
 			componentAlertLabelKey: componentAlertLabelValue,
+			infraAlertLabelKey:     "true",
 		},
 	},
 	{
@@ -116,6 +119,7 @@ var alertRulesList = []promv1.Rule{
 			severityAlertLabelKey:  "critical",
 			partOfAlertLabelKey:    partOfAlertLabelValue,
 			componentAlertLabelKey: componentAlertLabelValue,
+			infraAlertLabelKey:     "true",
 		},
 	},
 	{
@@ -130,6 +134,7 @@ var alertRulesList = []promv1.Rule{
 			severityAlertLabelKey:  "warning",
 			partOfAlertLabelKey:    partOfAlertLabelValue,
 			componentAlertLabelKey: componentAlertLabelValue,
+			infraAlertLabelKey:     "true",
 		},
 	},
 	{
@@ -144,6 +149,7 @@ var alertRulesList = []promv1.Rule{
 			severityAlertLabelKey:  "warning",
 			partOfAlertLabelKey:    partOfAlertLabelValue,
 			componentAlertLabelKey: componentAlertLabelValue,
+			infraAlertLabelKey:     "true",
 		},
 	},
 }


### PR DESCRIPTION
This PR adds a boolean label to each of SSP alerts, so that we can differentiate between alerts that are related to infrastructure, and alerts that are related to vmi. 
For more info, please see [#7796](https://github.com/kubevirt/kubevirt/pull/7796).

Signed-off-by: assafad [aadmi@redhat.com](mailto:aadmi@redhat.com)

```release-note
None
```