### PR TITLE
add eventually in AfterEach in validator webhook tests which tries to delete template

### DIFF
--- a/tests/validator_test.go
+++ b/tests/validator_test.go
@@ -426,10 +426,11 @@ var _ = Describe("Template validator webhooks", func() {
 			waitForDeletion(client.ObjectKeyFromObject(vm), vm)
 		}
 		if template != nil {
-			err := apiClient.Delete(ctx, template)
-			if !errors.IsNotFound(err) {
-				Expect(err).ToNot(HaveOccurred(), "Failed to delete Template")
-			}
+			Eventually(func(g Gomega) {
+				if err := apiClient.Delete(ctx, template); err != nil {
+					g.Expect(errors.ReasonForError(err)).To(Equal(metav1.StatusReasonNotFound))
+				}
+			}, shortTimeout, time.Second).Should(Succeed(), "Template should be deleted")
 		}
 	})
 


### PR DESCRIPTION
**What this PR does / why we need it**:
add eventually in AfterEach in validator webhook tests which tries to delete template
Signed-off-by: Karel Šimon <ksimon@redhat.com>

**Release note**:
```
NONE

```
