### PR TITLE
[backport release-v0.12] change a way ho golang is installed in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
 # Build the manager binary
 FROM registry.access.redhat.com/ubi8/ubi-minimal as builder
 
-RUN microdnf install -y make golang-1.16.* which && microdnf clean all
+RUN microdnf install -y make tar gzip which && microdnf clean all
+
+RUN curl -L https://go.dev/dl/go1.16.15.linux-amd64.tar.gz | tar -C /usr/local -xzf -
+ENV PATH=$PATH:/usr/local/go/bin
 
 # Consume required variables so we can work with make
 ARG IMG_REPOSITORY

--- a/internal/operands/common-templates/data/common-templates-bundle/common-templates-v0.16.5.yaml
+++ b/internal/operands/common-templates/data/common-templates-bundle/common-templates-v0.16.5.yaml
@@ -1,0 +1,14963 @@
+# Version v0.16.5
+---
+# Source: dist/templates/centos6-server-large.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: centos6-server-large
+  annotations:
+    openshift.io/display-name: "CentOS 6.0+ VM"
+    description: >-
+      Template for CentOS 6 VM or newer.
+      A PVC with the CentOS disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,linux,centos"
+    iconClass: "icon-centos"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/centos6.0: CentOS 6.0 or higher
+    name.os.template.kubevirt.io/centos6.1: CentOS 6.0 or higher
+    name.os.template.kubevirt.io/centos6.10: CentOS 6.0 or higher
+    name.os.template.kubevirt.io/centos6.2: CentOS 6.0 or higher
+    name.os.template.kubevirt.io/centos6.3: CentOS 6.0 or higher
+    name.os.template.kubevirt.io/centos6.4: CentOS 6.0 or higher
+    name.os.template.kubevirt.io/centos6.5: CentOS 6.0 or higher
+    name.os.template.kubevirt.io/centos6.6: CentOS 6.0 or higher
+    name.os.template.kubevirt.io/centos6.7: CentOS 6.0 or higher
+    name.os.template.kubevirt.io/centos6.8: CentOS 6.0 or higher
+    name.os.template.kubevirt.io/centos6.9: CentOS 6.0 or higher
+  labels:
+    os.template.kubevirt.io/centos6.0: "true"
+    os.template.kubevirt.io/centos6.1: "true"
+    os.template.kubevirt.io/centos6.10: "true"
+    os.template.kubevirt.io/centos6.2: "true"
+    os.template.kubevirt.io/centos6.3: "true"
+    os.template.kubevirt.io/centos6.4: "true"
+    os.template.kubevirt.io/centos6.5: "true"
+    os.template.kubevirt.io/centos6.6: "true"
+    os.template.kubevirt.io/centos6.7: "true"
+    os.template.kubevirt.io/centos6.8: "true"
+    os.template.kubevirt.io/centos6.9: "true"
+    workload.template.kubevirt.io/server: "true"
+    flavor.template.kubevirt.io/large: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: centos6-server-large
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 536870912
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "centos6"
+          vm.kubevirt.io/workload: "server"
+          vm.kubevirt.io/flavor: "large"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: large
+      spec:
+        domain:
+          cpu:
+            sockets: 2
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 8Gi
+          devices:
+            networkInterfaceMultiqueue: true
+            useVirtioTransitional: true
+            rng: {}
+            disks:
+            - bootOrder: 1
+              disk:
+                bus: virtio
+              name: ${NAME}
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+              model: virtio
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: centos
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'centos6-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'centos6'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user centos
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/centos6-server-medium.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: centos6-server-medium
+  annotations:
+    openshift.io/display-name: "CentOS 6.0+ VM"
+    description: >-
+      Template for CentOS 6 VM or newer.
+      A PVC with the CentOS disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,linux,centos"
+    iconClass: "icon-centos"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/centos6.0: CentOS 6.0 or higher
+    name.os.template.kubevirt.io/centos6.1: CentOS 6.0 or higher
+    name.os.template.kubevirt.io/centos6.10: CentOS 6.0 or higher
+    name.os.template.kubevirt.io/centos6.2: CentOS 6.0 or higher
+    name.os.template.kubevirt.io/centos6.3: CentOS 6.0 or higher
+    name.os.template.kubevirt.io/centos6.4: CentOS 6.0 or higher
+    name.os.template.kubevirt.io/centos6.5: CentOS 6.0 or higher
+    name.os.template.kubevirt.io/centos6.6: CentOS 6.0 or higher
+    name.os.template.kubevirt.io/centos6.7: CentOS 6.0 or higher
+    name.os.template.kubevirt.io/centos6.8: CentOS 6.0 or higher
+    name.os.template.kubevirt.io/centos6.9: CentOS 6.0 or higher
+  labels:
+    os.template.kubevirt.io/centos6.0: "true"
+    os.template.kubevirt.io/centos6.1: "true"
+    os.template.kubevirt.io/centos6.10: "true"
+    os.template.kubevirt.io/centos6.2: "true"
+    os.template.kubevirt.io/centos6.3: "true"
+    os.template.kubevirt.io/centos6.4: "true"
+    os.template.kubevirt.io/centos6.5: "true"
+    os.template.kubevirt.io/centos6.6: "true"
+    os.template.kubevirt.io/centos6.7: "true"
+    os.template.kubevirt.io/centos6.8: "true"
+    os.template.kubevirt.io/centos6.9: "true"
+    workload.template.kubevirt.io/server: "true"
+    flavor.template.kubevirt.io/medium: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: centos6-server-medium
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 536870912
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "centos6"
+          vm.kubevirt.io/workload: "server"
+          vm.kubevirt.io/flavor: "medium"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: medium
+      spec:
+        domain:
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 4Gi
+          devices:
+            networkInterfaceMultiqueue: true
+            useVirtioTransitional: true
+            rng: {}
+            disks:
+            - bootOrder: 1
+              disk:
+                bus: virtio
+              name: ${NAME}
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+              model: virtio
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: centos
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'centos6-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'centos6'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user centos
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/centos6-server-small.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: centos6-server-small
+  annotations:
+    openshift.io/display-name: "CentOS 6.0+ VM"
+    description: >-
+      Template for CentOS 6 VM or newer.
+      A PVC with the CentOS disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,linux,centos"
+    iconClass: "icon-centos"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/centos6.0: CentOS 6.0 or higher
+    name.os.template.kubevirt.io/centos6.1: CentOS 6.0 or higher
+    name.os.template.kubevirt.io/centos6.10: CentOS 6.0 or higher
+    name.os.template.kubevirt.io/centos6.2: CentOS 6.0 or higher
+    name.os.template.kubevirt.io/centos6.3: CentOS 6.0 or higher
+    name.os.template.kubevirt.io/centos6.4: CentOS 6.0 or higher
+    name.os.template.kubevirt.io/centos6.5: CentOS 6.0 or higher
+    name.os.template.kubevirt.io/centos6.6: CentOS 6.0 or higher
+    name.os.template.kubevirt.io/centos6.7: CentOS 6.0 or higher
+    name.os.template.kubevirt.io/centos6.8: CentOS 6.0 or higher
+    name.os.template.kubevirt.io/centos6.9: CentOS 6.0 or higher
+  labels:
+    os.template.kubevirt.io/centos6.0: "true"
+    os.template.kubevirt.io/centos6.1: "true"
+    os.template.kubevirt.io/centos6.10: "true"
+    os.template.kubevirt.io/centos6.2: "true"
+    os.template.kubevirt.io/centos6.3: "true"
+    os.template.kubevirt.io/centos6.4: "true"
+    os.template.kubevirt.io/centos6.5: "true"
+    os.template.kubevirt.io/centos6.6: "true"
+    os.template.kubevirt.io/centos6.7: "true"
+    os.template.kubevirt.io/centos6.8: "true"
+    os.template.kubevirt.io/centos6.9: "true"
+    workload.template.kubevirt.io/server: "true"
+    flavor.template.kubevirt.io/small: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+    template.kubevirt.io/default-os-variant: "true"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: centos6-server-small
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 536870912
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "centos6"
+          vm.kubevirt.io/workload: "server"
+          vm.kubevirt.io/flavor: "small"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: small
+      spec:
+        domain:
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 2Gi
+          devices:
+            networkInterfaceMultiqueue: true
+            useVirtioTransitional: true
+            rng: {}
+            disks:
+            - bootOrder: 1
+              disk:
+                bus: virtio
+              name: ${NAME}
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+              model: virtio
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: centos
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'centos6-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'centos6'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user centos
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/centos6-server-tiny.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: centos6-server-tiny
+  annotations:
+    openshift.io/display-name: "CentOS 6.0+ VM"
+    description: >-
+      Template for CentOS 6 VM or newer.
+      A PVC with the CentOS disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,linux,centos"
+    iconClass: "icon-centos"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/centos6.0: CentOS 6.0 or higher
+    name.os.template.kubevirt.io/centos6.1: CentOS 6.0 or higher
+    name.os.template.kubevirt.io/centos6.10: CentOS 6.0 or higher
+    name.os.template.kubevirt.io/centos6.2: CentOS 6.0 or higher
+    name.os.template.kubevirt.io/centos6.3: CentOS 6.0 or higher
+    name.os.template.kubevirt.io/centos6.4: CentOS 6.0 or higher
+    name.os.template.kubevirt.io/centos6.5: CentOS 6.0 or higher
+    name.os.template.kubevirt.io/centos6.6: CentOS 6.0 or higher
+    name.os.template.kubevirt.io/centos6.7: CentOS 6.0 or higher
+    name.os.template.kubevirt.io/centos6.8: CentOS 6.0 or higher
+    name.os.template.kubevirt.io/centos6.9: CentOS 6.0 or higher
+  labels:
+    os.template.kubevirt.io/centos6.0: "true"
+    os.template.kubevirt.io/centos6.1: "true"
+    os.template.kubevirt.io/centos6.10: "true"
+    os.template.kubevirt.io/centos6.2: "true"
+    os.template.kubevirt.io/centos6.3: "true"
+    os.template.kubevirt.io/centos6.4: "true"
+    os.template.kubevirt.io/centos6.5: "true"
+    os.template.kubevirt.io/centos6.6: "true"
+    os.template.kubevirt.io/centos6.7: "true"
+    os.template.kubevirt.io/centos6.8: "true"
+    os.template.kubevirt.io/centos6.9: "true"
+    workload.template.kubevirt.io/server: "true"
+    flavor.template.kubevirt.io/tiny: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: centos6-server-tiny
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 536870912
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "centos6"
+          vm.kubevirt.io/workload: "server"
+          vm.kubevirt.io/flavor: "tiny"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: tiny
+      spec:
+        domain:
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 1Gi
+          devices:
+            networkInterfaceMultiqueue: true
+            useVirtioTransitional: true
+            rng: {}
+            disks:
+            - bootOrder: 1
+              disk:
+                bus: virtio
+              name: ${NAME}
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+              model: virtio
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: centos
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'centos6-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'centos6'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user centos
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/centos7-desktop-large.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: centos7-desktop-large
+  annotations:
+    openshift.io/display-name: "CentOS 7.0+ VM"
+    description: >-
+      Template for CentOS 7 VM or newer.
+      A PVC with the CentOS disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,linux,centos"
+    iconClass: "icon-centos"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/centos7.0: CentOS 7 or higher
+  labels:
+    os.template.kubevirt.io/centos7.0: "true"
+    workload.template.kubevirt.io/desktop: "true"
+    flavor.template.kubevirt.io/large: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: centos7-desktop-large
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 1073741824
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "centos7"
+          vm.kubevirt.io/workload: "desktop"
+          vm.kubevirt.io/flavor: "large"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: large
+      spec:
+        domain:
+          cpu:
+            sockets: 2
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 8Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            inputs:
+              - type: tablet
+                bus: virtio
+                name: tablet
+            disks:
+            - disk:
+                bus: virtio
+              name: ${NAME}
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: centos
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'centos7-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'centos7'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user centos
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/centos7-desktop-medium.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: centos7-desktop-medium
+  annotations:
+    openshift.io/display-name: "CentOS 7.0+ VM"
+    description: >-
+      Template for CentOS 7 VM or newer.
+      A PVC with the CentOS disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,linux,centos"
+    iconClass: "icon-centos"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/centos7.0: CentOS 7 or higher
+  labels:
+    os.template.kubevirt.io/centos7.0: "true"
+    workload.template.kubevirt.io/desktop: "true"
+    flavor.template.kubevirt.io/medium: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: centos7-desktop-medium
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 1073741824
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "centos7"
+          vm.kubevirt.io/workload: "desktop"
+          vm.kubevirt.io/flavor: "medium"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: medium
+      spec:
+        domain:
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 4Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            inputs:
+              - type: tablet
+                bus: virtio
+                name: tablet
+            disks:
+            - disk:
+                bus: virtio
+              name: ${NAME}
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: centos
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'centos7-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'centos7'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user centos
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/centos7-desktop-small.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: centos7-desktop-small
+  annotations:
+    openshift.io/display-name: "CentOS 7.0+ VM"
+    description: >-
+      Template for CentOS 7 VM or newer.
+      A PVC with the CentOS disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,linux,centos"
+    iconClass: "icon-centos"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/centos7.0: CentOS 7 or higher
+  labels:
+    os.template.kubevirt.io/centos7.0: "true"
+    workload.template.kubevirt.io/desktop: "true"
+    flavor.template.kubevirt.io/small: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: centos7-desktop-small
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 1073741824
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "centos7"
+          vm.kubevirt.io/workload: "desktop"
+          vm.kubevirt.io/flavor: "small"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: small
+      spec:
+        domain:
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 2Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            inputs:
+              - type: tablet
+                bus: virtio
+                name: tablet
+            disks:
+            - disk:
+                bus: virtio
+              name: ${NAME}
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: centos
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'centos7-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'centos7'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user centos
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/centos7-desktop-tiny.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: centos7-desktop-tiny
+  annotations:
+    openshift.io/display-name: "CentOS 7.0+ VM"
+    description: >-
+      Template for CentOS 7 VM or newer.
+      A PVC with the CentOS disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,linux,centos"
+    iconClass: "icon-centos"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/centos7.0: CentOS 7 or higher
+  labels:
+    os.template.kubevirt.io/centos7.0: "true"
+    workload.template.kubevirt.io/desktop: "true"
+    flavor.template.kubevirt.io/tiny: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: centos7-desktop-tiny
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 1073741824
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "centos7"
+          vm.kubevirt.io/workload: "desktop"
+          vm.kubevirt.io/flavor: "tiny"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: tiny
+      spec:
+        domain:
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 1Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            inputs:
+              - type: tablet
+                bus: virtio
+                name: tablet
+            disks:
+            - disk:
+                bus: virtio
+              name: ${NAME}
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: centos
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'centos7-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'centos7'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user centos
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/centos7-server-large.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: centos7-server-large
+  annotations:
+    openshift.io/display-name: "CentOS 7.0+ VM"
+    description: >-
+      Template for CentOS 7 VM or newer.
+      A PVC with the CentOS disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,linux,centos"
+    iconClass: "icon-centos"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/centos7.0: CentOS 7 or higher
+  labels:
+    os.template.kubevirt.io/centos7.0: "true"
+    workload.template.kubevirt.io/server: "true"
+    flavor.template.kubevirt.io/large: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: centos7-server-large
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 1073741824
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "centos7"
+          vm.kubevirt.io/workload: "server"
+          vm.kubevirt.io/flavor: "large"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: large
+      spec:
+        domain:
+          cpu:
+            sockets: 2
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 8Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            disks:
+            - disk:
+                bus: virtio
+              name: ${NAME}
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: centos
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'centos7-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'centos7'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user centos
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/centos7-server-medium.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: centos7-server-medium
+  annotations:
+    openshift.io/display-name: "CentOS 7.0+ VM"
+    description: >-
+      Template for CentOS 7 VM or newer.
+      A PVC with the CentOS disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,linux,centos"
+    iconClass: "icon-centos"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/centos7.0: CentOS 7 or higher
+  labels:
+    os.template.kubevirt.io/centos7.0: "true"
+    workload.template.kubevirt.io/server: "true"
+    flavor.template.kubevirt.io/medium: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: centos7-server-medium
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 1073741824
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "centos7"
+          vm.kubevirt.io/workload: "server"
+          vm.kubevirt.io/flavor: "medium"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: medium
+      spec:
+        domain:
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 4Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            disks:
+            - disk:
+                bus: virtio
+              name: ${NAME}
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: centos
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'centos7-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'centos7'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user centos
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/centos7-server-small.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: centos7-server-small
+  annotations:
+    openshift.io/display-name: "CentOS 7.0+ VM"
+    description: >-
+      Template for CentOS 7 VM or newer.
+      A PVC with the CentOS disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,linux,centos"
+    iconClass: "icon-centos"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/centos7.0: CentOS 7 or higher
+  labels:
+    os.template.kubevirt.io/centos7.0: "true"
+    workload.template.kubevirt.io/server: "true"
+    flavor.template.kubevirt.io/small: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+    template.kubevirt.io/default-os-variant: "true"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: centos7-server-small
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 1073741824
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "centos7"
+          vm.kubevirt.io/workload: "server"
+          vm.kubevirt.io/flavor: "small"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: small
+      spec:
+        domain:
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 2Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            disks:
+            - disk:
+                bus: virtio
+              name: ${NAME}
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: centos
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'centos7-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'centos7'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user centos
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/centos7-server-tiny.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: centos7-server-tiny
+  annotations:
+    openshift.io/display-name: "CentOS 7.0+ VM"
+    description: >-
+      Template for CentOS 7 VM or newer.
+      A PVC with the CentOS disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,linux,centos"
+    iconClass: "icon-centos"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/centos7.0: CentOS 7 or higher
+  labels:
+    os.template.kubevirt.io/centos7.0: "true"
+    workload.template.kubevirt.io/server: "true"
+    flavor.template.kubevirt.io/tiny: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: centos7-server-tiny
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 1073741824
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "centos7"
+          vm.kubevirt.io/workload: "server"
+          vm.kubevirt.io/flavor: "tiny"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: tiny
+      spec:
+        domain:
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 1Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            disks:
+            - disk:
+                bus: virtio
+              name: ${NAME}
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: centos
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'centos7-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'centos7'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user centos
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/centos8-desktop-large.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: centos8-desktop-large
+  annotations:
+    openshift.io/display-name: "CentOS 8.0+ VM"
+    description: >-
+      Template for CentOS 8 VM or newer.
+      A PVC with the CentOS disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,linux,centos"
+    iconClass: "icon-centos"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/centos8: CentOS 8 or higher
+  labels:
+    os.template.kubevirt.io/centos8: "true"
+    workload.template.kubevirt.io/desktop: "true"
+    flavor.template.kubevirt.io/large: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: centos8-desktop-large
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 1610612736
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "centos8"
+          vm.kubevirt.io/workload: "desktop"
+          vm.kubevirt.io/flavor: "large"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: large
+      spec:
+        domain:
+          cpu:
+            sockets: 2
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 8Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            inputs:
+              - type: tablet
+                bus: virtio
+                name: tablet
+            disks:
+            - disk:
+                bus: virtio
+              name: ${NAME}
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: centos
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'centos8-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'centos8'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user centos
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/centos8-desktop-medium.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: centos8-desktop-medium
+  annotations:
+    openshift.io/display-name: "CentOS 8.0+ VM"
+    description: >-
+      Template for CentOS 8 VM or newer.
+      A PVC with the CentOS disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,linux,centos"
+    iconClass: "icon-centos"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/centos8: CentOS 8 or higher
+  labels:
+    os.template.kubevirt.io/centos8: "true"
+    workload.template.kubevirt.io/desktop: "true"
+    flavor.template.kubevirt.io/medium: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: centos8-desktop-medium
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 1610612736
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "centos8"
+          vm.kubevirt.io/workload: "desktop"
+          vm.kubevirt.io/flavor: "medium"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: medium
+      spec:
+        domain:
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 4Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            inputs:
+              - type: tablet
+                bus: virtio
+                name: tablet
+            disks:
+            - disk:
+                bus: virtio
+              name: ${NAME}
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: centos
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'centos8-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'centos8'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user centos
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/centos8-desktop-small.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: centos8-desktop-small
+  annotations:
+    openshift.io/display-name: "CentOS 8.0+ VM"
+    description: >-
+      Template for CentOS 8 VM or newer.
+      A PVC with the CentOS disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,linux,centos"
+    iconClass: "icon-centos"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/centos8: CentOS 8 or higher
+  labels:
+    os.template.kubevirt.io/centos8: "true"
+    workload.template.kubevirt.io/desktop: "true"
+    flavor.template.kubevirt.io/small: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: centos8-desktop-small
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 1610612736
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "centos8"
+          vm.kubevirt.io/workload: "desktop"
+          vm.kubevirt.io/flavor: "small"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: small
+      spec:
+        domain:
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 2Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            inputs:
+              - type: tablet
+                bus: virtio
+                name: tablet
+            disks:
+            - disk:
+                bus: virtio
+              name: ${NAME}
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: centos
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'centos8-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'centos8'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user centos
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/centos8-desktop-tiny.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: centos8-desktop-tiny
+  annotations:
+    openshift.io/display-name: "CentOS 8.0+ VM"
+    description: >-
+      Template for CentOS 8 VM or newer.
+      A PVC with the CentOS disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,linux,centos"
+    iconClass: "icon-centos"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/centos8: CentOS 8 or higher
+  labels:
+    os.template.kubevirt.io/centos8: "true"
+    workload.template.kubevirt.io/desktop: "true"
+    flavor.template.kubevirt.io/tiny: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: centos8-desktop-tiny
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 1610612736
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "centos8"
+          vm.kubevirt.io/workload: "desktop"
+          vm.kubevirt.io/flavor: "tiny"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: tiny
+      spec:
+        domain:
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 1.5Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            inputs:
+              - type: tablet
+                bus: virtio
+                name: tablet
+            disks:
+            - disk:
+                bus: virtio
+              name: ${NAME}
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: centos
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'centos8-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'centos8'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user centos
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/centos8-server-large.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: centos8-server-large
+  annotations:
+    openshift.io/display-name: "CentOS 8.0+ VM"
+    description: >-
+      Template for CentOS 8 VM or newer.
+      A PVC with the CentOS disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,linux,centos"
+    iconClass: "icon-centos"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/centos8: CentOS 8 or higher
+  labels:
+    os.template.kubevirt.io/centos8: "true"
+    workload.template.kubevirt.io/server: "true"
+    flavor.template.kubevirt.io/large: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: centos8-server-large
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 1610612736
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "centos8"
+          vm.kubevirt.io/workload: "server"
+          vm.kubevirt.io/flavor: "large"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: large
+      spec:
+        domain:
+          cpu:
+            sockets: 2
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 8Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            disks:
+            - disk:
+                bus: virtio
+              name: ${NAME}
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: centos
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'centos8-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'centos8'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user centos
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/centos8-server-medium.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: centos8-server-medium
+  annotations:
+    openshift.io/display-name: "CentOS 8.0+ VM"
+    description: >-
+      Template for CentOS 8 VM or newer.
+      A PVC with the CentOS disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,linux,centos"
+    iconClass: "icon-centos"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/centos8: CentOS 8 or higher
+  labels:
+    os.template.kubevirt.io/centos8: "true"
+    workload.template.kubevirt.io/server: "true"
+    flavor.template.kubevirt.io/medium: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: centos8-server-medium
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 1610612736
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "centos8"
+          vm.kubevirt.io/workload: "server"
+          vm.kubevirt.io/flavor: "medium"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: medium
+      spec:
+        domain:
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 4Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            disks:
+            - disk:
+                bus: virtio
+              name: ${NAME}
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: centos
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'centos8-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'centos8'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user centos
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/centos8-server-small.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: centos8-server-small
+  annotations:
+    openshift.io/display-name: "CentOS 8.0+ VM"
+    description: >-
+      Template for CentOS 8 VM or newer.
+      A PVC with the CentOS disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,linux,centos"
+    iconClass: "icon-centos"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/centos8: CentOS 8 or higher
+  labels:
+    os.template.kubevirt.io/centos8: "true"
+    workload.template.kubevirt.io/server: "true"
+    flavor.template.kubevirt.io/small: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+    template.kubevirt.io/default-os-variant: "true"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: centos8-server-small
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 1610612736
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "centos8"
+          vm.kubevirt.io/workload: "server"
+          vm.kubevirt.io/flavor: "small"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: small
+      spec:
+        domain:
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 2Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            disks:
+            - disk:
+                bus: virtio
+              name: ${NAME}
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: centos
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'centos8-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'centos8'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user centos
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/centos8-server-tiny.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: centos8-server-tiny
+  annotations:
+    openshift.io/display-name: "CentOS 8.0+ VM"
+    description: >-
+      Template for CentOS 8 VM or newer.
+      A PVC with the CentOS disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,linux,centos"
+    iconClass: "icon-centos"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/centos8: CentOS 8 or higher
+  labels:
+    os.template.kubevirt.io/centos8: "true"
+    workload.template.kubevirt.io/server: "true"
+    flavor.template.kubevirt.io/tiny: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: centos8-server-tiny
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 1610612736
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "centos8"
+          vm.kubevirt.io/workload: "server"
+          vm.kubevirt.io/flavor: "tiny"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: tiny
+      spec:
+        domain:
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 1.5Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            disks:
+            - disk:
+                bus: virtio
+              name: ${NAME}
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: centos
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'centos8-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'centos8'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user centos
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/fedora-desktop-large.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: fedora-desktop-large
+  annotations:
+    openshift.io/display-name: "Fedora 33+ VM"
+    description: >-
+      Template for Fedora 33 VM or newer.
+      A PVC with the Fedora disk image must be available.
+      Recommended disk image:
+      https://download.fedoraproject.org/pub/fedora/linux/releases/32/Cloud/x86_64/images/Fedora-Cloud-Base-32-1.6.x86_64.qcow2
+    tags: "hidden,kubevirt,virtualmachine,fedora"
+    iconClass: "icon-fedora"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/fedora33: Fedora 33 or higher
+    name.os.template.kubevirt.io/fedora34: Fedora 33 or higher
+    name.os.template.kubevirt.io/silverblue33: Fedora 33 or higher
+    name.os.template.kubevirt.io/silverblue34: Fedora 33 or higher
+  labels:
+    os.template.kubevirt.io/fedora33: "true"
+    os.template.kubevirt.io/fedora34: "true"
+    os.template.kubevirt.io/silverblue33: "true"
+    os.template.kubevirt.io/silverblue34: "true"
+    workload.template.kubevirt.io/desktop: "true"
+    flavor.template.kubevirt.io/large: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: fedora-desktop-large
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 1073741824
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "fedora"
+          vm.kubevirt.io/workload: "desktop"
+          vm.kubevirt.io/flavor: "large"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: large
+      spec:
+        domain:
+          cpu:
+            sockets: 2
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 8Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            inputs:
+              - type: tablet
+                bus: virtio
+                name: tablet
+            disks:
+            - disk:
+                bus: virtio
+              name: ${NAME}
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: fedora
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'fedora-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'fedora'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user fedora
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/fedora-desktop-medium.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: fedora-desktop-medium
+  annotations:
+    openshift.io/display-name: "Fedora 33+ VM"
+    description: >-
+      Template for Fedora 33 VM or newer.
+      A PVC with the Fedora disk image must be available.
+      Recommended disk image:
+      https://download.fedoraproject.org/pub/fedora/linux/releases/32/Cloud/x86_64/images/Fedora-Cloud-Base-32-1.6.x86_64.qcow2
+    tags: "hidden,kubevirt,virtualmachine,fedora"
+    iconClass: "icon-fedora"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/fedora33: Fedora 33 or higher
+    name.os.template.kubevirt.io/fedora34: Fedora 33 or higher
+    name.os.template.kubevirt.io/silverblue33: Fedora 33 or higher
+    name.os.template.kubevirt.io/silverblue34: Fedora 33 or higher
+  labels:
+    os.template.kubevirt.io/fedora33: "true"
+    os.template.kubevirt.io/fedora34: "true"
+    os.template.kubevirt.io/silverblue33: "true"
+    os.template.kubevirt.io/silverblue34: "true"
+    workload.template.kubevirt.io/desktop: "true"
+    flavor.template.kubevirt.io/medium: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: fedora-desktop-medium
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 1073741824
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "fedora"
+          vm.kubevirt.io/workload: "desktop"
+          vm.kubevirt.io/flavor: "medium"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: medium
+      spec:
+        domain:
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 4Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            inputs:
+              - type: tablet
+                bus: virtio
+                name: tablet
+            disks:
+            - disk:
+                bus: virtio
+              name: ${NAME}
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: fedora
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'fedora-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'fedora'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user fedora
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/fedora-desktop-small.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: fedora-desktop-small
+  annotations:
+    openshift.io/display-name: "Fedora 33+ VM"
+    description: >-
+      Template for Fedora 33 VM or newer.
+      A PVC with the Fedora disk image must be available.
+      Recommended disk image:
+      https://download.fedoraproject.org/pub/fedora/linux/releases/32/Cloud/x86_64/images/Fedora-Cloud-Base-32-1.6.x86_64.qcow2
+    tags: "hidden,kubevirt,virtualmachine,fedora"
+    iconClass: "icon-fedora"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/fedora33: Fedora 33 or higher
+    name.os.template.kubevirt.io/fedora34: Fedora 33 or higher
+    name.os.template.kubevirt.io/silverblue33: Fedora 33 or higher
+    name.os.template.kubevirt.io/silverblue34: Fedora 33 or higher
+  labels:
+    os.template.kubevirt.io/fedora33: "true"
+    os.template.kubevirt.io/fedora34: "true"
+    os.template.kubevirt.io/silverblue33: "true"
+    os.template.kubevirt.io/silverblue34: "true"
+    workload.template.kubevirt.io/desktop: "true"
+    flavor.template.kubevirt.io/small: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: fedora-desktop-small
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 1073741824
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "fedora"
+          vm.kubevirt.io/workload: "desktop"
+          vm.kubevirt.io/flavor: "small"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: small
+      spec:
+        domain:
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 2Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            inputs:
+              - type: tablet
+                bus: virtio
+                name: tablet
+            disks:
+            - disk:
+                bus: virtio
+              name: ${NAME}
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: fedora
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'fedora-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'fedora'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user fedora
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/fedora-desktop-tiny.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: fedora-desktop-tiny
+  annotations:
+    openshift.io/display-name: "Fedora 33+ VM"
+    description: >-
+      Template for Fedora 33 VM or newer.
+      A PVC with the Fedora disk image must be available.
+      Recommended disk image:
+      https://download.fedoraproject.org/pub/fedora/linux/releases/32/Cloud/x86_64/images/Fedora-Cloud-Base-32-1.6.x86_64.qcow2
+    tags: "hidden,kubevirt,virtualmachine,fedora"
+    iconClass: "icon-fedora"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/fedora33: Fedora 33 or higher
+    name.os.template.kubevirt.io/fedora34: Fedora 33 or higher
+    name.os.template.kubevirt.io/silverblue33: Fedora 33 or higher
+    name.os.template.kubevirt.io/silverblue34: Fedora 33 or higher
+  labels:
+    os.template.kubevirt.io/fedora33: "true"
+    os.template.kubevirt.io/fedora34: "true"
+    os.template.kubevirt.io/silverblue33: "true"
+    os.template.kubevirt.io/silverblue34: "true"
+    workload.template.kubevirt.io/desktop: "true"
+    flavor.template.kubevirt.io/tiny: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: fedora-desktop-tiny
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 1073741824
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "fedora"
+          vm.kubevirt.io/workload: "desktop"
+          vm.kubevirt.io/flavor: "tiny"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: tiny
+      spec:
+        domain:
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 1Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            inputs:
+              - type: tablet
+                bus: virtio
+                name: tablet
+            disks:
+            - disk:
+                bus: virtio
+              name: ${NAME}
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: fedora
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'fedora-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'fedora'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user fedora
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/fedora-highperformance-large.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: fedora-highperformance-large
+  annotations:
+    openshift.io/display-name: "Fedora 33+ VM"
+    description: >-
+      Template for Fedora 33 VM or newer.
+      A PVC with the Fedora disk image must be available.
+      Recommended disk image:
+      https://download.fedoraproject.org/pub/fedora/linux/releases/32/Cloud/x86_64/images/Fedora-Cloud-Base-32-1.6.x86_64.qcow2
+    tags: "hidden,kubevirt,virtualmachine,fedora"
+    iconClass: "icon-fedora"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/fedora33: Fedora 33 or higher
+    name.os.template.kubevirt.io/fedora34: Fedora 33 or higher
+    name.os.template.kubevirt.io/silverblue33: Fedora 33 or higher
+    name.os.template.kubevirt.io/silverblue34: Fedora 33 or higher
+  labels:
+    os.template.kubevirt.io/fedora33: "true"
+    os.template.kubevirt.io/fedora34: "true"
+    os.template.kubevirt.io/silverblue33: "true"
+    os.template.kubevirt.io/silverblue34: "true"
+    workload.template.kubevirt.io/highperformance: "true"
+    flavor.template.kubevirt.io/large: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: fedora-highperformance-large
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 1073741824
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "fedora"
+          vm.kubevirt.io/workload: "highperformance"
+          vm.kubevirt.io/flavor: "large"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: large
+      spec:
+        domain:
+          ioThreadsPolicy: shared
+          cpu:
+            sockets: 2
+            cores: 1
+            threads: 1
+            dedicatedCpuPlacement: True
+            isolateEmulatorThread: True
+          resources:
+            requests:
+              memory: 8Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            disks:
+            - disk:
+                bus: virtio
+              name: ${NAME}
+              dedicatedIOThread: true
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: fedora
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'fedora-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'fedora'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user fedora
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/fedora-highperformance-medium.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: fedora-highperformance-medium
+  annotations:
+    openshift.io/display-name: "Fedora 33+ VM"
+    description: >-
+      Template for Fedora 33 VM or newer.
+      A PVC with the Fedora disk image must be available.
+      Recommended disk image:
+      https://download.fedoraproject.org/pub/fedora/linux/releases/32/Cloud/x86_64/images/Fedora-Cloud-Base-32-1.6.x86_64.qcow2
+    tags: "hidden,kubevirt,virtualmachine,fedora"
+    iconClass: "icon-fedora"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/fedora33: Fedora 33 or higher
+    name.os.template.kubevirt.io/fedora34: Fedora 33 or higher
+    name.os.template.kubevirt.io/silverblue33: Fedora 33 or higher
+    name.os.template.kubevirt.io/silverblue34: Fedora 33 or higher
+  labels:
+    os.template.kubevirt.io/fedora33: "true"
+    os.template.kubevirt.io/fedora34: "true"
+    os.template.kubevirt.io/silverblue33: "true"
+    os.template.kubevirt.io/silverblue34: "true"
+    workload.template.kubevirt.io/highperformance: "true"
+    flavor.template.kubevirt.io/medium: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: fedora-highperformance-medium
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 1073741824
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "fedora"
+          vm.kubevirt.io/workload: "highperformance"
+          vm.kubevirt.io/flavor: "medium"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: medium
+      spec:
+        domain:
+          ioThreadsPolicy: shared
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+            dedicatedCpuPlacement: True
+            isolateEmulatorThread: True
+          resources:
+            requests:
+              memory: 4Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            disks:
+            - disk:
+                bus: virtio
+              name: ${NAME}
+              dedicatedIOThread: true
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: fedora
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'fedora-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'fedora'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user fedora
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/fedora-highperformance-small.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: fedora-highperformance-small
+  annotations:
+    openshift.io/display-name: "Fedora 33+ VM"
+    description: >-
+      Template for Fedora 33 VM or newer.
+      A PVC with the Fedora disk image must be available.
+      Recommended disk image:
+      https://download.fedoraproject.org/pub/fedora/linux/releases/32/Cloud/x86_64/images/Fedora-Cloud-Base-32-1.6.x86_64.qcow2
+    tags: "hidden,kubevirt,virtualmachine,fedora"
+    iconClass: "icon-fedora"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/fedora33: Fedora 33 or higher
+    name.os.template.kubevirt.io/fedora34: Fedora 33 or higher
+    name.os.template.kubevirt.io/silverblue33: Fedora 33 or higher
+    name.os.template.kubevirt.io/silverblue34: Fedora 33 or higher
+  labels:
+    os.template.kubevirt.io/fedora33: "true"
+    os.template.kubevirt.io/fedora34: "true"
+    os.template.kubevirt.io/silverblue33: "true"
+    os.template.kubevirt.io/silverblue34: "true"
+    workload.template.kubevirt.io/highperformance: "true"
+    flavor.template.kubevirt.io/small: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: fedora-highperformance-small
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 1073741824
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "fedora"
+          vm.kubevirt.io/workload: "highperformance"
+          vm.kubevirt.io/flavor: "small"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: small
+      spec:
+        domain:
+          ioThreadsPolicy: shared
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+            dedicatedCpuPlacement: True
+            isolateEmulatorThread: True
+          resources:
+            requests:
+              memory: 2Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            disks:
+            - disk:
+                bus: virtio
+              name: ${NAME}
+              dedicatedIOThread: true
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: fedora
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'fedora-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'fedora'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user fedora
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/fedora-highperformance-tiny.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: fedora-highperformance-tiny
+  annotations:
+    openshift.io/display-name: "Fedora 33+ VM"
+    description: >-
+      Template for Fedora 33 VM or newer.
+      A PVC with the Fedora disk image must be available.
+      Recommended disk image:
+      https://download.fedoraproject.org/pub/fedora/linux/releases/32/Cloud/x86_64/images/Fedora-Cloud-Base-32-1.6.x86_64.qcow2
+    tags: "hidden,kubevirt,virtualmachine,fedora"
+    iconClass: "icon-fedora"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/fedora33: Fedora 33 or higher
+    name.os.template.kubevirt.io/fedora34: Fedora 33 or higher
+    name.os.template.kubevirt.io/silverblue33: Fedora 33 or higher
+    name.os.template.kubevirt.io/silverblue34: Fedora 33 or higher
+  labels:
+    os.template.kubevirt.io/fedora33: "true"
+    os.template.kubevirt.io/fedora34: "true"
+    os.template.kubevirt.io/silverblue33: "true"
+    os.template.kubevirt.io/silverblue34: "true"
+    workload.template.kubevirt.io/highperformance: "true"
+    flavor.template.kubevirt.io/tiny: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: fedora-highperformance-tiny
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 1073741824
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "fedora"
+          vm.kubevirt.io/workload: "highperformance"
+          vm.kubevirt.io/flavor: "tiny"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: tiny
+      spec:
+        domain:
+          ioThreadsPolicy: shared
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+            dedicatedCpuPlacement: True
+            isolateEmulatorThread: True
+          resources:
+            requests:
+              memory: 1Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            disks:
+            - disk:
+                bus: virtio
+              name: ${NAME}
+              dedicatedIOThread: true
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: fedora
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'fedora-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'fedora'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user fedora
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/fedora-server-large.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: fedora-server-large
+  annotations:
+    openshift.io/display-name: "Fedora 33+ VM"
+    description: >-
+      Template for Fedora 33 VM or newer.
+      A PVC with the Fedora disk image must be available.
+      Recommended disk image:
+      https://download.fedoraproject.org/pub/fedora/linux/releases/32/Cloud/x86_64/images/Fedora-Cloud-Base-32-1.6.x86_64.qcow2
+    tags: "hidden,kubevirt,virtualmachine,fedora"
+    iconClass: "icon-fedora"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/fedora33: Fedora 33 or higher
+    name.os.template.kubevirt.io/fedora34: Fedora 33 or higher
+    name.os.template.kubevirt.io/silverblue33: Fedora 33 or higher
+    name.os.template.kubevirt.io/silverblue34: Fedora 33 or higher
+  labels:
+    os.template.kubevirt.io/fedora33: "true"
+    os.template.kubevirt.io/fedora34: "true"
+    os.template.kubevirt.io/silverblue33: "true"
+    os.template.kubevirt.io/silverblue34: "true"
+    workload.template.kubevirt.io/server: "true"
+    flavor.template.kubevirt.io/large: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: fedora-server-large
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 1073741824
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "fedora"
+          vm.kubevirt.io/workload: "server"
+          vm.kubevirt.io/flavor: "large"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: large
+      spec:
+        domain:
+          cpu:
+            sockets: 2
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 8Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            disks:
+            - disk:
+                bus: virtio
+              name: ${NAME}
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: fedora
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'fedora-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'fedora'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user fedora
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/fedora-server-medium.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: fedora-server-medium
+  annotations:
+    openshift.io/display-name: "Fedora 33+ VM"
+    description: >-
+      Template for Fedora 33 VM or newer.
+      A PVC with the Fedora disk image must be available.
+      Recommended disk image:
+      https://download.fedoraproject.org/pub/fedora/linux/releases/32/Cloud/x86_64/images/Fedora-Cloud-Base-32-1.6.x86_64.qcow2
+    tags: "hidden,kubevirt,virtualmachine,fedora"
+    iconClass: "icon-fedora"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/fedora33: Fedora 33 or higher
+    name.os.template.kubevirt.io/fedora34: Fedora 33 or higher
+    name.os.template.kubevirt.io/silverblue33: Fedora 33 or higher
+    name.os.template.kubevirt.io/silverblue34: Fedora 33 or higher
+  labels:
+    os.template.kubevirt.io/fedora33: "true"
+    os.template.kubevirt.io/fedora34: "true"
+    os.template.kubevirt.io/silverblue33: "true"
+    os.template.kubevirt.io/silverblue34: "true"
+    workload.template.kubevirt.io/server: "true"
+    flavor.template.kubevirt.io/medium: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: fedora-server-medium
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 1073741824
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "fedora"
+          vm.kubevirt.io/workload: "server"
+          vm.kubevirt.io/flavor: "medium"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: medium
+      spec:
+        domain:
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 4Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            disks:
+            - disk:
+                bus: virtio
+              name: ${NAME}
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: fedora
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'fedora-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'fedora'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user fedora
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/fedora-server-small.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: fedora-server-small
+  annotations:
+    openshift.io/display-name: "Fedora 33+ VM"
+    description: >-
+      Template for Fedora 33 VM or newer.
+      A PVC with the Fedora disk image must be available.
+      Recommended disk image:
+      https://download.fedoraproject.org/pub/fedora/linux/releases/32/Cloud/x86_64/images/Fedora-Cloud-Base-32-1.6.x86_64.qcow2
+    tags: "hidden,kubevirt,virtualmachine,fedora"
+    iconClass: "icon-fedora"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/fedora33: Fedora 33 or higher
+    name.os.template.kubevirt.io/fedora34: Fedora 33 or higher
+    name.os.template.kubevirt.io/silverblue33: Fedora 33 or higher
+    name.os.template.kubevirt.io/silverblue34: Fedora 33 or higher
+  labels:
+    os.template.kubevirt.io/fedora33: "true"
+    os.template.kubevirt.io/fedora34: "true"
+    os.template.kubevirt.io/silverblue33: "true"
+    os.template.kubevirt.io/silverblue34: "true"
+    workload.template.kubevirt.io/server: "true"
+    flavor.template.kubevirt.io/small: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+    template.kubevirt.io/default-os-variant: "true"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: fedora-server-small
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 1073741824
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "fedora"
+          vm.kubevirt.io/workload: "server"
+          vm.kubevirt.io/flavor: "small"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: small
+      spec:
+        domain:
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 2Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            disks:
+            - disk:
+                bus: virtio
+              name: ${NAME}
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: fedora
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'fedora-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'fedora'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user fedora
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/fedora-server-tiny.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: fedora-server-tiny
+  annotations:
+    openshift.io/display-name: "Fedora 33+ VM"
+    description: >-
+      Template for Fedora 33 VM or newer.
+      A PVC with the Fedora disk image must be available.
+      Recommended disk image:
+      https://download.fedoraproject.org/pub/fedora/linux/releases/32/Cloud/x86_64/images/Fedora-Cloud-Base-32-1.6.x86_64.qcow2
+    tags: "hidden,kubevirt,virtualmachine,fedora"
+    iconClass: "icon-fedora"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/fedora33: Fedora 33 or higher
+    name.os.template.kubevirt.io/fedora34: Fedora 33 or higher
+    name.os.template.kubevirt.io/silverblue33: Fedora 33 or higher
+    name.os.template.kubevirt.io/silverblue34: Fedora 33 or higher
+  labels:
+    os.template.kubevirt.io/fedora33: "true"
+    os.template.kubevirt.io/fedora34: "true"
+    os.template.kubevirt.io/silverblue33: "true"
+    os.template.kubevirt.io/silverblue34: "true"
+    workload.template.kubevirt.io/server: "true"
+    flavor.template.kubevirt.io/tiny: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: fedora-server-tiny
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 1073741824
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "fedora"
+          vm.kubevirt.io/workload: "server"
+          vm.kubevirt.io/flavor: "tiny"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: tiny
+      spec:
+        domain:
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 1Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            disks:
+            - disk:
+                bus: virtio
+              name: ${NAME}
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: fedora
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'fedora-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'fedora'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user fedora
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/opensuse-server-large.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: opensuse-server-large
+  annotations:
+    openshift.io/display-name: "OpenSUSE Leap 15.0 VM"
+    description: >-
+      Template for OpenSUSE Leap 15.0 VM.
+      A PVC with the OpenSUSE disk image must be available.
+      Recommended disk image:
+      https://download.opensuse.org/repositories/Cloud:/Images:/Leap_15.0/images/
+    tags: "hidden,kubevirt,virtualmachine,linux,opensuse"
+    iconClass: "icon-opensuse"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/opensuse15.0: openSUSE Leap 15.0 or higher
+  labels:
+    os.template.kubevirt.io/opensuse15.0: "true"
+    workload.template.kubevirt.io/server: "true"
+    flavor.template.kubevirt.io/large: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: opensuse-server-large
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 1073741824
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "opensuse"
+          vm.kubevirt.io/workload: "server"
+          vm.kubevirt.io/flavor: "large"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: large
+      spec:
+        domain:
+          cpu:
+            sockets: 2
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 8Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            disks:
+            - disk:
+                bus: virtio
+              name: ${NAME}
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: opensuse
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'opensuse-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'opensuse'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user opensuse
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/opensuse-server-medium.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: opensuse-server-medium
+  annotations:
+    openshift.io/display-name: "OpenSUSE Leap 15.0 VM"
+    description: >-
+      Template for OpenSUSE Leap 15.0 VM.
+      A PVC with the OpenSUSE disk image must be available.
+      Recommended disk image:
+      https://download.opensuse.org/repositories/Cloud:/Images:/Leap_15.0/images/
+    tags: "hidden,kubevirt,virtualmachine,linux,opensuse"
+    iconClass: "icon-opensuse"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/opensuse15.0: openSUSE Leap 15.0 or higher
+  labels:
+    os.template.kubevirt.io/opensuse15.0: "true"
+    workload.template.kubevirt.io/server: "true"
+    flavor.template.kubevirt.io/medium: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: opensuse-server-medium
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 1073741824
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "opensuse"
+          vm.kubevirt.io/workload: "server"
+          vm.kubevirt.io/flavor: "medium"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: medium
+      spec:
+        domain:
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 4Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            disks:
+            - disk:
+                bus: virtio
+              name: ${NAME}
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: opensuse
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'opensuse-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'opensuse'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user opensuse
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/opensuse-server-small.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: opensuse-server-small
+  annotations:
+    openshift.io/display-name: "OpenSUSE Leap 15.0 VM"
+    description: >-
+      Template for OpenSUSE Leap 15.0 VM.
+      A PVC with the OpenSUSE disk image must be available.
+      Recommended disk image:
+      https://download.opensuse.org/repositories/Cloud:/Images:/Leap_15.0/images/
+    tags: "hidden,kubevirt,virtualmachine,linux,opensuse"
+    iconClass: "icon-opensuse"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/opensuse15.0: openSUSE Leap 15.0 or higher
+  labels:
+    os.template.kubevirt.io/opensuse15.0: "true"
+    workload.template.kubevirt.io/server: "true"
+    flavor.template.kubevirt.io/small: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+    template.kubevirt.io/default-os-variant: "true"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: opensuse-server-small
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 1073741824
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "opensuse"
+          vm.kubevirt.io/workload: "server"
+          vm.kubevirt.io/flavor: "small"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: small
+      spec:
+        domain:
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 2Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            disks:
+            - disk:
+                bus: virtio
+              name: ${NAME}
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: opensuse
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'opensuse-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'opensuse'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user opensuse
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/opensuse-server-tiny.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: opensuse-server-tiny
+  annotations:
+    openshift.io/display-name: "OpenSUSE Leap 15.0 VM"
+    description: >-
+      Template for OpenSUSE Leap 15.0 VM.
+      A PVC with the OpenSUSE disk image must be available.
+      Recommended disk image:
+      https://download.opensuse.org/repositories/Cloud:/Images:/Leap_15.0/images/
+    tags: "hidden,kubevirt,virtualmachine,linux,opensuse"
+    iconClass: "icon-opensuse"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/opensuse15.0: openSUSE Leap 15.0 or higher
+  labels:
+    os.template.kubevirt.io/opensuse15.0: "true"
+    workload.template.kubevirt.io/server: "true"
+    flavor.template.kubevirt.io/tiny: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: opensuse-server-tiny
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 1073741824
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "opensuse"
+          vm.kubevirt.io/workload: "server"
+          vm.kubevirt.io/flavor: "tiny"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: tiny
+      spec:
+        domain:
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 1Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            disks:
+            - disk:
+                bus: virtio
+              name: ${NAME}
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: opensuse
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'opensuse-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'opensuse'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user opensuse
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/rhel6-desktop-large.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: rhel6-desktop-large
+  annotations:
+    openshift.io/display-name: "Red Hat Enterprise Linux 6.0+ VM"
+    description: >-
+      Template for Red Hat Enterprise Linux 6 VM or newer.
+      A PVC with the RHEL disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,linux,rhel"
+    iconClass: "icon-rhel"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/rhel6.0: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.1: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.10: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.2: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.3: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.4: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.5: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.6: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.7: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.8: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.9: Red Hat Enterprise Linux 6.0 or higher
+  labels:
+    os.template.kubevirt.io/rhel6.0: "true"
+    os.template.kubevirt.io/rhel6.1: "true"
+    os.template.kubevirt.io/rhel6.10: "true"
+    os.template.kubevirt.io/rhel6.2: "true"
+    os.template.kubevirt.io/rhel6.3: "true"
+    os.template.kubevirt.io/rhel6.4: "true"
+    os.template.kubevirt.io/rhel6.5: "true"
+    os.template.kubevirt.io/rhel6.6: "true"
+    os.template.kubevirt.io/rhel6.7: "true"
+    os.template.kubevirt.io/rhel6.8: "true"
+    os.template.kubevirt.io/rhel6.9: "true"
+    workload.template.kubevirt.io/desktop: "true"
+    flavor.template.kubevirt.io/large: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: rhel6-desktop-large
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 536870912
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "rhel6"
+          vm.kubevirt.io/workload: "desktop"
+          vm.kubevirt.io/flavor: "large"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: large
+      spec:
+        domain:
+          cpu:
+            sockets: 2
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 8Gi
+          devices:
+            networkInterfaceMultiqueue: true
+            useVirtioTransitional: true
+            rng: {}
+            inputs:
+              - type: tablet
+                bus: virtio
+                name: tablet
+            disks:
+            - bootOrder: 1
+              disk:
+                bus: virtio
+              name: ${NAME}
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+              model: virtio
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: cloud-user
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'rhel6-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'rhel6'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user cloud-user
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/rhel6-desktop-medium.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: rhel6-desktop-medium
+  annotations:
+    openshift.io/display-name: "Red Hat Enterprise Linux 6.0+ VM"
+    description: >-
+      Template for Red Hat Enterprise Linux 6 VM or newer.
+      A PVC with the RHEL disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,linux,rhel"
+    iconClass: "icon-rhel"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/rhel6.0: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.1: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.10: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.2: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.3: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.4: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.5: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.6: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.7: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.8: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.9: Red Hat Enterprise Linux 6.0 or higher
+  labels:
+    os.template.kubevirt.io/rhel6.0: "true"
+    os.template.kubevirt.io/rhel6.1: "true"
+    os.template.kubevirt.io/rhel6.10: "true"
+    os.template.kubevirt.io/rhel6.2: "true"
+    os.template.kubevirt.io/rhel6.3: "true"
+    os.template.kubevirt.io/rhel6.4: "true"
+    os.template.kubevirt.io/rhel6.5: "true"
+    os.template.kubevirt.io/rhel6.6: "true"
+    os.template.kubevirt.io/rhel6.7: "true"
+    os.template.kubevirt.io/rhel6.8: "true"
+    os.template.kubevirt.io/rhel6.9: "true"
+    workload.template.kubevirt.io/desktop: "true"
+    flavor.template.kubevirt.io/medium: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: rhel6-desktop-medium
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 536870912
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "rhel6"
+          vm.kubevirt.io/workload: "desktop"
+          vm.kubevirt.io/flavor: "medium"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: medium
+      spec:
+        domain:
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 4Gi
+          devices:
+            networkInterfaceMultiqueue: true
+            useVirtioTransitional: true
+            rng: {}
+            inputs:
+              - type: tablet
+                bus: virtio
+                name: tablet
+            disks:
+            - bootOrder: 1
+              disk:
+                bus: virtio
+              name: ${NAME}
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+              model: virtio
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: cloud-user
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'rhel6-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'rhel6'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user cloud-user
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/rhel6-desktop-small.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: rhel6-desktop-small
+  annotations:
+    openshift.io/display-name: "Red Hat Enterprise Linux 6.0+ VM"
+    description: >-
+      Template for Red Hat Enterprise Linux 6 VM or newer.
+      A PVC with the RHEL disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,linux,rhel"
+    iconClass: "icon-rhel"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/rhel6.0: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.1: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.10: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.2: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.3: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.4: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.5: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.6: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.7: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.8: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.9: Red Hat Enterprise Linux 6.0 or higher
+  labels:
+    os.template.kubevirt.io/rhel6.0: "true"
+    os.template.kubevirt.io/rhel6.1: "true"
+    os.template.kubevirt.io/rhel6.10: "true"
+    os.template.kubevirt.io/rhel6.2: "true"
+    os.template.kubevirt.io/rhel6.3: "true"
+    os.template.kubevirt.io/rhel6.4: "true"
+    os.template.kubevirt.io/rhel6.5: "true"
+    os.template.kubevirt.io/rhel6.6: "true"
+    os.template.kubevirt.io/rhel6.7: "true"
+    os.template.kubevirt.io/rhel6.8: "true"
+    os.template.kubevirt.io/rhel6.9: "true"
+    workload.template.kubevirt.io/desktop: "true"
+    flavor.template.kubevirt.io/small: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: rhel6-desktop-small
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 536870912
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "rhel6"
+          vm.kubevirt.io/workload: "desktop"
+          vm.kubevirt.io/flavor: "small"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: small
+      spec:
+        domain:
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 2Gi
+          devices:
+            networkInterfaceMultiqueue: true
+            useVirtioTransitional: true
+            rng: {}
+            inputs:
+              - type: tablet
+                bus: virtio
+                name: tablet
+            disks:
+            - bootOrder: 1
+              disk:
+                bus: virtio
+              name: ${NAME}
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+              model: virtio
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: cloud-user
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'rhel6-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'rhel6'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user cloud-user
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/rhel6-desktop-tiny.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: rhel6-desktop-tiny
+  annotations:
+    openshift.io/display-name: "Red Hat Enterprise Linux 6.0+ VM"
+    description: >-
+      Template for Red Hat Enterprise Linux 6 VM or newer.
+      A PVC with the RHEL disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,linux,rhel"
+    iconClass: "icon-rhel"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/rhel6.0: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.1: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.10: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.2: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.3: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.4: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.5: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.6: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.7: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.8: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.9: Red Hat Enterprise Linux 6.0 or higher
+  labels:
+    os.template.kubevirt.io/rhel6.0: "true"
+    os.template.kubevirt.io/rhel6.1: "true"
+    os.template.kubevirt.io/rhel6.10: "true"
+    os.template.kubevirt.io/rhel6.2: "true"
+    os.template.kubevirt.io/rhel6.3: "true"
+    os.template.kubevirt.io/rhel6.4: "true"
+    os.template.kubevirt.io/rhel6.5: "true"
+    os.template.kubevirt.io/rhel6.6: "true"
+    os.template.kubevirt.io/rhel6.7: "true"
+    os.template.kubevirt.io/rhel6.8: "true"
+    os.template.kubevirt.io/rhel6.9: "true"
+    workload.template.kubevirt.io/desktop: "true"
+    flavor.template.kubevirt.io/tiny: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: rhel6-desktop-tiny
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 536870912
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "rhel6"
+          vm.kubevirt.io/workload: "desktop"
+          vm.kubevirt.io/flavor: "tiny"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: tiny
+      spec:
+        domain:
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 1Gi
+          devices:
+            networkInterfaceMultiqueue: true
+            useVirtioTransitional: true
+            rng: {}
+            inputs:
+              - type: tablet
+                bus: virtio
+                name: tablet
+            disks:
+            - bootOrder: 1
+              disk:
+                bus: virtio
+              name: ${NAME}
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+              model: virtio
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: cloud-user
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'rhel6-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'rhel6'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user cloud-user
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/rhel6-server-large.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: rhel6-server-large
+  annotations:
+    openshift.io/display-name: "Red Hat Enterprise Linux 6.0+ VM"
+    description: >-
+      Template for Red Hat Enterprise Linux 6 VM or newer.
+      A PVC with the RHEL disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,linux,rhel"
+    iconClass: "icon-rhel"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/rhel6.0: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.1: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.10: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.2: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.3: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.4: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.5: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.6: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.7: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.8: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.9: Red Hat Enterprise Linux 6.0 or higher
+  labels:
+    os.template.kubevirt.io/rhel6.0: "true"
+    os.template.kubevirt.io/rhel6.1: "true"
+    os.template.kubevirt.io/rhel6.10: "true"
+    os.template.kubevirt.io/rhel6.2: "true"
+    os.template.kubevirt.io/rhel6.3: "true"
+    os.template.kubevirt.io/rhel6.4: "true"
+    os.template.kubevirt.io/rhel6.5: "true"
+    os.template.kubevirt.io/rhel6.6: "true"
+    os.template.kubevirt.io/rhel6.7: "true"
+    os.template.kubevirt.io/rhel6.8: "true"
+    os.template.kubevirt.io/rhel6.9: "true"
+    workload.template.kubevirt.io/server: "true"
+    flavor.template.kubevirt.io/large: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: rhel6-server-large
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 536870912
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "rhel6"
+          vm.kubevirt.io/workload: "server"
+          vm.kubevirt.io/flavor: "large"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: large
+      spec:
+        domain:
+          cpu:
+            sockets: 2
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 8Gi
+          devices:
+            networkInterfaceMultiqueue: true
+            useVirtioTransitional: true
+            rng: {}
+            disks:
+            - bootOrder: 1
+              disk:
+                bus: virtio
+              name: ${NAME}
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+              model: virtio
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: cloud-user
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'rhel6-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'rhel6'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user cloud-user
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/rhel6-server-medium.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: rhel6-server-medium
+  annotations:
+    openshift.io/display-name: "Red Hat Enterprise Linux 6.0+ VM"
+    description: >-
+      Template for Red Hat Enterprise Linux 6 VM or newer.
+      A PVC with the RHEL disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,linux,rhel"
+    iconClass: "icon-rhel"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/rhel6.0: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.1: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.10: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.2: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.3: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.4: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.5: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.6: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.7: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.8: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.9: Red Hat Enterprise Linux 6.0 or higher
+  labels:
+    os.template.kubevirt.io/rhel6.0: "true"
+    os.template.kubevirt.io/rhel6.1: "true"
+    os.template.kubevirt.io/rhel6.10: "true"
+    os.template.kubevirt.io/rhel6.2: "true"
+    os.template.kubevirt.io/rhel6.3: "true"
+    os.template.kubevirt.io/rhel6.4: "true"
+    os.template.kubevirt.io/rhel6.5: "true"
+    os.template.kubevirt.io/rhel6.6: "true"
+    os.template.kubevirt.io/rhel6.7: "true"
+    os.template.kubevirt.io/rhel6.8: "true"
+    os.template.kubevirt.io/rhel6.9: "true"
+    workload.template.kubevirt.io/server: "true"
+    flavor.template.kubevirt.io/medium: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: rhel6-server-medium
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 536870912
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "rhel6"
+          vm.kubevirt.io/workload: "server"
+          vm.kubevirt.io/flavor: "medium"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: medium
+      spec:
+        domain:
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 4Gi
+          devices:
+            networkInterfaceMultiqueue: true
+            useVirtioTransitional: true
+            rng: {}
+            disks:
+            - bootOrder: 1
+              disk:
+                bus: virtio
+              name: ${NAME}
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+              model: virtio
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: cloud-user
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'rhel6-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'rhel6'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user cloud-user
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/rhel6-server-small.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: rhel6-server-small
+  annotations:
+    openshift.io/display-name: "Red Hat Enterprise Linux 6.0+ VM"
+    description: >-
+      Template for Red Hat Enterprise Linux 6 VM or newer.
+      A PVC with the RHEL disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,linux,rhel"
+    iconClass: "icon-rhel"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/rhel6.0: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.1: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.10: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.2: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.3: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.4: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.5: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.6: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.7: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.8: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.9: Red Hat Enterprise Linux 6.0 or higher
+  labels:
+    os.template.kubevirt.io/rhel6.0: "true"
+    os.template.kubevirt.io/rhel6.1: "true"
+    os.template.kubevirt.io/rhel6.10: "true"
+    os.template.kubevirt.io/rhel6.2: "true"
+    os.template.kubevirt.io/rhel6.3: "true"
+    os.template.kubevirt.io/rhel6.4: "true"
+    os.template.kubevirt.io/rhel6.5: "true"
+    os.template.kubevirt.io/rhel6.6: "true"
+    os.template.kubevirt.io/rhel6.7: "true"
+    os.template.kubevirt.io/rhel6.8: "true"
+    os.template.kubevirt.io/rhel6.9: "true"
+    workload.template.kubevirt.io/server: "true"
+    flavor.template.kubevirt.io/small: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+    template.kubevirt.io/default-os-variant: "true"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: rhel6-server-small
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 536870912
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "rhel6"
+          vm.kubevirt.io/workload: "server"
+          vm.kubevirt.io/flavor: "small"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: small
+      spec:
+        domain:
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 2Gi
+          devices:
+            networkInterfaceMultiqueue: true
+            useVirtioTransitional: true
+            rng: {}
+            disks:
+            - bootOrder: 1
+              disk:
+                bus: virtio
+              name: ${NAME}
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+              model: virtio
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: cloud-user
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'rhel6-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'rhel6'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user cloud-user
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/rhel6-server-tiny.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: rhel6-server-tiny
+  annotations:
+    openshift.io/display-name: "Red Hat Enterprise Linux 6.0+ VM"
+    description: >-
+      Template for Red Hat Enterprise Linux 6 VM or newer.
+      A PVC with the RHEL disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,linux,rhel"
+    iconClass: "icon-rhel"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/rhel6.0: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.1: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.10: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.2: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.3: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.4: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.5: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.6: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.7: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.8: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.9: Red Hat Enterprise Linux 6.0 or higher
+  labels:
+    os.template.kubevirt.io/rhel6.0: "true"
+    os.template.kubevirt.io/rhel6.1: "true"
+    os.template.kubevirt.io/rhel6.10: "true"
+    os.template.kubevirt.io/rhel6.2: "true"
+    os.template.kubevirt.io/rhel6.3: "true"
+    os.template.kubevirt.io/rhel6.4: "true"
+    os.template.kubevirt.io/rhel6.5: "true"
+    os.template.kubevirt.io/rhel6.6: "true"
+    os.template.kubevirt.io/rhel6.7: "true"
+    os.template.kubevirt.io/rhel6.8: "true"
+    os.template.kubevirt.io/rhel6.9: "true"
+    workload.template.kubevirt.io/server: "true"
+    flavor.template.kubevirt.io/tiny: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: rhel6-server-tiny
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 536870912
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "rhel6"
+          vm.kubevirt.io/workload: "server"
+          vm.kubevirt.io/flavor: "tiny"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: tiny
+      spec:
+        domain:
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 1Gi
+          devices:
+            networkInterfaceMultiqueue: true
+            useVirtioTransitional: true
+            rng: {}
+            disks:
+            - bootOrder: 1
+              disk:
+                bus: virtio
+              name: ${NAME}
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+              model: virtio
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: cloud-user
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'rhel6-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'rhel6'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user cloud-user
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/rhel7-desktop-large.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: rhel7-desktop-large
+  annotations:
+    openshift.io/display-name: "Red Hat Enterprise Linux 7.0+ VM"
+    description: >-
+      Template for Red Hat Enterprise Linux 7 VM or newer.
+      A PVC with the RHEL disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,linux,rhel"
+    iconClass: "icon-rhel"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/rhel7.0: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.1: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.2: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.3: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.4: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.5: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.6: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.7: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.8: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.9: Red Hat Enterprise Linux 7.0 or higher
+  labels:
+    os.template.kubevirt.io/rhel7.0: "true"
+    os.template.kubevirt.io/rhel7.1: "true"
+    os.template.kubevirt.io/rhel7.2: "true"
+    os.template.kubevirt.io/rhel7.3: "true"
+    os.template.kubevirt.io/rhel7.4: "true"
+    os.template.kubevirt.io/rhel7.5: "true"
+    os.template.kubevirt.io/rhel7.6: "true"
+    os.template.kubevirt.io/rhel7.7: "true"
+    os.template.kubevirt.io/rhel7.8: "true"
+    os.template.kubevirt.io/rhel7.9: "true"
+    workload.template.kubevirt.io/desktop: "true"
+    flavor.template.kubevirt.io/large: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: rhel7-desktop-large
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 1073741824
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "rhel7"
+          vm.kubevirt.io/workload: "desktop"
+          vm.kubevirt.io/flavor: "large"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: large
+      spec:
+        domain:
+          cpu:
+            sockets: 2
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 8Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            inputs:
+              - type: tablet
+                bus: virtio
+                name: tablet
+            disks:
+            - disk:
+                bus: virtio
+              name: ${NAME}
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: cloud-user
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'rhel7-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'rhel7'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user cloud-user
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/rhel7-desktop-medium.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: rhel7-desktop-medium
+  annotations:
+    openshift.io/display-name: "Red Hat Enterprise Linux 7.0+ VM"
+    description: >-
+      Template for Red Hat Enterprise Linux 7 VM or newer.
+      A PVC with the RHEL disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,linux,rhel"
+    iconClass: "icon-rhel"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/rhel7.0: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.1: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.2: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.3: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.4: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.5: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.6: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.7: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.8: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.9: Red Hat Enterprise Linux 7.0 or higher
+  labels:
+    os.template.kubevirt.io/rhel7.0: "true"
+    os.template.kubevirt.io/rhel7.1: "true"
+    os.template.kubevirt.io/rhel7.2: "true"
+    os.template.kubevirt.io/rhel7.3: "true"
+    os.template.kubevirt.io/rhel7.4: "true"
+    os.template.kubevirt.io/rhel7.5: "true"
+    os.template.kubevirt.io/rhel7.6: "true"
+    os.template.kubevirt.io/rhel7.7: "true"
+    os.template.kubevirt.io/rhel7.8: "true"
+    os.template.kubevirt.io/rhel7.9: "true"
+    workload.template.kubevirt.io/desktop: "true"
+    flavor.template.kubevirt.io/medium: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: rhel7-desktop-medium
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 1073741824
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "rhel7"
+          vm.kubevirt.io/workload: "desktop"
+          vm.kubevirt.io/flavor: "medium"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: medium
+      spec:
+        domain:
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 4Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            inputs:
+              - type: tablet
+                bus: virtio
+                name: tablet
+            disks:
+            - disk:
+                bus: virtio
+              name: ${NAME}
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: cloud-user
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'rhel7-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'rhel7'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user cloud-user
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/rhel7-desktop-small.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: rhel7-desktop-small
+  annotations:
+    openshift.io/display-name: "Red Hat Enterprise Linux 7.0+ VM"
+    description: >-
+      Template for Red Hat Enterprise Linux 7 VM or newer.
+      A PVC with the RHEL disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,linux,rhel"
+    iconClass: "icon-rhel"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/rhel7.0: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.1: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.2: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.3: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.4: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.5: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.6: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.7: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.8: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.9: Red Hat Enterprise Linux 7.0 or higher
+  labels:
+    os.template.kubevirt.io/rhel7.0: "true"
+    os.template.kubevirt.io/rhel7.1: "true"
+    os.template.kubevirt.io/rhel7.2: "true"
+    os.template.kubevirt.io/rhel7.3: "true"
+    os.template.kubevirt.io/rhel7.4: "true"
+    os.template.kubevirt.io/rhel7.5: "true"
+    os.template.kubevirt.io/rhel7.6: "true"
+    os.template.kubevirt.io/rhel7.7: "true"
+    os.template.kubevirt.io/rhel7.8: "true"
+    os.template.kubevirt.io/rhel7.9: "true"
+    workload.template.kubevirt.io/desktop: "true"
+    flavor.template.kubevirt.io/small: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: rhel7-desktop-small
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 1073741824
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "rhel7"
+          vm.kubevirt.io/workload: "desktop"
+          vm.kubevirt.io/flavor: "small"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: small
+      spec:
+        domain:
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 2Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            inputs:
+              - type: tablet
+                bus: virtio
+                name: tablet
+            disks:
+            - disk:
+                bus: virtio
+              name: ${NAME}
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: cloud-user
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'rhel7-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'rhel7'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user cloud-user
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/rhel7-desktop-tiny.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: rhel7-desktop-tiny
+  annotations:
+    openshift.io/display-name: "Red Hat Enterprise Linux 7.0+ VM"
+    description: >-
+      Template for Red Hat Enterprise Linux 7 VM or newer.
+      A PVC with the RHEL disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,linux,rhel"
+    iconClass: "icon-rhel"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/rhel7.0: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.1: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.2: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.3: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.4: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.5: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.6: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.7: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.8: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.9: Red Hat Enterprise Linux 7.0 or higher
+  labels:
+    os.template.kubevirt.io/rhel7.0: "true"
+    os.template.kubevirt.io/rhel7.1: "true"
+    os.template.kubevirt.io/rhel7.2: "true"
+    os.template.kubevirt.io/rhel7.3: "true"
+    os.template.kubevirt.io/rhel7.4: "true"
+    os.template.kubevirt.io/rhel7.5: "true"
+    os.template.kubevirt.io/rhel7.6: "true"
+    os.template.kubevirt.io/rhel7.7: "true"
+    os.template.kubevirt.io/rhel7.8: "true"
+    os.template.kubevirt.io/rhel7.9: "true"
+    workload.template.kubevirt.io/desktop: "true"
+    flavor.template.kubevirt.io/tiny: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: rhel7-desktop-tiny
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 1073741824
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "rhel7"
+          vm.kubevirt.io/workload: "desktop"
+          vm.kubevirt.io/flavor: "tiny"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: tiny
+      spec:
+        domain:
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 1Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            inputs:
+              - type: tablet
+                bus: virtio
+                name: tablet
+            disks:
+            - disk:
+                bus: virtio
+              name: ${NAME}
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: cloud-user
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'rhel7-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'rhel7'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user cloud-user
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/rhel7-highperformance-large.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: rhel7-highperformance-large
+  annotations:
+    openshift.io/display-name: "Red Hat Enterprise Linux 7.0+ VM"
+    description: >-
+      Template for Red Hat Enterprise Linux 7 VM or newer.
+      A PVC with the RHEL disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,linux,rhel"
+    iconClass: "icon-rhel"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/rhel7.0: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.1: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.2: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.3: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.4: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.5: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.6: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.7: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.8: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.9: Red Hat Enterprise Linux 7.0 or higher
+  labels:
+    os.template.kubevirt.io/rhel7.0: "true"
+    os.template.kubevirt.io/rhel7.1: "true"
+    os.template.kubevirt.io/rhel7.2: "true"
+    os.template.kubevirt.io/rhel7.3: "true"
+    os.template.kubevirt.io/rhel7.4: "true"
+    os.template.kubevirt.io/rhel7.5: "true"
+    os.template.kubevirt.io/rhel7.6: "true"
+    os.template.kubevirt.io/rhel7.7: "true"
+    os.template.kubevirt.io/rhel7.8: "true"
+    os.template.kubevirt.io/rhel7.9: "true"
+    workload.template.kubevirt.io/highperformance: "true"
+    flavor.template.kubevirt.io/large: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: rhel7-highperformance-large
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 1073741824
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "rhel7"
+          vm.kubevirt.io/workload: "highperformance"
+          vm.kubevirt.io/flavor: "large"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: large
+      spec:
+        domain:
+          ioThreadsPolicy: shared
+          cpu:
+            sockets: 2
+            cores: 1
+            threads: 1
+            dedicatedCpuPlacement: True
+            isolateEmulatorThread: True
+          resources:
+            requests:
+              memory: 8Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            disks:
+            - disk:
+                bus: virtio
+              name: ${NAME}
+              dedicatedIOThread: true
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: cloud-user
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'rhel7-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'rhel7'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user cloud-user
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/rhel7-highperformance-medium.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: rhel7-highperformance-medium
+  annotations:
+    openshift.io/display-name: "Red Hat Enterprise Linux 7.0+ VM"
+    description: >-
+      Template for Red Hat Enterprise Linux 7 VM or newer.
+      A PVC with the RHEL disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,linux,rhel"
+    iconClass: "icon-rhel"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/rhel7.0: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.1: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.2: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.3: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.4: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.5: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.6: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.7: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.8: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.9: Red Hat Enterprise Linux 7.0 or higher
+  labels:
+    os.template.kubevirt.io/rhel7.0: "true"
+    os.template.kubevirt.io/rhel7.1: "true"
+    os.template.kubevirt.io/rhel7.2: "true"
+    os.template.kubevirt.io/rhel7.3: "true"
+    os.template.kubevirt.io/rhel7.4: "true"
+    os.template.kubevirt.io/rhel7.5: "true"
+    os.template.kubevirt.io/rhel7.6: "true"
+    os.template.kubevirt.io/rhel7.7: "true"
+    os.template.kubevirt.io/rhel7.8: "true"
+    os.template.kubevirt.io/rhel7.9: "true"
+    workload.template.kubevirt.io/highperformance: "true"
+    flavor.template.kubevirt.io/medium: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: rhel7-highperformance-medium
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 1073741824
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "rhel7"
+          vm.kubevirt.io/workload: "highperformance"
+          vm.kubevirt.io/flavor: "medium"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: medium
+      spec:
+        domain:
+          ioThreadsPolicy: shared
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+            dedicatedCpuPlacement: True
+            isolateEmulatorThread: True
+          resources:
+            requests:
+              memory: 4Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            disks:
+            - disk:
+                bus: virtio
+              name: ${NAME}
+              dedicatedIOThread: true
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: cloud-user
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'rhel7-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'rhel7'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user cloud-user
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/rhel7-highperformance-small.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: rhel7-highperformance-small
+  annotations:
+    openshift.io/display-name: "Red Hat Enterprise Linux 7.0+ VM"
+    description: >-
+      Template for Red Hat Enterprise Linux 7 VM or newer.
+      A PVC with the RHEL disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,linux,rhel"
+    iconClass: "icon-rhel"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/rhel7.0: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.1: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.2: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.3: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.4: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.5: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.6: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.7: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.8: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.9: Red Hat Enterprise Linux 7.0 or higher
+  labels:
+    os.template.kubevirt.io/rhel7.0: "true"
+    os.template.kubevirt.io/rhel7.1: "true"
+    os.template.kubevirt.io/rhel7.2: "true"
+    os.template.kubevirt.io/rhel7.3: "true"
+    os.template.kubevirt.io/rhel7.4: "true"
+    os.template.kubevirt.io/rhel7.5: "true"
+    os.template.kubevirt.io/rhel7.6: "true"
+    os.template.kubevirt.io/rhel7.7: "true"
+    os.template.kubevirt.io/rhel7.8: "true"
+    os.template.kubevirt.io/rhel7.9: "true"
+    workload.template.kubevirt.io/highperformance: "true"
+    flavor.template.kubevirt.io/small: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: rhel7-highperformance-small
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 1073741824
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "rhel7"
+          vm.kubevirt.io/workload: "highperformance"
+          vm.kubevirt.io/flavor: "small"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: small
+      spec:
+        domain:
+          ioThreadsPolicy: shared
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+            dedicatedCpuPlacement: True
+            isolateEmulatorThread: True
+          resources:
+            requests:
+              memory: 2Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            disks:
+            - disk:
+                bus: virtio
+              name: ${NAME}
+              dedicatedIOThread: true
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: cloud-user
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'rhel7-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'rhel7'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user cloud-user
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/rhel7-highperformance-tiny.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: rhel7-highperformance-tiny
+  annotations:
+    openshift.io/display-name: "Red Hat Enterprise Linux 7.0+ VM"
+    description: >-
+      Template for Red Hat Enterprise Linux 7 VM or newer.
+      A PVC with the RHEL disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,linux,rhel"
+    iconClass: "icon-rhel"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/rhel7.0: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.1: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.2: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.3: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.4: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.5: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.6: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.7: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.8: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.9: Red Hat Enterprise Linux 7.0 or higher
+  labels:
+    os.template.kubevirt.io/rhel7.0: "true"
+    os.template.kubevirt.io/rhel7.1: "true"
+    os.template.kubevirt.io/rhel7.2: "true"
+    os.template.kubevirt.io/rhel7.3: "true"
+    os.template.kubevirt.io/rhel7.4: "true"
+    os.template.kubevirt.io/rhel7.5: "true"
+    os.template.kubevirt.io/rhel7.6: "true"
+    os.template.kubevirt.io/rhel7.7: "true"
+    os.template.kubevirt.io/rhel7.8: "true"
+    os.template.kubevirt.io/rhel7.9: "true"
+    workload.template.kubevirt.io/highperformance: "true"
+    flavor.template.kubevirt.io/tiny: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: rhel7-highperformance-tiny
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 1073741824
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "rhel7"
+          vm.kubevirt.io/workload: "highperformance"
+          vm.kubevirt.io/flavor: "tiny"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: tiny
+      spec:
+        domain:
+          ioThreadsPolicy: shared
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+            dedicatedCpuPlacement: True
+            isolateEmulatorThread: True
+          resources:
+            requests:
+              memory: 1Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            disks:
+            - disk:
+                bus: virtio
+              name: ${NAME}
+              dedicatedIOThread: true
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: cloud-user
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'rhel7-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'rhel7'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user cloud-user
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/rhel7-server-large.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: rhel7-server-large
+  annotations:
+    openshift.io/display-name: "Red Hat Enterprise Linux 7.0+ VM"
+    description: >-
+      Template for Red Hat Enterprise Linux 7 VM or newer.
+      A PVC with the RHEL disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,linux,rhel"
+    iconClass: "icon-rhel"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/rhel7.0: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.1: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.2: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.3: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.4: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.5: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.6: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.7: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.8: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.9: Red Hat Enterprise Linux 7.0 or higher
+  labels:
+    os.template.kubevirt.io/rhel7.0: "true"
+    os.template.kubevirt.io/rhel7.1: "true"
+    os.template.kubevirt.io/rhel7.2: "true"
+    os.template.kubevirt.io/rhel7.3: "true"
+    os.template.kubevirt.io/rhel7.4: "true"
+    os.template.kubevirt.io/rhel7.5: "true"
+    os.template.kubevirt.io/rhel7.6: "true"
+    os.template.kubevirt.io/rhel7.7: "true"
+    os.template.kubevirt.io/rhel7.8: "true"
+    os.template.kubevirt.io/rhel7.9: "true"
+    workload.template.kubevirt.io/server: "true"
+    flavor.template.kubevirt.io/large: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: rhel7-server-large
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 1073741824
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "rhel7"
+          vm.kubevirt.io/workload: "server"
+          vm.kubevirt.io/flavor: "large"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: large
+      spec:
+        domain:
+          cpu:
+            sockets: 2
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 8Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            disks:
+            - disk:
+                bus: virtio
+              name: ${NAME}
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: cloud-user
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'rhel7-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'rhel7'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user cloud-user
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/rhel7-server-medium.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: rhel7-server-medium
+  annotations:
+    openshift.io/display-name: "Red Hat Enterprise Linux 7.0+ VM"
+    description: >-
+      Template for Red Hat Enterprise Linux 7 VM or newer.
+      A PVC with the RHEL disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,linux,rhel"
+    iconClass: "icon-rhel"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/rhel7.0: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.1: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.2: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.3: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.4: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.5: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.6: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.7: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.8: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.9: Red Hat Enterprise Linux 7.0 or higher
+  labels:
+    os.template.kubevirt.io/rhel7.0: "true"
+    os.template.kubevirt.io/rhel7.1: "true"
+    os.template.kubevirt.io/rhel7.2: "true"
+    os.template.kubevirt.io/rhel7.3: "true"
+    os.template.kubevirt.io/rhel7.4: "true"
+    os.template.kubevirt.io/rhel7.5: "true"
+    os.template.kubevirt.io/rhel7.6: "true"
+    os.template.kubevirt.io/rhel7.7: "true"
+    os.template.kubevirt.io/rhel7.8: "true"
+    os.template.kubevirt.io/rhel7.9: "true"
+    workload.template.kubevirt.io/server: "true"
+    flavor.template.kubevirt.io/medium: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: rhel7-server-medium
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 1073741824
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "rhel7"
+          vm.kubevirt.io/workload: "server"
+          vm.kubevirt.io/flavor: "medium"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: medium
+      spec:
+        domain:
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 4Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            disks:
+            - disk:
+                bus: virtio
+              name: ${NAME}
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: cloud-user
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'rhel7-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'rhel7'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user cloud-user
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/rhel7-server-small.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: rhel7-server-small
+  annotations:
+    openshift.io/display-name: "Red Hat Enterprise Linux 7.0+ VM"
+    description: >-
+      Template for Red Hat Enterprise Linux 7 VM or newer.
+      A PVC with the RHEL disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,linux,rhel"
+    iconClass: "icon-rhel"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/rhel7.0: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.1: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.2: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.3: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.4: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.5: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.6: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.7: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.8: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.9: Red Hat Enterprise Linux 7.0 or higher
+  labels:
+    os.template.kubevirt.io/rhel7.0: "true"
+    os.template.kubevirt.io/rhel7.1: "true"
+    os.template.kubevirt.io/rhel7.2: "true"
+    os.template.kubevirt.io/rhel7.3: "true"
+    os.template.kubevirt.io/rhel7.4: "true"
+    os.template.kubevirt.io/rhel7.5: "true"
+    os.template.kubevirt.io/rhel7.6: "true"
+    os.template.kubevirt.io/rhel7.7: "true"
+    os.template.kubevirt.io/rhel7.8: "true"
+    os.template.kubevirt.io/rhel7.9: "true"
+    workload.template.kubevirt.io/server: "true"
+    flavor.template.kubevirt.io/small: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+    template.kubevirt.io/default-os-variant: "true"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: rhel7-server-small
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 1073741824
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "rhel7"
+          vm.kubevirt.io/workload: "server"
+          vm.kubevirt.io/flavor: "small"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: small
+      spec:
+        domain:
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 2Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            disks:
+            - disk:
+                bus: virtio
+              name: ${NAME}
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: cloud-user
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'rhel7-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'rhel7'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user cloud-user
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/rhel7-server-tiny.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: rhel7-server-tiny
+  annotations:
+    openshift.io/display-name: "Red Hat Enterprise Linux 7.0+ VM"
+    description: >-
+      Template for Red Hat Enterprise Linux 7 VM or newer.
+      A PVC with the RHEL disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,linux,rhel"
+    iconClass: "icon-rhel"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/rhel7.0: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.1: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.2: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.3: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.4: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.5: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.6: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.7: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.8: Red Hat Enterprise Linux 7.0 or higher
+    name.os.template.kubevirt.io/rhel7.9: Red Hat Enterprise Linux 7.0 or higher
+  labels:
+    os.template.kubevirt.io/rhel7.0: "true"
+    os.template.kubevirt.io/rhel7.1: "true"
+    os.template.kubevirt.io/rhel7.2: "true"
+    os.template.kubevirt.io/rhel7.3: "true"
+    os.template.kubevirt.io/rhel7.4: "true"
+    os.template.kubevirt.io/rhel7.5: "true"
+    os.template.kubevirt.io/rhel7.6: "true"
+    os.template.kubevirt.io/rhel7.7: "true"
+    os.template.kubevirt.io/rhel7.8: "true"
+    os.template.kubevirt.io/rhel7.9: "true"
+    workload.template.kubevirt.io/server: "true"
+    flavor.template.kubevirt.io/tiny: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: rhel7-server-tiny
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 1073741824
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "rhel7"
+          vm.kubevirt.io/workload: "server"
+          vm.kubevirt.io/flavor: "tiny"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: tiny
+      spec:
+        domain:
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 1Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            disks:
+            - disk:
+                bus: virtio
+              name: ${NAME}
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: cloud-user
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'rhel7-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'rhel7'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user cloud-user
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/rhel8-desktop-large.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: rhel8-desktop-large
+  annotations:
+    openshift.io/display-name: "Red Hat Enterprise Linux 8.0+ VM"
+    description: >-
+      Template for Red Hat Enterprise Linux 8 VM or newer.
+      A PVC with the RHEL disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,linux,rhel"
+    iconClass: "icon-rhel"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/rhel8.0: Red Hat Enterprise Linux 8.0 or higher
+    name.os.template.kubevirt.io/rhel8.1: Red Hat Enterprise Linux 8.0 or higher
+    name.os.template.kubevirt.io/rhel8.2: Red Hat Enterprise Linux 8.0 or higher
+    name.os.template.kubevirt.io/rhel8.3: Red Hat Enterprise Linux 8.0 or higher
+    name.os.template.kubevirt.io/rhel8.4: Red Hat Enterprise Linux 8.0 or higher
+    name.os.template.kubevirt.io/rhel8.5: Red Hat Enterprise Linux 8.0 or higher
+  labels:
+    os.template.kubevirt.io/rhel8.0: "true"
+    os.template.kubevirt.io/rhel8.1: "true"
+    os.template.kubevirt.io/rhel8.2: "true"
+    os.template.kubevirt.io/rhel8.3: "true"
+    os.template.kubevirt.io/rhel8.4: "true"
+    os.template.kubevirt.io/rhel8.5: "true"
+    workload.template.kubevirt.io/desktop: "true"
+    flavor.template.kubevirt.io/large: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: rhel8-desktop-large
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 1610612736
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "rhel8"
+          vm.kubevirt.io/workload: "desktop"
+          vm.kubevirt.io/flavor: "large"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: large
+      spec:
+        domain:
+          cpu:
+            sockets: 2
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 8Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            inputs:
+              - type: tablet
+                bus: virtio
+                name: tablet
+            disks:
+            - disk:
+                bus: virtio
+              name: ${NAME}
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: cloud-user
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'rhel8-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'rhel8'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user cloud-user
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/rhel8-desktop-medium.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: rhel8-desktop-medium
+  annotations:
+    openshift.io/display-name: "Red Hat Enterprise Linux 8.0+ VM"
+    description: >-
+      Template for Red Hat Enterprise Linux 8 VM or newer.
+      A PVC with the RHEL disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,linux,rhel"
+    iconClass: "icon-rhel"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/rhel8.0: Red Hat Enterprise Linux 8.0 or higher
+    name.os.template.kubevirt.io/rhel8.1: Red Hat Enterprise Linux 8.0 or higher
+    name.os.template.kubevirt.io/rhel8.2: Red Hat Enterprise Linux 8.0 or higher
+    name.os.template.kubevirt.io/rhel8.3: Red Hat Enterprise Linux 8.0 or higher
+    name.os.template.kubevirt.io/rhel8.4: Red Hat Enterprise Linux 8.0 or higher
+    name.os.template.kubevirt.io/rhel8.5: Red Hat Enterprise Linux 8.0 or higher
+  labels:
+    os.template.kubevirt.io/rhel8.0: "true"
+    os.template.kubevirt.io/rhel8.1: "true"
+    os.template.kubevirt.io/rhel8.2: "true"
+    os.template.kubevirt.io/rhel8.3: "true"
+    os.template.kubevirt.io/rhel8.4: "true"
+    os.template.kubevirt.io/rhel8.5: "true"
+    workload.template.kubevirt.io/desktop: "true"
+    flavor.template.kubevirt.io/medium: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: rhel8-desktop-medium
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 1610612736
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "rhel8"
+          vm.kubevirt.io/workload: "desktop"
+          vm.kubevirt.io/flavor: "medium"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: medium
+      spec:
+        domain:
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 4Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            inputs:
+              - type: tablet
+                bus: virtio
+                name: tablet
+            disks:
+            - disk:
+                bus: virtio
+              name: ${NAME}
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: cloud-user
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'rhel8-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'rhel8'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user cloud-user
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/rhel8-desktop-small.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: rhel8-desktop-small
+  annotations:
+    openshift.io/display-name: "Red Hat Enterprise Linux 8.0+ VM"
+    description: >-
+      Template for Red Hat Enterprise Linux 8 VM or newer.
+      A PVC with the RHEL disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,linux,rhel"
+    iconClass: "icon-rhel"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/rhel8.0: Red Hat Enterprise Linux 8.0 or higher
+    name.os.template.kubevirt.io/rhel8.1: Red Hat Enterprise Linux 8.0 or higher
+    name.os.template.kubevirt.io/rhel8.2: Red Hat Enterprise Linux 8.0 or higher
+    name.os.template.kubevirt.io/rhel8.3: Red Hat Enterprise Linux 8.0 or higher
+    name.os.template.kubevirt.io/rhel8.4: Red Hat Enterprise Linux 8.0 or higher
+    name.os.template.kubevirt.io/rhel8.5: Red Hat Enterprise Linux 8.0 or higher
+  labels:
+    os.template.kubevirt.io/rhel8.0: "true"
+    os.template.kubevirt.io/rhel8.1: "true"
+    os.template.kubevirt.io/rhel8.2: "true"
+    os.template.kubevirt.io/rhel8.3: "true"
+    os.template.kubevirt.io/rhel8.4: "true"
+    os.template.kubevirt.io/rhel8.5: "true"
+    workload.template.kubevirt.io/desktop: "true"
+    flavor.template.kubevirt.io/small: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: rhel8-desktop-small
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 1610612736
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "rhel8"
+          vm.kubevirt.io/workload: "desktop"
+          vm.kubevirt.io/flavor: "small"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: small
+      spec:
+        domain:
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 2Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            inputs:
+              - type: tablet
+                bus: virtio
+                name: tablet
+            disks:
+            - disk:
+                bus: virtio
+              name: ${NAME}
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: cloud-user
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'rhel8-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'rhel8'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user cloud-user
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/rhel8-desktop-tiny.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: rhel8-desktop-tiny
+  annotations:
+    openshift.io/display-name: "Red Hat Enterprise Linux 8.0+ VM"
+    description: >-
+      Template for Red Hat Enterprise Linux 8 VM or newer.
+      A PVC with the RHEL disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,linux,rhel"
+    iconClass: "icon-rhel"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/rhel8.0: Red Hat Enterprise Linux 8.0 or higher
+    name.os.template.kubevirt.io/rhel8.1: Red Hat Enterprise Linux 8.0 or higher
+    name.os.template.kubevirt.io/rhel8.2: Red Hat Enterprise Linux 8.0 or higher
+    name.os.template.kubevirt.io/rhel8.3: Red Hat Enterprise Linux 8.0 or higher
+    name.os.template.kubevirt.io/rhel8.4: Red Hat Enterprise Linux 8.0 or higher
+    name.os.template.kubevirt.io/rhel8.5: Red Hat Enterprise Linux 8.0 or higher
+  labels:
+    os.template.kubevirt.io/rhel8.0: "true"
+    os.template.kubevirt.io/rhel8.1: "true"
+    os.template.kubevirt.io/rhel8.2: "true"
+    os.template.kubevirt.io/rhel8.3: "true"
+    os.template.kubevirt.io/rhel8.4: "true"
+    os.template.kubevirt.io/rhel8.5: "true"
+    workload.template.kubevirt.io/desktop: "true"
+    flavor.template.kubevirt.io/tiny: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: rhel8-desktop-tiny
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 1610612736
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "rhel8"
+          vm.kubevirt.io/workload: "desktop"
+          vm.kubevirt.io/flavor: "tiny"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: tiny
+      spec:
+        domain:
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 1.5Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            inputs:
+              - type: tablet
+                bus: virtio
+                name: tablet
+            disks:
+            - disk:
+                bus: virtio
+              name: ${NAME}
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: cloud-user
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'rhel8-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'rhel8'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user cloud-user
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/rhel8-highperformance-large.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: rhel8-highperformance-large
+  annotations:
+    openshift.io/display-name: "Red Hat Enterprise Linux 8.0+ VM"
+    description: >-
+      Template for Red Hat Enterprise Linux 8 VM or newer.
+      A PVC with the RHEL disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,linux,rhel"
+    iconClass: "icon-rhel"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/rhel8.0: Red Hat Enterprise Linux 8.0 or higher
+    name.os.template.kubevirt.io/rhel8.1: Red Hat Enterprise Linux 8.0 or higher
+    name.os.template.kubevirt.io/rhel8.2: Red Hat Enterprise Linux 8.0 or higher
+    name.os.template.kubevirt.io/rhel8.3: Red Hat Enterprise Linux 8.0 or higher
+    name.os.template.kubevirt.io/rhel8.4: Red Hat Enterprise Linux 8.0 or higher
+    name.os.template.kubevirt.io/rhel8.5: Red Hat Enterprise Linux 8.0 or higher
+  labels:
+    os.template.kubevirt.io/rhel8.0: "true"
+    os.template.kubevirt.io/rhel8.1: "true"
+    os.template.kubevirt.io/rhel8.2: "true"
+    os.template.kubevirt.io/rhel8.3: "true"
+    os.template.kubevirt.io/rhel8.4: "true"
+    os.template.kubevirt.io/rhel8.5: "true"
+    workload.template.kubevirt.io/highperformance: "true"
+    flavor.template.kubevirt.io/large: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: rhel8-highperformance-large
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 1610612736
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "rhel8"
+          vm.kubevirt.io/workload: "highperformance"
+          vm.kubevirt.io/flavor: "large"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: large
+      spec:
+        domain:
+          ioThreadsPolicy: shared
+          cpu:
+            sockets: 2
+            cores: 1
+            threads: 1
+            dedicatedCpuPlacement: True
+            isolateEmulatorThread: True
+          resources:
+            requests:
+              memory: 8Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            disks:
+            - disk:
+                bus: virtio
+              name: ${NAME}
+              dedicatedIOThread: true
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: cloud-user
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'rhel8-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'rhel8'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user cloud-user
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/rhel8-highperformance-medium.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: rhel8-highperformance-medium
+  annotations:
+    openshift.io/display-name: "Red Hat Enterprise Linux 8.0+ VM"
+    description: >-
+      Template for Red Hat Enterprise Linux 8 VM or newer.
+      A PVC with the RHEL disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,linux,rhel"
+    iconClass: "icon-rhel"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/rhel8.0: Red Hat Enterprise Linux 8.0 or higher
+    name.os.template.kubevirt.io/rhel8.1: Red Hat Enterprise Linux 8.0 or higher
+    name.os.template.kubevirt.io/rhel8.2: Red Hat Enterprise Linux 8.0 or higher
+    name.os.template.kubevirt.io/rhel8.3: Red Hat Enterprise Linux 8.0 or higher
+    name.os.template.kubevirt.io/rhel8.4: Red Hat Enterprise Linux 8.0 or higher
+    name.os.template.kubevirt.io/rhel8.5: Red Hat Enterprise Linux 8.0 or higher
+  labels:
+    os.template.kubevirt.io/rhel8.0: "true"
+    os.template.kubevirt.io/rhel8.1: "true"
+    os.template.kubevirt.io/rhel8.2: "true"
+    os.template.kubevirt.io/rhel8.3: "true"
+    os.template.kubevirt.io/rhel8.4: "true"
+    os.template.kubevirt.io/rhel8.5: "true"
+    workload.template.kubevirt.io/highperformance: "true"
+    flavor.template.kubevirt.io/medium: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: rhel8-highperformance-medium
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 1610612736
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "rhel8"
+          vm.kubevirt.io/workload: "highperformance"
+          vm.kubevirt.io/flavor: "medium"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: medium
+      spec:
+        domain:
+          ioThreadsPolicy: shared
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+            dedicatedCpuPlacement: True
+            isolateEmulatorThread: True
+          resources:
+            requests:
+              memory: 4Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            disks:
+            - disk:
+                bus: virtio
+              name: ${NAME}
+              dedicatedIOThread: true
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: cloud-user
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'rhel8-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'rhel8'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user cloud-user
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/rhel8-highperformance-small.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: rhel8-highperformance-small
+  annotations:
+    openshift.io/display-name: "Red Hat Enterprise Linux 8.0+ VM"
+    description: >-
+      Template for Red Hat Enterprise Linux 8 VM or newer.
+      A PVC with the RHEL disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,linux,rhel"
+    iconClass: "icon-rhel"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/rhel8.0: Red Hat Enterprise Linux 8.0 or higher
+    name.os.template.kubevirt.io/rhel8.1: Red Hat Enterprise Linux 8.0 or higher
+    name.os.template.kubevirt.io/rhel8.2: Red Hat Enterprise Linux 8.0 or higher
+    name.os.template.kubevirt.io/rhel8.3: Red Hat Enterprise Linux 8.0 or higher
+    name.os.template.kubevirt.io/rhel8.4: Red Hat Enterprise Linux 8.0 or higher
+    name.os.template.kubevirt.io/rhel8.5: Red Hat Enterprise Linux 8.0 or higher
+  labels:
+    os.template.kubevirt.io/rhel8.0: "true"
+    os.template.kubevirt.io/rhel8.1: "true"
+    os.template.kubevirt.io/rhel8.2: "true"
+    os.template.kubevirt.io/rhel8.3: "true"
+    os.template.kubevirt.io/rhel8.4: "true"
+    os.template.kubevirt.io/rhel8.5: "true"
+    workload.template.kubevirt.io/highperformance: "true"
+    flavor.template.kubevirt.io/small: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: rhel8-highperformance-small
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 1610612736
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "rhel8"
+          vm.kubevirt.io/workload: "highperformance"
+          vm.kubevirt.io/flavor: "small"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: small
+      spec:
+        domain:
+          ioThreadsPolicy: shared
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+            dedicatedCpuPlacement: True
+            isolateEmulatorThread: True
+          resources:
+            requests:
+              memory: 2Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            disks:
+            - disk:
+                bus: virtio
+              name: ${NAME}
+              dedicatedIOThread: true
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: cloud-user
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'rhel8-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'rhel8'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user cloud-user
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/rhel8-highperformance-tiny.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: rhel8-highperformance-tiny
+  annotations:
+    openshift.io/display-name: "Red Hat Enterprise Linux 8.0+ VM"
+    description: >-
+      Template for Red Hat Enterprise Linux 8 VM or newer.
+      A PVC with the RHEL disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,linux,rhel"
+    iconClass: "icon-rhel"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/rhel8.0: Red Hat Enterprise Linux 8.0 or higher
+    name.os.template.kubevirt.io/rhel8.1: Red Hat Enterprise Linux 8.0 or higher
+    name.os.template.kubevirt.io/rhel8.2: Red Hat Enterprise Linux 8.0 or higher
+    name.os.template.kubevirt.io/rhel8.3: Red Hat Enterprise Linux 8.0 or higher
+    name.os.template.kubevirt.io/rhel8.4: Red Hat Enterprise Linux 8.0 or higher
+    name.os.template.kubevirt.io/rhel8.5: Red Hat Enterprise Linux 8.0 or higher
+  labels:
+    os.template.kubevirt.io/rhel8.0: "true"
+    os.template.kubevirt.io/rhel8.1: "true"
+    os.template.kubevirt.io/rhel8.2: "true"
+    os.template.kubevirt.io/rhel8.3: "true"
+    os.template.kubevirt.io/rhel8.4: "true"
+    os.template.kubevirt.io/rhel8.5: "true"
+    workload.template.kubevirt.io/highperformance: "true"
+    flavor.template.kubevirt.io/tiny: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: rhel8-highperformance-tiny
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 1610612736
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "rhel8"
+          vm.kubevirt.io/workload: "highperformance"
+          vm.kubevirt.io/flavor: "tiny"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: tiny
+      spec:
+        domain:
+          ioThreadsPolicy: shared
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+            dedicatedCpuPlacement: True
+            isolateEmulatorThread: True
+          resources:
+            requests:
+              memory: 1.5Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            disks:
+            - disk:
+                bus: virtio
+              name: ${NAME}
+              dedicatedIOThread: true
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: cloud-user
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'rhel8-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'rhel8'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user cloud-user
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/rhel8-server-large.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: rhel8-server-large
+  annotations:
+    openshift.io/display-name: "Red Hat Enterprise Linux 8.0+ VM"
+    description: >-
+      Template for Red Hat Enterprise Linux 8 VM or newer.
+      A PVC with the RHEL disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,linux,rhel"
+    iconClass: "icon-rhel"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/rhel8.0: Red Hat Enterprise Linux 8.0 or higher
+    name.os.template.kubevirt.io/rhel8.1: Red Hat Enterprise Linux 8.0 or higher
+    name.os.template.kubevirt.io/rhel8.2: Red Hat Enterprise Linux 8.0 or higher
+    name.os.template.kubevirt.io/rhel8.3: Red Hat Enterprise Linux 8.0 or higher
+    name.os.template.kubevirt.io/rhel8.4: Red Hat Enterprise Linux 8.0 or higher
+    name.os.template.kubevirt.io/rhel8.5: Red Hat Enterprise Linux 8.0 or higher
+  labels:
+    os.template.kubevirt.io/rhel8.0: "true"
+    os.template.kubevirt.io/rhel8.1: "true"
+    os.template.kubevirt.io/rhel8.2: "true"
+    os.template.kubevirt.io/rhel8.3: "true"
+    os.template.kubevirt.io/rhel8.4: "true"
+    os.template.kubevirt.io/rhel8.5: "true"
+    workload.template.kubevirt.io/server: "true"
+    flavor.template.kubevirt.io/large: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: rhel8-server-large
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 1610612736
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "rhel8"
+          vm.kubevirt.io/workload: "server"
+          vm.kubevirt.io/flavor: "large"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: large
+      spec:
+        domain:
+          cpu:
+            sockets: 2
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 8Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            disks:
+            - disk:
+                bus: virtio
+              name: ${NAME}
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: cloud-user
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'rhel8-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'rhel8'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user cloud-user
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/rhel8-server-medium.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: rhel8-server-medium
+  annotations:
+    openshift.io/display-name: "Red Hat Enterprise Linux 8.0+ VM"
+    description: >-
+      Template for Red Hat Enterprise Linux 8 VM or newer.
+      A PVC with the RHEL disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,linux,rhel"
+    iconClass: "icon-rhel"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/rhel8.0: Red Hat Enterprise Linux 8.0 or higher
+    name.os.template.kubevirt.io/rhel8.1: Red Hat Enterprise Linux 8.0 or higher
+    name.os.template.kubevirt.io/rhel8.2: Red Hat Enterprise Linux 8.0 or higher
+    name.os.template.kubevirt.io/rhel8.3: Red Hat Enterprise Linux 8.0 or higher
+    name.os.template.kubevirt.io/rhel8.4: Red Hat Enterprise Linux 8.0 or higher
+    name.os.template.kubevirt.io/rhel8.5: Red Hat Enterprise Linux 8.0 or higher
+  labels:
+    os.template.kubevirt.io/rhel8.0: "true"
+    os.template.kubevirt.io/rhel8.1: "true"
+    os.template.kubevirt.io/rhel8.2: "true"
+    os.template.kubevirt.io/rhel8.3: "true"
+    os.template.kubevirt.io/rhel8.4: "true"
+    os.template.kubevirt.io/rhel8.5: "true"
+    workload.template.kubevirt.io/server: "true"
+    flavor.template.kubevirt.io/medium: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: rhel8-server-medium
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 1610612736
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "rhel8"
+          vm.kubevirt.io/workload: "server"
+          vm.kubevirt.io/flavor: "medium"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: medium
+      spec:
+        domain:
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 4Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            disks:
+            - disk:
+                bus: virtio
+              name: ${NAME}
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: cloud-user
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'rhel8-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'rhel8'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user cloud-user
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/rhel8-server-small.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: rhel8-server-small
+  annotations:
+    openshift.io/display-name: "Red Hat Enterprise Linux 8.0+ VM"
+    description: >-
+      Template for Red Hat Enterprise Linux 8 VM or newer.
+      A PVC with the RHEL disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,linux,rhel"
+    iconClass: "icon-rhel"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/rhel8.0: Red Hat Enterprise Linux 8.0 or higher
+    name.os.template.kubevirt.io/rhel8.1: Red Hat Enterprise Linux 8.0 or higher
+    name.os.template.kubevirt.io/rhel8.2: Red Hat Enterprise Linux 8.0 or higher
+    name.os.template.kubevirt.io/rhel8.3: Red Hat Enterprise Linux 8.0 or higher
+    name.os.template.kubevirt.io/rhel8.4: Red Hat Enterprise Linux 8.0 or higher
+    name.os.template.kubevirt.io/rhel8.5: Red Hat Enterprise Linux 8.0 or higher
+  labels:
+    os.template.kubevirt.io/rhel8.0: "true"
+    os.template.kubevirt.io/rhel8.1: "true"
+    os.template.kubevirt.io/rhel8.2: "true"
+    os.template.kubevirt.io/rhel8.3: "true"
+    os.template.kubevirt.io/rhel8.4: "true"
+    os.template.kubevirt.io/rhel8.5: "true"
+    workload.template.kubevirt.io/server: "true"
+    flavor.template.kubevirt.io/small: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+    template.kubevirt.io/default-os-variant: "true"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: rhel8-server-small
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 1610612736
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "rhel8"
+          vm.kubevirt.io/workload: "server"
+          vm.kubevirt.io/flavor: "small"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: small
+      spec:
+        domain:
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 2Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            disks:
+            - disk:
+                bus: virtio
+              name: ${NAME}
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: cloud-user
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'rhel8-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'rhel8'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user cloud-user
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/rhel8-server-tiny.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: rhel8-server-tiny
+  annotations:
+    openshift.io/display-name: "Red Hat Enterprise Linux 8.0+ VM"
+    description: >-
+      Template for Red Hat Enterprise Linux 8 VM or newer.
+      A PVC with the RHEL disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,linux,rhel"
+    iconClass: "icon-rhel"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/rhel8.0: Red Hat Enterprise Linux 8.0 or higher
+    name.os.template.kubevirt.io/rhel8.1: Red Hat Enterprise Linux 8.0 or higher
+    name.os.template.kubevirt.io/rhel8.2: Red Hat Enterprise Linux 8.0 or higher
+    name.os.template.kubevirt.io/rhel8.3: Red Hat Enterprise Linux 8.0 or higher
+    name.os.template.kubevirt.io/rhel8.4: Red Hat Enterprise Linux 8.0 or higher
+    name.os.template.kubevirt.io/rhel8.5: Red Hat Enterprise Linux 8.0 or higher
+  labels:
+    os.template.kubevirt.io/rhel8.0: "true"
+    os.template.kubevirt.io/rhel8.1: "true"
+    os.template.kubevirt.io/rhel8.2: "true"
+    os.template.kubevirt.io/rhel8.3: "true"
+    os.template.kubevirt.io/rhel8.4: "true"
+    os.template.kubevirt.io/rhel8.5: "true"
+    workload.template.kubevirt.io/server: "true"
+    flavor.template.kubevirt.io/tiny: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: rhel8-server-tiny
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 1610612736
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "rhel8"
+          vm.kubevirt.io/workload: "server"
+          vm.kubevirt.io/flavor: "tiny"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: tiny
+      spec:
+        domain:
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 1.5Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            disks:
+            - disk:
+                bus: virtio
+              name: ${NAME}
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: cloud-user
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'rhel8-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'rhel8'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user cloud-user
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/rhel9-desktop-large.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: rhel9-desktop-large
+  annotations:
+    openshift.io/display-name: "Red Hat Enterprise Linux 9.0 VM"
+    description: >-
+      Template for Red Hat Enterprise Linux 9 VM or newer.
+      A PVC with the RHEL disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,linux,rhel"
+    iconClass: "icon-rhel"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/rhel9.0: Red Hat Enterprise Linux 9.0 or higher
+  labels:
+    os.template.kubevirt.io/rhel9.0: "true"
+    workload.template.kubevirt.io/desktop: "true"
+    flavor.template.kubevirt.io/large: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: rhel9-desktop-large
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 1610612736
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "rhel9"
+          vm.kubevirt.io/workload: "desktop"
+          vm.kubevirt.io/flavor: "large"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: large
+      spec:
+        domain:
+          cpu:
+            sockets: 2
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 8Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            inputs:
+              - type: tablet
+                bus: virtio
+                name: tablet
+            disks:
+            - disk:
+                bus: virtio
+              name: ${NAME}
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: cloud-user
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'rhel9-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'rhel9'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user cloud-user
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/rhel9-desktop-medium.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: rhel9-desktop-medium
+  annotations:
+    openshift.io/display-name: "Red Hat Enterprise Linux 9.0 VM"
+    description: >-
+      Template for Red Hat Enterprise Linux 9 VM or newer.
+      A PVC with the RHEL disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,linux,rhel"
+    iconClass: "icon-rhel"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/rhel9.0: Red Hat Enterprise Linux 9.0 or higher
+  labels:
+    os.template.kubevirt.io/rhel9.0: "true"
+    workload.template.kubevirt.io/desktop: "true"
+    flavor.template.kubevirt.io/medium: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: rhel9-desktop-medium
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 1610612736
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "rhel9"
+          vm.kubevirt.io/workload: "desktop"
+          vm.kubevirt.io/flavor: "medium"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: medium
+      spec:
+        domain:
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 4Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            inputs:
+              - type: tablet
+                bus: virtio
+                name: tablet
+            disks:
+            - disk:
+                bus: virtio
+              name: ${NAME}
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: cloud-user
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'rhel9-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'rhel9'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user cloud-user
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/rhel9-desktop-small.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: rhel9-desktop-small
+  annotations:
+    openshift.io/display-name: "Red Hat Enterprise Linux 9.0 VM"
+    description: >-
+      Template for Red Hat Enterprise Linux 9 VM or newer.
+      A PVC with the RHEL disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,linux,rhel"
+    iconClass: "icon-rhel"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/rhel9.0: Red Hat Enterprise Linux 9.0 or higher
+  labels:
+    os.template.kubevirt.io/rhel9.0: "true"
+    workload.template.kubevirt.io/desktop: "true"
+    flavor.template.kubevirt.io/small: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: rhel9-desktop-small
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 1610612736
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "rhel9"
+          vm.kubevirt.io/workload: "desktop"
+          vm.kubevirt.io/flavor: "small"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: small
+      spec:
+        domain:
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 2Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            inputs:
+              - type: tablet
+                bus: virtio
+                name: tablet
+            disks:
+            - disk:
+                bus: virtio
+              name: ${NAME}
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: cloud-user
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'rhel9-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'rhel9'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user cloud-user
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/rhel9-desktop-tiny.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: rhel9-desktop-tiny
+  annotations:
+    openshift.io/display-name: "Red Hat Enterprise Linux 9.0 VM"
+    description: >-
+      Template for Red Hat Enterprise Linux 9 VM or newer.
+      A PVC with the RHEL disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,linux,rhel"
+    iconClass: "icon-rhel"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/rhel9.0: Red Hat Enterprise Linux 9.0 or higher
+  labels:
+    os.template.kubevirt.io/rhel9.0: "true"
+    workload.template.kubevirt.io/desktop: "true"
+    flavor.template.kubevirt.io/tiny: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: rhel9-desktop-tiny
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 1610612736
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "rhel9"
+          vm.kubevirt.io/workload: "desktop"
+          vm.kubevirt.io/flavor: "tiny"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: tiny
+      spec:
+        domain:
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 1.5Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            inputs:
+              - type: tablet
+                bus: virtio
+                name: tablet
+            disks:
+            - disk:
+                bus: virtio
+              name: ${NAME}
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: cloud-user
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'rhel9-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'rhel9'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user cloud-user
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/rhel9-highperformance-large.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: rhel9-highperformance-large
+  annotations:
+    openshift.io/display-name: "Red Hat Enterprise Linux 9.0 VM"
+    description: >-
+      Template for Red Hat Enterprise Linux 9 VM or newer.
+      A PVC with the RHEL disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,linux,rhel"
+    iconClass: "icon-rhel"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/rhel9.0: Red Hat Enterprise Linux 9.0 or higher
+  labels:
+    os.template.kubevirt.io/rhel9.0: "true"
+    workload.template.kubevirt.io/highperformance: "true"
+    flavor.template.kubevirt.io/large: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: rhel9-highperformance-large
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 1610612736
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "rhel9"
+          vm.kubevirt.io/workload: "highperformance"
+          vm.kubevirt.io/flavor: "large"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: large
+      spec:
+        domain:
+          ioThreadsPolicy: shared
+          cpu:
+            sockets: 2
+            cores: 1
+            threads: 1
+            dedicatedCpuPlacement: True
+            isolateEmulatorThread: True
+          resources:
+            requests:
+              memory: 8Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            disks:
+            - disk:
+                bus: virtio
+              name: ${NAME}
+              dedicatedIOThread: true
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: cloud-user
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'rhel9-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'rhel9'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user cloud-user
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/rhel9-highperformance-medium.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: rhel9-highperformance-medium
+  annotations:
+    openshift.io/display-name: "Red Hat Enterprise Linux 9.0 VM"
+    description: >-
+      Template for Red Hat Enterprise Linux 9 VM or newer.
+      A PVC with the RHEL disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,linux,rhel"
+    iconClass: "icon-rhel"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/rhel9.0: Red Hat Enterprise Linux 9.0 or higher
+  labels:
+    os.template.kubevirt.io/rhel9.0: "true"
+    workload.template.kubevirt.io/highperformance: "true"
+    flavor.template.kubevirt.io/medium: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: rhel9-highperformance-medium
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 1610612736
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "rhel9"
+          vm.kubevirt.io/workload: "highperformance"
+          vm.kubevirt.io/flavor: "medium"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: medium
+      spec:
+        domain:
+          ioThreadsPolicy: shared
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+            dedicatedCpuPlacement: True
+            isolateEmulatorThread: True
+          resources:
+            requests:
+              memory: 4Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            disks:
+            - disk:
+                bus: virtio
+              name: ${NAME}
+              dedicatedIOThread: true
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: cloud-user
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'rhel9-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'rhel9'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user cloud-user
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/rhel9-highperformance-small.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: rhel9-highperformance-small
+  annotations:
+    openshift.io/display-name: "Red Hat Enterprise Linux 9.0 VM"
+    description: >-
+      Template for Red Hat Enterprise Linux 9 VM or newer.
+      A PVC with the RHEL disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,linux,rhel"
+    iconClass: "icon-rhel"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/rhel9.0: Red Hat Enterprise Linux 9.0 or higher
+  labels:
+    os.template.kubevirt.io/rhel9.0: "true"
+    workload.template.kubevirt.io/highperformance: "true"
+    flavor.template.kubevirt.io/small: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: rhel9-highperformance-small
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 1610612736
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "rhel9"
+          vm.kubevirt.io/workload: "highperformance"
+          vm.kubevirt.io/flavor: "small"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: small
+      spec:
+        domain:
+          ioThreadsPolicy: shared
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+            dedicatedCpuPlacement: True
+            isolateEmulatorThread: True
+          resources:
+            requests:
+              memory: 2Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            disks:
+            - disk:
+                bus: virtio
+              name: ${NAME}
+              dedicatedIOThread: true
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: cloud-user
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'rhel9-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'rhel9'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user cloud-user
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/rhel9-highperformance-tiny.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: rhel9-highperformance-tiny
+  annotations:
+    openshift.io/display-name: "Red Hat Enterprise Linux 9.0 VM"
+    description: >-
+      Template for Red Hat Enterprise Linux 9 VM or newer.
+      A PVC with the RHEL disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,linux,rhel"
+    iconClass: "icon-rhel"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/rhel9.0: Red Hat Enterprise Linux 9.0 or higher
+  labels:
+    os.template.kubevirt.io/rhel9.0: "true"
+    workload.template.kubevirt.io/highperformance: "true"
+    flavor.template.kubevirt.io/tiny: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: rhel9-highperformance-tiny
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 1610612736
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "rhel9"
+          vm.kubevirt.io/workload: "highperformance"
+          vm.kubevirt.io/flavor: "tiny"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: tiny
+      spec:
+        domain:
+          ioThreadsPolicy: shared
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+            dedicatedCpuPlacement: True
+            isolateEmulatorThread: True
+          resources:
+            requests:
+              memory: 1.5Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            disks:
+            - disk:
+                bus: virtio
+              name: ${NAME}
+              dedicatedIOThread: true
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: cloud-user
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'rhel9-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'rhel9'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user cloud-user
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/rhel9-server-large.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: rhel9-server-large
+  annotations:
+    openshift.io/display-name: "Red Hat Enterprise Linux 9.0 VM"
+    description: >-
+      Template for Red Hat Enterprise Linux 9 VM or newer.
+      A PVC with the RHEL disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,linux,rhel"
+    iconClass: "icon-rhel"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/rhel9.0: Red Hat Enterprise Linux 9.0 or higher
+  labels:
+    os.template.kubevirt.io/rhel9.0: "true"
+    workload.template.kubevirt.io/server: "true"
+    flavor.template.kubevirt.io/large: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: rhel9-server-large
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 1610612736
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "rhel9"
+          vm.kubevirt.io/workload: "server"
+          vm.kubevirt.io/flavor: "large"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: large
+      spec:
+        domain:
+          cpu:
+            sockets: 2
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 8Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            disks:
+            - disk:
+                bus: virtio
+              name: ${NAME}
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: cloud-user
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'rhel9-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'rhel9'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user cloud-user
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/rhel9-server-medium.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: rhel9-server-medium
+  annotations:
+    openshift.io/display-name: "Red Hat Enterprise Linux 9.0 VM"
+    description: >-
+      Template for Red Hat Enterprise Linux 9 VM or newer.
+      A PVC with the RHEL disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,linux,rhel"
+    iconClass: "icon-rhel"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/rhel9.0: Red Hat Enterprise Linux 9.0 or higher
+  labels:
+    os.template.kubevirt.io/rhel9.0: "true"
+    workload.template.kubevirt.io/server: "true"
+    flavor.template.kubevirt.io/medium: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: rhel9-server-medium
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 1610612736
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "rhel9"
+          vm.kubevirt.io/workload: "server"
+          vm.kubevirt.io/flavor: "medium"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: medium
+      spec:
+        domain:
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 4Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            disks:
+            - disk:
+                bus: virtio
+              name: ${NAME}
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: cloud-user
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'rhel9-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'rhel9'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user cloud-user
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/rhel9-server-small.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: rhel9-server-small
+  annotations:
+    openshift.io/display-name: "Red Hat Enterprise Linux 9.0 VM"
+    description: >-
+      Template for Red Hat Enterprise Linux 9 VM or newer.
+      A PVC with the RHEL disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,linux,rhel"
+    iconClass: "icon-rhel"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/rhel9.0: Red Hat Enterprise Linux 9.0 or higher
+  labels:
+    os.template.kubevirt.io/rhel9.0: "true"
+    workload.template.kubevirt.io/server: "true"
+    flavor.template.kubevirt.io/small: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+    template.kubevirt.io/default-os-variant: "true"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: rhel9-server-small
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 1610612736
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "rhel9"
+          vm.kubevirt.io/workload: "server"
+          vm.kubevirt.io/flavor: "small"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: small
+      spec:
+        domain:
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 2Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            disks:
+            - disk:
+                bus: virtio
+              name: ${NAME}
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: cloud-user
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'rhel9-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'rhel9'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user cloud-user
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/rhel9-server-tiny.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: rhel9-server-tiny
+  annotations:
+    openshift.io/display-name: "Red Hat Enterprise Linux 9.0 VM"
+    description: >-
+      Template for Red Hat Enterprise Linux 9 VM or newer.
+      A PVC with the RHEL disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,linux,rhel"
+    iconClass: "icon-rhel"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/rhel9.0: Red Hat Enterprise Linux 9.0 or higher
+  labels:
+    os.template.kubevirt.io/rhel9.0: "true"
+    workload.template.kubevirt.io/server: "true"
+    flavor.template.kubevirt.io/tiny: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: rhel9-server-tiny
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 1610612736
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "rhel9"
+          vm.kubevirt.io/workload: "server"
+          vm.kubevirt.io/flavor: "tiny"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: tiny
+      spec:
+        domain:
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 1.5Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            disks:
+            - disk:
+                bus: virtio
+              name: ${NAME}
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: cloud-user
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'rhel9-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'rhel9'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user cloud-user
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/ubuntu-desktop-large.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: ubuntu-desktop-large
+  annotations:
+    openshift.io/display-name: Ubuntu 20.04 LTS (Focal Fossa) VM"
+    description: >-
+      Template for Ubuntu 20.04 LTS (Focal Fossa) VM.
+      A PVC with the Ubuntu disk image must be available.
+      Recommended disk image:
+      http://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img
+    tags: "hidden,kubevirt,virtualmachine,ubuntu"
+    iconClass: "icon-ubuntu"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/ubuntu20.04: Ubuntu 20.04 LTS or higher
+  labels:
+    os.template.kubevirt.io/ubuntu20.04: "true"
+    workload.template.kubevirt.io/desktop: "true"
+    flavor.template.kubevirt.io/large: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: ubuntu-desktop-large
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 2147483648
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "ubuntu"
+          vm.kubevirt.io/workload: "desktop"
+          vm.kubevirt.io/flavor: "large"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: large
+      spec:
+        domain:
+          cpu:
+            sockets: 2
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 8Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            inputs:
+              - type: tablet
+                bus: virtio
+                name: tablet
+            disks:
+            - disk:
+                bus: virtio
+              name: ${NAME}
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: ubuntu
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'ubuntu-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'ubuntu'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user ubuntu
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/ubuntu-desktop-medium.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: ubuntu-desktop-medium
+  annotations:
+    openshift.io/display-name: Ubuntu 20.04 LTS (Focal Fossa) VM"
+    description: >-
+      Template for Ubuntu 20.04 LTS (Focal Fossa) VM.
+      A PVC with the Ubuntu disk image must be available.
+      Recommended disk image:
+      http://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img
+    tags: "hidden,kubevirt,virtualmachine,ubuntu"
+    iconClass: "icon-ubuntu"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/ubuntu20.04: Ubuntu 20.04 LTS or higher
+  labels:
+    os.template.kubevirt.io/ubuntu20.04: "true"
+    workload.template.kubevirt.io/desktop: "true"
+    flavor.template.kubevirt.io/medium: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: ubuntu-desktop-medium
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 2147483648
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "ubuntu"
+          vm.kubevirt.io/workload: "desktop"
+          vm.kubevirt.io/flavor: "medium"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: medium
+      spec:
+        domain:
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 4Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            inputs:
+              - type: tablet
+                bus: virtio
+                name: tablet
+            disks:
+            - disk:
+                bus: virtio
+              name: ${NAME}
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: ubuntu
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'ubuntu-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'ubuntu'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user ubuntu
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/ubuntu-desktop-small.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: ubuntu-desktop-small
+  annotations:
+    openshift.io/display-name: Ubuntu 20.04 LTS (Focal Fossa) VM"
+    description: >-
+      Template for Ubuntu 20.04 LTS (Focal Fossa) VM.
+      A PVC with the Ubuntu disk image must be available.
+      Recommended disk image:
+      http://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img
+    tags: "hidden,kubevirt,virtualmachine,ubuntu"
+    iconClass: "icon-ubuntu"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/ubuntu20.04: Ubuntu 20.04 LTS or higher
+  labels:
+    os.template.kubevirt.io/ubuntu20.04: "true"
+    workload.template.kubevirt.io/desktop: "true"
+    flavor.template.kubevirt.io/small: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+    template.kubevirt.io/default-os-variant: "true"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: ubuntu-desktop-small
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 2147483648
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "ubuntu"
+          vm.kubevirt.io/workload: "desktop"
+          vm.kubevirt.io/flavor: "small"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: small
+      spec:
+        domain:
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 2Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            inputs:
+              - type: tablet
+                bus: virtio
+                name: tablet
+            disks:
+            - disk:
+                bus: virtio
+              name: ${NAME}
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: ubuntu
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'ubuntu-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'ubuntu'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user ubuntu
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/ubuntu-desktop-tiny.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: ubuntu-desktop-tiny
+  annotations:
+    openshift.io/display-name: Ubuntu 20.04 LTS (Focal Fossa) VM"
+    description: >-
+      Template for Ubuntu 20.04 LTS (Focal Fossa) VM.
+      A PVC with the Ubuntu disk image must be available.
+      Recommended disk image:
+      http://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img
+    tags: "hidden,kubevirt,virtualmachine,ubuntu"
+    iconClass: "icon-ubuntu"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/ubuntu20.04: Ubuntu 20.04 LTS or higher
+  labels:
+    os.template.kubevirt.io/ubuntu20.04: "true"
+    workload.template.kubevirt.io/desktop: "true"
+    flavor.template.kubevirt.io/tiny: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: ubuntu-desktop-tiny
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 2147483648
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "ubuntu"
+          vm.kubevirt.io/workload: "desktop"
+          vm.kubevirt.io/flavor: "tiny"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: tiny
+      spec:
+        domain:
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 2Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            inputs:
+              - type: tablet
+                bus: virtio
+                name: tablet
+            disks:
+            - disk:
+                bus: virtio
+              name: ${NAME}
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: ubuntu
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'ubuntu-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'ubuntu'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user ubuntu
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/windows10-desktop-large.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: windows10-desktop-large
+  annotations:
+    openshift.io/display-name: "Microsoft Windows 10 VM"
+    description: >-
+      Template for Microsoft Windows 10 VM.
+      A PVC with the Windows disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,windows"
+    iconClass: "icon-windows"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    defaults.template.kubevirt.io/network: default
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/win10: Microsoft Windows 10
+  labels:
+    os.template.kubevirt.io/win10: "true"
+    workload.template.kubevirt.io/desktop: "true"
+    flavor.template.kubevirt.io/large: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: windows10-desktop-large
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 2147483648
+          }, {
+            "name": "windows-virtio-bus",
+            "path": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+            "valid": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+            "rule": "enum",
+            "message": "virto disk bus type has better performance, install virtio drivers in VM and change bus type",
+            "values": ["virtio"],
+            "justWarning": true
+          }, {
+            "name": "windows-disk-bus",
+            "path": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+            "valid": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+            "rule": "enum",
+            "message": "disk bus has to be either virtio or sata or scsi",
+            "values": ["virtio", "sata", "scsi"]
+          }, {
+            "name": "windows-cd-bus",
+            "path": "jsonpath::.spec.domain.devices.disks[*].cdrom.bus",
+            "valid": "jsonpath::.spec.domain.devices.disks[*].cdrom.bus",
+            "rule": "enum",
+            "message": "cd bus has to be sata",
+            "values": ["sata"]
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+      - apiVersion: cdi.kubevirt.io/v1beta1
+        kind: DataVolume
+        metadata:
+          name: ${NAME}
+        spec:
+          pvc:
+            accessModes:
+              - ReadWriteMany
+            resources:
+              requests:
+                storage: 60Gi
+          source:
+            pvc:
+              name: ${SRC_PVC_NAME}
+              namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "windows10"
+          vm.kubevirt.io/workload: "desktop"
+          vm.kubevirt.io/flavor: "large"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: large
+      spec:
+        domain:
+          clock:
+            utc: {}
+            timer:
+              hpet:
+                present: false
+              pit:
+                tickPolicy: delay
+              rtc:
+                tickPolicy: catchup
+              hyperv: {}
+          cpu:
+            sockets: 2
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 8Gi
+          features:
+            acpi: {}
+            apic: {}
+            hyperv:
+              relaxed: {}
+              vapic: {}
+              vpindex: {}
+              spinlocks:
+                spinlocks: 8191
+              synic: {}
+              synictimer:
+                direct: {}
+              tlbflush: {}
+              frequencies: {}
+              reenlightenment: {}
+              ipi: {}
+              runtime: {}
+              reset: {}
+          devices:
+            disks:
+            - disk:
+                bus: sata
+              name: ${NAME}
+            interfaces:
+            - masquerade: {}
+              model: e1000e
+              name: default
+            inputs:
+              - type: tablet
+                bus: usb
+                name: tablet
+        terminationGracePeriodSeconds: 3600
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        networks:
+        - name: default
+          pod: {}
+parameters:
+- name: NAME
+  description: VM name
+  generate: expression
+  from: "windows-[a-z0-9]{6}"
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: win10
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+---
+# Source: dist/templates/windows10-desktop-medium.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: windows10-desktop-medium
+  annotations:
+    openshift.io/display-name: "Microsoft Windows 10 VM"
+    description: >-
+      Template for Microsoft Windows 10 VM.
+      A PVC with the Windows disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,windows"
+    iconClass: "icon-windows"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    defaults.template.kubevirt.io/network: default
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/win10: Microsoft Windows 10
+  labels:
+    os.template.kubevirt.io/win10: "true"
+    workload.template.kubevirt.io/desktop: "true"
+    flavor.template.kubevirt.io/medium: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+    template.kubevirt.io/default-os-variant: "true"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: windows10-desktop-medium
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 2147483648
+          }, {
+            "name": "windows-virtio-bus",
+            "path": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+            "valid": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+            "rule": "enum",
+            "message": "virto disk bus type has better performance, install virtio drivers in VM and change bus type",
+            "values": ["virtio"],
+            "justWarning": true
+          }, {
+            "name": "windows-disk-bus",
+            "path": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+            "valid": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+            "rule": "enum",
+            "message": "disk bus has to be either virtio or sata or scsi",
+            "values": ["virtio", "sata", "scsi"]
+          }, {
+            "name": "windows-cd-bus",
+            "path": "jsonpath::.spec.domain.devices.disks[*].cdrom.bus",
+            "valid": "jsonpath::.spec.domain.devices.disks[*].cdrom.bus",
+            "rule": "enum",
+            "message": "cd bus has to be sata",
+            "values": ["sata"]
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+      - apiVersion: cdi.kubevirt.io/v1beta1
+        kind: DataVolume
+        metadata:
+          name: ${NAME}
+        spec:
+          pvc:
+            accessModes:
+              - ReadWriteMany
+            resources:
+              requests:
+                storage: 60Gi
+          source:
+            pvc:
+              name: ${SRC_PVC_NAME}
+              namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "windows10"
+          vm.kubevirt.io/workload: "desktop"
+          vm.kubevirt.io/flavor: "medium"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: medium
+      spec:
+        domain:
+          clock:
+            utc: {}
+            timer:
+              hpet:
+                present: false
+              pit:
+                tickPolicy: delay
+              rtc:
+                tickPolicy: catchup
+              hyperv: {}
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 4Gi
+          features:
+            acpi: {}
+            apic: {}
+            hyperv:
+              relaxed: {}
+              vapic: {}
+              vpindex: {}
+              spinlocks:
+                spinlocks: 8191
+              synic: {}
+              synictimer:
+                direct: {}
+              tlbflush: {}
+              frequencies: {}
+              reenlightenment: {}
+              ipi: {}
+              runtime: {}
+              reset: {}
+          devices:
+            disks:
+            - disk:
+                bus: sata
+              name: ${NAME}
+            interfaces:
+            - masquerade: {}
+              model: e1000e
+              name: default
+            inputs:
+              - type: tablet
+                bus: usb
+                name: tablet
+        terminationGracePeriodSeconds: 3600
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        networks:
+        - name: default
+          pod: {}
+parameters:
+- name: NAME
+  description: VM name
+  generate: expression
+  from: "windows-[a-z0-9]{6}"
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: win10
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+---
+# Source: dist/templates/windows10-highperformance-large.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: windows10-highperformance-large
+  annotations:
+    openshift.io/display-name: "Microsoft Windows 10 VM"
+    description: >-
+      Template for Microsoft Windows 10 VM.
+      A PVC with the Windows disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,windows"
+    iconClass: "icon-windows"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    defaults.template.kubevirt.io/network: default
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/win10: Microsoft Windows 10
+  labels:
+    os.template.kubevirt.io/win10: "true"
+    workload.template.kubevirt.io/highperformance: "true"
+    flavor.template.kubevirt.io/large: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: windows10-highperformance-large
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 2147483648
+          }, {
+            "name": "windows-virtio-bus",
+            "path": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+            "valid": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+            "rule": "enum",
+            "message": "virto disk bus type has better performance, install virtio drivers in VM and change bus type",
+            "values": ["virtio"],
+            "justWarning": true
+          }, {
+            "name": "windows-disk-bus",
+            "path": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+            "valid": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+            "rule": "enum",
+            "message": "disk bus has to be either virtio or sata or scsi",
+            "values": ["virtio", "sata", "scsi"]
+          }, {
+            "name": "windows-cd-bus",
+            "path": "jsonpath::.spec.domain.devices.disks[*].cdrom.bus",
+            "valid": "jsonpath::.spec.domain.devices.disks[*].cdrom.bus",
+            "rule": "enum",
+            "message": "cd bus has to be sata",
+            "values": ["sata"]
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+      - apiVersion: cdi.kubevirt.io/v1beta1
+        kind: DataVolume
+        metadata:
+          name: ${NAME}
+        spec:
+          pvc:
+            accessModes:
+              - ReadWriteMany
+            resources:
+              requests:
+                storage: 60Gi
+          source:
+            pvc:
+              name: ${SRC_PVC_NAME}
+              namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "windows10"
+          vm.kubevirt.io/workload: "highperformance"
+          vm.kubevirt.io/flavor: "large"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: large
+      spec:
+        domain:
+          clock:
+            utc: {}
+            timer:
+              hpet:
+                present: false
+              pit:
+                tickPolicy: delay
+              rtc:
+                tickPolicy: catchup
+              hyperv: {}
+          cpu:
+            sockets: 2
+            cores: 1
+            threads: 1
+            dedicatedCpuPlacement: True
+            isolateEmulatorThread: True
+          resources:
+            requests:
+              memory: 8Gi
+          features:
+            acpi: {}
+            apic: {}
+            hyperv:
+              relaxed: {}
+              vapic: {}
+              vpindex: {}
+              spinlocks:
+                spinlocks: 8191
+              synic: {}
+              synictimer:
+                direct: {}
+              tlbflush: {}
+              frequencies: {}
+              reenlightenment: {}
+              ipi: {}
+              runtime: {}
+              reset: {}
+          devices:
+            networkInterfaceMultiqueue: True
+            disks:
+            - disk:
+                bus: sata
+              name: ${NAME}
+            interfaces:
+            - masquerade: {}
+              model: virtio
+              name: default
+            inputs:
+              - type: tablet
+                bus: usb
+                name: tablet
+        terminationGracePeriodSeconds: 3600
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        networks:
+        - name: default
+          pod: {}
+parameters:
+- name: NAME
+  description: VM name
+  generate: expression
+  from: "windows-[a-z0-9]{6}"
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: win10
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+---
+# Source: dist/templates/windows10-highperformance-medium.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: windows10-highperformance-medium
+  annotations:
+    openshift.io/display-name: "Microsoft Windows 10 VM"
+    description: >-
+      Template for Microsoft Windows 10 VM.
+      A PVC with the Windows disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,windows"
+    iconClass: "icon-windows"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    defaults.template.kubevirt.io/network: default
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/win10: Microsoft Windows 10
+  labels:
+    os.template.kubevirt.io/win10: "true"
+    workload.template.kubevirt.io/highperformance: "true"
+    flavor.template.kubevirt.io/medium: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: windows10-highperformance-medium
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 2147483648
+          }, {
+            "name": "windows-virtio-bus",
+            "path": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+            "valid": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+            "rule": "enum",
+            "message": "virto disk bus type has better performance, install virtio drivers in VM and change bus type",
+            "values": ["virtio"],
+            "justWarning": true
+          }, {
+            "name": "windows-disk-bus",
+            "path": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+            "valid": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+            "rule": "enum",
+            "message": "disk bus has to be either virtio or sata or scsi",
+            "values": ["virtio", "sata", "scsi"]
+          }, {
+            "name": "windows-cd-bus",
+            "path": "jsonpath::.spec.domain.devices.disks[*].cdrom.bus",
+            "valid": "jsonpath::.spec.domain.devices.disks[*].cdrom.bus",
+            "rule": "enum",
+            "message": "cd bus has to be sata",
+            "values": ["sata"]
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+      - apiVersion: cdi.kubevirt.io/v1beta1
+        kind: DataVolume
+        metadata:
+          name: ${NAME}
+        spec:
+          pvc:
+            accessModes:
+              - ReadWriteMany
+            resources:
+              requests:
+                storage: 60Gi
+          source:
+            pvc:
+              name: ${SRC_PVC_NAME}
+              namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "windows10"
+          vm.kubevirt.io/workload: "highperformance"
+          vm.kubevirt.io/flavor: "medium"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: medium
+      spec:
+        domain:
+          clock:
+            utc: {}
+            timer:
+              hpet:
+                present: false
+              pit:
+                tickPolicy: delay
+              rtc:
+                tickPolicy: catchup
+              hyperv: {}
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+            dedicatedCpuPlacement: True
+            isolateEmulatorThread: True
+          resources:
+            requests:
+              memory: 4Gi
+          features:
+            acpi: {}
+            apic: {}
+            hyperv:
+              relaxed: {}
+              vapic: {}
+              vpindex: {}
+              spinlocks:
+                spinlocks: 8191
+              synic: {}
+              synictimer:
+                direct: {}
+              tlbflush: {}
+              frequencies: {}
+              reenlightenment: {}
+              ipi: {}
+              runtime: {}
+              reset: {}
+          devices:
+            networkInterfaceMultiqueue: True
+            disks:
+            - disk:
+                bus: sata
+              name: ${NAME}
+            interfaces:
+            - masquerade: {}
+              model: virtio
+              name: default
+            inputs:
+              - type: tablet
+                bus: usb
+                name: tablet
+        terminationGracePeriodSeconds: 3600
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        networks:
+        - name: default
+          pod: {}
+parameters:
+- name: NAME
+  description: VM name
+  generate: expression
+  from: "windows-[a-z0-9]{6}"
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: win10
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+---
+# Source: dist/templates/windows2k12r2-highperformance-large.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: windows2k12r2-highperformance-large
+  annotations:
+    openshift.io/display-name: "Microsoft Windows Server 2012 R2 VM"
+    description: >-
+      Template for Microsoft Windows Server 2012 R2 VM.
+      A PVC with the Windows disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,windows"
+    iconClass: "icon-windows"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    defaults.template.kubevirt.io/network: default
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/win2k12r2: Microsoft Windows Server 2012 R2
+  labels:
+    os.template.kubevirt.io/win2k12r2: "true"
+    workload.template.kubevirt.io/highperformance: "true"
+    flavor.template.kubevirt.io/large: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: windows2k12r2-highperformance-large
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 536870912
+          }, {
+            "name": "windows-virtio-bus",
+            "path": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+            "valid": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+            "rule": "enum",
+            "message": "virto disk bus type has better performance, install virtio drivers in VM and change bus type",
+            "values": ["virtio"],
+            "justWarning": true
+          }, {
+            "name": "windows-disk-bus",
+            "path": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+            "valid": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+            "rule": "enum",
+            "message": "disk bus has to be either virtio or sata or scsi",
+            "values": ["virtio", "sata", "scsi"]
+          }, {
+            "name": "windows-cd-bus",
+            "path": "jsonpath::.spec.domain.devices.disks[*].cdrom.bus",
+            "valid": "jsonpath::.spec.domain.devices.disks[*].cdrom.bus",
+            "rule": "enum",
+            "message": "cd bus has to be sata",
+            "values": ["sata"]
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+      - apiVersion: cdi.kubevirt.io/v1beta1
+        kind: DataVolume
+        metadata:
+          name: ${NAME}
+        spec:
+          pvc:
+            accessModes:
+              - ReadWriteMany
+            resources:
+              requests:
+                storage: 60Gi
+          source:
+            pvc:
+              name: ${SRC_PVC_NAME}
+              namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "windows2k12r2"
+          vm.kubevirt.io/workload: "highperformance"
+          vm.kubevirt.io/flavor: "large"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: large
+      spec:
+        domain:
+          clock:
+            utc: {}
+            timer:
+              hpet:
+                present: false
+              pit:
+                tickPolicy: delay
+              rtc:
+                tickPolicy: catchup
+              hyperv: {}
+          cpu:
+            sockets: 2
+            cores: 1
+            threads: 1
+            dedicatedCpuPlacement: True
+            isolateEmulatorThread: True
+          resources:
+            requests:
+              memory: 8Gi
+          features:
+            acpi: {}
+            apic: {}
+            hyperv:
+              relaxed: {}
+              vapic: {}
+              vpindex: {}
+              spinlocks:
+                spinlocks: 8191
+              synic: {}
+              synictimer:
+                direct: {}
+              tlbflush: {}
+              frequencies: {}
+              reenlightenment: {}
+              ipi: {}
+              runtime: {}
+              reset: {}
+          devices:
+            networkInterfaceMultiqueue: True
+            disks:
+            - disk:
+                bus: sata
+              name: ${NAME}
+            interfaces:
+            - masquerade: {}
+              model: virtio
+              name: default
+            inputs:
+              - type: tablet
+                bus: usb
+                name: tablet
+        terminationGracePeriodSeconds: 3600
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        networks:
+        - name: default
+          pod: {}
+parameters:
+- name: NAME
+  description: VM name
+  generate: expression
+  from: "windows-[a-z0-9]{6}"
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: win2k12r2
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+---
+# Source: dist/templates/windows2k12r2-highperformance-medium.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: windows2k12r2-highperformance-medium
+  annotations:
+    openshift.io/display-name: "Microsoft Windows Server 2012 R2 VM"
+    description: >-
+      Template for Microsoft Windows Server 2012 R2 VM.
+      A PVC with the Windows disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,windows"
+    iconClass: "icon-windows"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    defaults.template.kubevirt.io/network: default
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/win2k12r2: Microsoft Windows Server 2012 R2
+  labels:
+    os.template.kubevirt.io/win2k12r2: "true"
+    workload.template.kubevirt.io/highperformance: "true"
+    flavor.template.kubevirt.io/medium: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: windows2k12r2-highperformance-medium
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 536870912
+          }, {
+            "name": "windows-virtio-bus",
+            "path": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+            "valid": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+            "rule": "enum",
+            "message": "virto disk bus type has better performance, install virtio drivers in VM and change bus type",
+            "values": ["virtio"],
+            "justWarning": true
+          }, {
+            "name": "windows-disk-bus",
+            "path": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+            "valid": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+            "rule": "enum",
+            "message": "disk bus has to be either virtio or sata or scsi",
+            "values": ["virtio", "sata", "scsi"]
+          }, {
+            "name": "windows-cd-bus",
+            "path": "jsonpath::.spec.domain.devices.disks[*].cdrom.bus",
+            "valid": "jsonpath::.spec.domain.devices.disks[*].cdrom.bus",
+            "rule": "enum",
+            "message": "cd bus has to be sata",
+            "values": ["sata"]
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+      - apiVersion: cdi.kubevirt.io/v1beta1
+        kind: DataVolume
+        metadata:
+          name: ${NAME}
+        spec:
+          pvc:
+            accessModes:
+              - ReadWriteMany
+            resources:
+              requests:
+                storage: 60Gi
+          source:
+            pvc:
+              name: ${SRC_PVC_NAME}
+              namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "windows2k12r2"
+          vm.kubevirt.io/workload: "highperformance"
+          vm.kubevirt.io/flavor: "medium"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: medium
+      spec:
+        domain:
+          clock:
+            utc: {}
+            timer:
+              hpet:
+                present: false
+              pit:
+                tickPolicy: delay
+              rtc:
+                tickPolicy: catchup
+              hyperv: {}
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+            dedicatedCpuPlacement: True
+            isolateEmulatorThread: True
+          resources:
+            requests:
+              memory: 4Gi
+          features:
+            acpi: {}
+            apic: {}
+            hyperv:
+              relaxed: {}
+              vapic: {}
+              vpindex: {}
+              spinlocks:
+                spinlocks: 8191
+              synic: {}
+              synictimer:
+                direct: {}
+              tlbflush: {}
+              frequencies: {}
+              reenlightenment: {}
+              ipi: {}
+              runtime: {}
+              reset: {}
+          devices:
+            networkInterfaceMultiqueue: True
+            disks:
+            - disk:
+                bus: sata
+              name: ${NAME}
+            interfaces:
+            - masquerade: {}
+              model: virtio
+              name: default
+            inputs:
+              - type: tablet
+                bus: usb
+                name: tablet
+        terminationGracePeriodSeconds: 3600
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        networks:
+        - name: default
+          pod: {}
+parameters:
+- name: NAME
+  description: VM name
+  generate: expression
+  from: "windows-[a-z0-9]{6}"
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: win2k12r2
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+---
+# Source: dist/templates/windows2k12r2-server-large.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: windows2k12r2-server-large
+  annotations:
+    openshift.io/display-name: "Microsoft Windows Server 2012 R2 VM"
+    description: >-
+      Template for Microsoft Windows Server 2012 R2 VM.
+      A PVC with the Windows disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,windows"
+    iconClass: "icon-windows"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    defaults.template.kubevirt.io/network: default
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/win2k12r2: Microsoft Windows Server 2012 R2
+  labels:
+    os.template.kubevirt.io/win2k12r2: "true"
+    workload.template.kubevirt.io/server: "true"
+    flavor.template.kubevirt.io/large: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: windows2k12r2-server-large
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 536870912
+          }, {
+            "name": "windows-virtio-bus",
+            "path": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+            "valid": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+            "rule": "enum",
+            "message": "virto disk bus type has better performance, install virtio drivers in VM and change bus type",
+            "values": ["virtio"],
+            "justWarning": true
+          }, {
+            "name": "windows-disk-bus",
+            "path": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+            "valid": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+            "rule": "enum",
+            "message": "disk bus has to be either virtio or sata or scsi",
+            "values": ["virtio", "sata", "scsi"]
+          }, {
+            "name": "windows-cd-bus",
+            "path": "jsonpath::.spec.domain.devices.disks[*].cdrom.bus",
+            "valid": "jsonpath::.spec.domain.devices.disks[*].cdrom.bus",
+            "rule": "enum",
+            "message": "cd bus has to be sata",
+            "values": ["sata"]
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+      - apiVersion: cdi.kubevirt.io/v1beta1
+        kind: DataVolume
+        metadata:
+          name: ${NAME}
+        spec:
+          pvc:
+            accessModes:
+              - ReadWriteMany
+            resources:
+              requests:
+                storage: 60Gi
+          source:
+            pvc:
+              name: ${SRC_PVC_NAME}
+              namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "windows2k12r2"
+          vm.kubevirt.io/workload: "server"
+          vm.kubevirt.io/flavor: "large"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: large
+      spec:
+        domain:
+          clock:
+            utc: {}
+            timer:
+              hpet:
+                present: false
+              pit:
+                tickPolicy: delay
+              rtc:
+                tickPolicy: catchup
+              hyperv: {}
+          cpu:
+            sockets: 2
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 8Gi
+          features:
+            acpi: {}
+            apic: {}
+            hyperv:
+              relaxed: {}
+              vapic: {}
+              vpindex: {}
+              spinlocks:
+                spinlocks: 8191
+              synic: {}
+              synictimer:
+                direct: {}
+              tlbflush: {}
+              frequencies: {}
+              reenlightenment: {}
+              ipi: {}
+              runtime: {}
+              reset: {}
+          devices:
+            disks:
+            - disk:
+                bus: sata
+              name: ${NAME}
+            interfaces:
+            - masquerade: {}
+              model: e1000e
+              name: default
+            inputs:
+              - type: tablet
+                bus: usb
+                name: tablet
+        terminationGracePeriodSeconds: 3600
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        networks:
+        - name: default
+          pod: {}
+parameters:
+- name: NAME
+  description: VM name
+  generate: expression
+  from: "windows-[a-z0-9]{6}"
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: win2k12r2
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+---
+# Source: dist/templates/windows2k12r2-server-medium.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: windows2k12r2-server-medium
+  annotations:
+    openshift.io/display-name: "Microsoft Windows Server 2012 R2 VM"
+    description: >-
+      Template for Microsoft Windows Server 2012 R2 VM.
+      A PVC with the Windows disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,windows"
+    iconClass: "icon-windows"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    defaults.template.kubevirt.io/network: default
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/win2k12r2: Microsoft Windows Server 2012 R2
+  labels:
+    os.template.kubevirt.io/win2k12r2: "true"
+    workload.template.kubevirt.io/server: "true"
+    flavor.template.kubevirt.io/medium: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+    template.kubevirt.io/default-os-variant: "true"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: windows2k12r2-server-medium
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 536870912
+          }, {
+            "name": "windows-virtio-bus",
+            "path": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+            "valid": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+            "rule": "enum",
+            "message": "virto disk bus type has better performance, install virtio drivers in VM and change bus type",
+            "values": ["virtio"],
+            "justWarning": true
+          }, {
+            "name": "windows-disk-bus",
+            "path": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+            "valid": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+            "rule": "enum",
+            "message": "disk bus has to be either virtio or sata or scsi",
+            "values": ["virtio", "sata", "scsi"]
+          }, {
+            "name": "windows-cd-bus",
+            "path": "jsonpath::.spec.domain.devices.disks[*].cdrom.bus",
+            "valid": "jsonpath::.spec.domain.devices.disks[*].cdrom.bus",
+            "rule": "enum",
+            "message": "cd bus has to be sata",
+            "values": ["sata"]
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+      - apiVersion: cdi.kubevirt.io/v1beta1
+        kind: DataVolume
+        metadata:
+          name: ${NAME}
+        spec:
+          pvc:
+            accessModes:
+              - ReadWriteMany
+            resources:
+              requests:
+                storage: 60Gi
+          source:
+            pvc:
+              name: ${SRC_PVC_NAME}
+              namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "windows2k12r2"
+          vm.kubevirt.io/workload: "server"
+          vm.kubevirt.io/flavor: "medium"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: medium
+      spec:
+        domain:
+          clock:
+            utc: {}
+            timer:
+              hpet:
+                present: false
+              pit:
+                tickPolicy: delay
+              rtc:
+                tickPolicy: catchup
+              hyperv: {}
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 4Gi
+          features:
+            acpi: {}
+            apic: {}
+            hyperv:
+              relaxed: {}
+              vapic: {}
+              vpindex: {}
+              spinlocks:
+                spinlocks: 8191
+              synic: {}
+              synictimer:
+                direct: {}
+              tlbflush: {}
+              frequencies: {}
+              reenlightenment: {}
+              ipi: {}
+              runtime: {}
+              reset: {}
+          devices:
+            disks:
+            - disk:
+                bus: sata
+              name: ${NAME}
+            interfaces:
+            - masquerade: {}
+              model: e1000e
+              name: default
+            inputs:
+              - type: tablet
+                bus: usb
+                name: tablet
+        terminationGracePeriodSeconds: 3600
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        networks:
+        - name: default
+          pod: {}
+parameters:
+- name: NAME
+  description: VM name
+  generate: expression
+  from: "windows-[a-z0-9]{6}"
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: win2k12r2
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+---
+# Source: dist/templates/windows2k16-highperformance-large.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: windows2k16-highperformance-large
+  annotations:
+    openshift.io/display-name: "Microsoft Windows Server 2016 VM"
+    description: >-
+      Template for Microsoft Windows Server 2016 VM.
+      A PVC with the Windows disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,windows"
+    iconClass: "icon-windows"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    defaults.template.kubevirt.io/network: default
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/win2k16: Microsoft Windows Server 2016
+  labels:
+    os.template.kubevirt.io/win2k16: "true"
+    workload.template.kubevirt.io/highperformance: "true"
+    flavor.template.kubevirt.io/large: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: windows2k16-highperformance-large
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 536870912
+          }, {
+            "name": "windows-virtio-bus",
+            "path": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+            "valid": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+            "rule": "enum",
+            "message": "virto disk bus type has better performance, install virtio drivers in VM and change bus type",
+            "values": ["virtio"],
+            "justWarning": true
+          }, {
+            "name": "windows-disk-bus",
+            "path": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+            "valid": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+            "rule": "enum",
+            "message": "disk bus has to be either virtio or sata or scsi",
+            "values": ["virtio", "sata", "scsi"]
+          }, {
+            "name": "windows-cd-bus",
+            "path": "jsonpath::.spec.domain.devices.disks[*].cdrom.bus",
+            "valid": "jsonpath::.spec.domain.devices.disks[*].cdrom.bus",
+            "rule": "enum",
+            "message": "cd bus has to be sata",
+            "values": ["sata"]
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+      - apiVersion: cdi.kubevirt.io/v1beta1
+        kind: DataVolume
+        metadata:
+          name: ${NAME}
+        spec:
+          pvc:
+            accessModes:
+              - ReadWriteMany
+            resources:
+              requests:
+                storage: 60Gi
+          source:
+            pvc:
+              name: ${SRC_PVC_NAME}
+              namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "windows2k16"
+          vm.kubevirt.io/workload: "highperformance"
+          vm.kubevirt.io/flavor: "large"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: large
+      spec:
+        domain:
+          clock:
+            utc: {}
+            timer:
+              hpet:
+                present: false
+              pit:
+                tickPolicy: delay
+              rtc:
+                tickPolicy: catchup
+              hyperv: {}
+          cpu:
+            sockets: 2
+            cores: 1
+            threads: 1
+            dedicatedCpuPlacement: True
+            isolateEmulatorThread: True
+          resources:
+            requests:
+              memory: 8Gi
+          features:
+            acpi: {}
+            apic: {}
+            hyperv:
+              relaxed: {}
+              vapic: {}
+              vpindex: {}
+              spinlocks:
+                spinlocks: 8191
+              synic: {}
+              synictimer:
+                direct: {}
+              tlbflush: {}
+              frequencies: {}
+              reenlightenment: {}
+              ipi: {}
+              runtime: {}
+              reset: {}
+          devices:
+            networkInterfaceMultiqueue: True
+            disks:
+            - disk:
+                bus: sata
+              name: ${NAME}
+            interfaces:
+            - masquerade: {}
+              model: virtio
+              name: default
+            inputs:
+              - type: tablet
+                bus: usb
+                name: tablet
+        terminationGracePeriodSeconds: 3600
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        networks:
+        - name: default
+          pod: {}
+parameters:
+- name: NAME
+  description: VM name
+  generate: expression
+  from: "windows-[a-z0-9]{6}"
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: win2k16
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+---
+# Source: dist/templates/windows2k16-highperformance-medium.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: windows2k16-highperformance-medium
+  annotations:
+    openshift.io/display-name: "Microsoft Windows Server 2016 VM"
+    description: >-
+      Template for Microsoft Windows Server 2016 VM.
+      A PVC with the Windows disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,windows"
+    iconClass: "icon-windows"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    defaults.template.kubevirt.io/network: default
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/win2k16: Microsoft Windows Server 2016
+  labels:
+    os.template.kubevirt.io/win2k16: "true"
+    workload.template.kubevirt.io/highperformance: "true"
+    flavor.template.kubevirt.io/medium: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: windows2k16-highperformance-medium
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 536870912
+          }, {
+            "name": "windows-virtio-bus",
+            "path": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+            "valid": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+            "rule": "enum",
+            "message": "virto disk bus type has better performance, install virtio drivers in VM and change bus type",
+            "values": ["virtio"],
+            "justWarning": true
+          }, {
+            "name": "windows-disk-bus",
+            "path": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+            "valid": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+            "rule": "enum",
+            "message": "disk bus has to be either virtio or sata or scsi",
+            "values": ["virtio", "sata", "scsi"]
+          }, {
+            "name": "windows-cd-bus",
+            "path": "jsonpath::.spec.domain.devices.disks[*].cdrom.bus",
+            "valid": "jsonpath::.spec.domain.devices.disks[*].cdrom.bus",
+            "rule": "enum",
+            "message": "cd bus has to be sata",
+            "values": ["sata"]
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+      - apiVersion: cdi.kubevirt.io/v1beta1
+        kind: DataVolume
+        metadata:
+          name: ${NAME}
+        spec:
+          pvc:
+            accessModes:
+              - ReadWriteMany
+            resources:
+              requests:
+                storage: 60Gi
+          source:
+            pvc:
+              name: ${SRC_PVC_NAME}
+              namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "windows2k16"
+          vm.kubevirt.io/workload: "highperformance"
+          vm.kubevirt.io/flavor: "medium"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: medium
+      spec:
+        domain:
+          clock:
+            utc: {}
+            timer:
+              hpet:
+                present: false
+              pit:
+                tickPolicy: delay
+              rtc:
+                tickPolicy: catchup
+              hyperv: {}
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+            dedicatedCpuPlacement: True
+            isolateEmulatorThread: True
+          resources:
+            requests:
+              memory: 4Gi
+          features:
+            acpi: {}
+            apic: {}
+            hyperv:
+              relaxed: {}
+              vapic: {}
+              vpindex: {}
+              spinlocks:
+                spinlocks: 8191
+              synic: {}
+              synictimer:
+                direct: {}
+              tlbflush: {}
+              frequencies: {}
+              reenlightenment: {}
+              ipi: {}
+              runtime: {}
+              reset: {}
+          devices:
+            networkInterfaceMultiqueue: True
+            disks:
+            - disk:
+                bus: sata
+              name: ${NAME}
+            interfaces:
+            - masquerade: {}
+              model: virtio
+              name: default
+            inputs:
+              - type: tablet
+                bus: usb
+                name: tablet
+        terminationGracePeriodSeconds: 3600
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        networks:
+        - name: default
+          pod: {}
+parameters:
+- name: NAME
+  description: VM name
+  generate: expression
+  from: "windows-[a-z0-9]{6}"
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: win2k16
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+---
+# Source: dist/templates/windows2k16-server-large.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: windows2k16-server-large
+  annotations:
+    openshift.io/display-name: "Microsoft Windows Server 2016 VM"
+    description: >-
+      Template for Microsoft Windows Server 2016 VM.
+      A PVC with the Windows disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,windows"
+    iconClass: "icon-windows"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    defaults.template.kubevirt.io/network: default
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/win2k16: Microsoft Windows Server 2016
+  labels:
+    os.template.kubevirt.io/win2k16: "true"
+    workload.template.kubevirt.io/server: "true"
+    flavor.template.kubevirt.io/large: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: windows2k16-server-large
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 536870912
+          }, {
+            "name": "windows-virtio-bus",
+            "path": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+            "valid": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+            "rule": "enum",
+            "message": "virto disk bus type has better performance, install virtio drivers in VM and change bus type",
+            "values": ["virtio"],
+            "justWarning": true
+          }, {
+            "name": "windows-disk-bus",
+            "path": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+            "valid": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+            "rule": "enum",
+            "message": "disk bus has to be either virtio or sata or scsi",
+            "values": ["virtio", "sata", "scsi"]
+          }, {
+            "name": "windows-cd-bus",
+            "path": "jsonpath::.spec.domain.devices.disks[*].cdrom.bus",
+            "valid": "jsonpath::.spec.domain.devices.disks[*].cdrom.bus",
+            "rule": "enum",
+            "message": "cd bus has to be sata",
+            "values": ["sata"]
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+      - apiVersion: cdi.kubevirt.io/v1beta1
+        kind: DataVolume
+        metadata:
+          name: ${NAME}
+        spec:
+          pvc:
+            accessModes:
+              - ReadWriteMany
+            resources:
+              requests:
+                storage: 60Gi
+          source:
+            pvc:
+              name: ${SRC_PVC_NAME}
+              namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "windows2k16"
+          vm.kubevirt.io/workload: "server"
+          vm.kubevirt.io/flavor: "large"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: large
+      spec:
+        domain:
+          clock:
+            utc: {}
+            timer:
+              hpet:
+                present: false
+              pit:
+                tickPolicy: delay
+              rtc:
+                tickPolicy: catchup
+              hyperv: {}
+          cpu:
+            sockets: 2
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 8Gi
+          features:
+            acpi: {}
+            apic: {}
+            hyperv:
+              relaxed: {}
+              vapic: {}
+              vpindex: {}
+              spinlocks:
+                spinlocks: 8191
+              synic: {}
+              synictimer:
+                direct: {}
+              tlbflush: {}
+              frequencies: {}
+              reenlightenment: {}
+              ipi: {}
+              runtime: {}
+              reset: {}
+          devices:
+            disks:
+            - disk:
+                bus: sata
+              name: ${NAME}
+            interfaces:
+            - masquerade: {}
+              model: e1000e
+              name: default
+            inputs:
+              - type: tablet
+                bus: usb
+                name: tablet
+        terminationGracePeriodSeconds: 3600
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        networks:
+        - name: default
+          pod: {}
+parameters:
+- name: NAME
+  description: VM name
+  generate: expression
+  from: "windows-[a-z0-9]{6}"
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: win2k16
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+---
+# Source: dist/templates/windows2k16-server-medium.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: windows2k16-server-medium
+  annotations:
+    openshift.io/display-name: "Microsoft Windows Server 2016 VM"
+    description: >-
+      Template for Microsoft Windows Server 2016 VM.
+      A PVC with the Windows disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,windows"
+    iconClass: "icon-windows"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    defaults.template.kubevirt.io/network: default
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/win2k16: Microsoft Windows Server 2016
+  labels:
+    os.template.kubevirt.io/win2k16: "true"
+    workload.template.kubevirt.io/server: "true"
+    flavor.template.kubevirt.io/medium: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+    template.kubevirt.io/default-os-variant: "true"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: windows2k16-server-medium
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 536870912
+          }, {
+            "name": "windows-virtio-bus",
+            "path": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+            "valid": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+            "rule": "enum",
+            "message": "virto disk bus type has better performance, install virtio drivers in VM and change bus type",
+            "values": ["virtio"],
+            "justWarning": true
+          }, {
+            "name": "windows-disk-bus",
+            "path": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+            "valid": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+            "rule": "enum",
+            "message": "disk bus has to be either virtio or sata or scsi",
+            "values": ["virtio", "sata", "scsi"]
+          }, {
+            "name": "windows-cd-bus",
+            "path": "jsonpath::.spec.domain.devices.disks[*].cdrom.bus",
+            "valid": "jsonpath::.spec.domain.devices.disks[*].cdrom.bus",
+            "rule": "enum",
+            "message": "cd bus has to be sata",
+            "values": ["sata"]
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+      - apiVersion: cdi.kubevirt.io/v1beta1
+        kind: DataVolume
+        metadata:
+          name: ${NAME}
+        spec:
+          pvc:
+            accessModes:
+              - ReadWriteMany
+            resources:
+              requests:
+                storage: 60Gi
+          source:
+            pvc:
+              name: ${SRC_PVC_NAME}
+              namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "windows2k16"
+          vm.kubevirt.io/workload: "server"
+          vm.kubevirt.io/flavor: "medium"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: medium
+      spec:
+        domain:
+          clock:
+            utc: {}
+            timer:
+              hpet:
+                present: false
+              pit:
+                tickPolicy: delay
+              rtc:
+                tickPolicy: catchup
+              hyperv: {}
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 4Gi
+          features:
+            acpi: {}
+            apic: {}
+            hyperv:
+              relaxed: {}
+              vapic: {}
+              vpindex: {}
+              spinlocks:
+                spinlocks: 8191
+              synic: {}
+              synictimer:
+                direct: {}
+              tlbflush: {}
+              frequencies: {}
+              reenlightenment: {}
+              ipi: {}
+              runtime: {}
+              reset: {}
+          devices:
+            disks:
+            - disk:
+                bus: sata
+              name: ${NAME}
+            interfaces:
+            - masquerade: {}
+              model: e1000e
+              name: default
+            inputs:
+              - type: tablet
+                bus: usb
+                name: tablet
+        terminationGracePeriodSeconds: 3600
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        networks:
+        - name: default
+          pod: {}
+parameters:
+- name: NAME
+  description: VM name
+  generate: expression
+  from: "windows-[a-z0-9]{6}"
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: win2k16
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+---
+# Source: dist/templates/windows2k19-highperformance-large.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: windows2k19-highperformance-large
+  annotations:
+    openshift.io/display-name: "Microsoft Windows Server 2019 VM"
+    description: >-
+      Template for Microsoft Windows Server 2019 VM.
+      A PVC with the Windows disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,windows"
+    iconClass: "icon-windows"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    defaults.template.kubevirt.io/network: default
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/win2k19: Microsoft Windows Server 2019
+  labels:
+    os.template.kubevirt.io/win2k19: "true"
+    workload.template.kubevirt.io/highperformance: "true"
+    flavor.template.kubevirt.io/large: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: windows2k19-highperformance-large
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 536870912
+          }, {
+            "name": "windows-virtio-bus",
+            "path": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+            "valid": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+            "rule": "enum",
+            "message": "virto disk bus type has better performance, install virtio drivers in VM and change bus type",
+            "values": ["virtio"],
+            "justWarning": true
+          }, {
+            "name": "windows-disk-bus",
+            "path": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+            "valid": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+            "rule": "enum",
+            "message": "disk bus has to be either virtio or sata or scsi",
+            "values": ["virtio", "sata", "scsi"]
+          }, {
+            "name": "windows-cd-bus",
+            "path": "jsonpath::.spec.domain.devices.disks[*].cdrom.bus",
+            "valid": "jsonpath::.spec.domain.devices.disks[*].cdrom.bus",
+            "rule": "enum",
+            "message": "cd bus has to be sata",
+            "values": ["sata"]
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+      - apiVersion: cdi.kubevirt.io/v1beta1
+        kind: DataVolume
+        metadata:
+          name: ${NAME}
+        spec:
+          pvc:
+            accessModes:
+              - ReadWriteMany
+            resources:
+              requests:
+                storage: 60Gi
+          source:
+            pvc:
+              name: ${SRC_PVC_NAME}
+              namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "windows2k19"
+          vm.kubevirt.io/workload: "highperformance"
+          vm.kubevirt.io/flavor: "large"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: large
+      spec:
+        domain:
+          clock:
+            utc: {}
+            timer:
+              hpet:
+                present: false
+              pit:
+                tickPolicy: delay
+              rtc:
+                tickPolicy: catchup
+              hyperv: {}
+          cpu:
+            sockets: 2
+            cores: 1
+            threads: 1
+            dedicatedCpuPlacement: True
+            isolateEmulatorThread: True
+          resources:
+            requests:
+              memory: 8Gi
+          features:
+            acpi: {}
+            apic: {}
+            hyperv:
+              relaxed: {}
+              vapic: {}
+              vpindex: {}
+              spinlocks:
+                spinlocks: 8191
+              synic: {}
+              synictimer:
+                direct: {}
+              tlbflush: {}
+              frequencies: {}
+              reenlightenment: {}
+              ipi: {}
+              runtime: {}
+              reset: {}
+          devices:
+            networkInterfaceMultiqueue: True
+            disks:
+            - disk:
+                bus: sata
+              name: ${NAME}
+            interfaces:
+            - masquerade: {}
+              model: virtio
+              name: default
+            inputs:
+              - type: tablet
+                bus: usb
+                name: tablet
+        terminationGracePeriodSeconds: 3600
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        networks:
+        - name: default
+          pod: {}
+parameters:
+- name: NAME
+  description: VM name
+  generate: expression
+  from: "windows-[a-z0-9]{6}"
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: win2k19
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+---
+# Source: dist/templates/windows2k19-highperformance-medium.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: windows2k19-highperformance-medium
+  annotations:
+    openshift.io/display-name: "Microsoft Windows Server 2019 VM"
+    description: >-
+      Template for Microsoft Windows Server 2019 VM.
+      A PVC with the Windows disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,windows"
+    iconClass: "icon-windows"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    defaults.template.kubevirt.io/network: default
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/win2k19: Microsoft Windows Server 2019
+  labels:
+    os.template.kubevirt.io/win2k19: "true"
+    workload.template.kubevirt.io/highperformance: "true"
+    flavor.template.kubevirt.io/medium: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: windows2k19-highperformance-medium
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 536870912
+          }, {
+            "name": "windows-virtio-bus",
+            "path": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+            "valid": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+            "rule": "enum",
+            "message": "virto disk bus type has better performance, install virtio drivers in VM and change bus type",
+            "values": ["virtio"],
+            "justWarning": true
+          }, {
+            "name": "windows-disk-bus",
+            "path": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+            "valid": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+            "rule": "enum",
+            "message": "disk bus has to be either virtio or sata or scsi",
+            "values": ["virtio", "sata", "scsi"]
+          }, {
+            "name": "windows-cd-bus",
+            "path": "jsonpath::.spec.domain.devices.disks[*].cdrom.bus",
+            "valid": "jsonpath::.spec.domain.devices.disks[*].cdrom.bus",
+            "rule": "enum",
+            "message": "cd bus has to be sata",
+            "values": ["sata"]
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+      - apiVersion: cdi.kubevirt.io/v1beta1
+        kind: DataVolume
+        metadata:
+          name: ${NAME}
+        spec:
+          pvc:
+            accessModes:
+              - ReadWriteMany
+            resources:
+              requests:
+                storage: 60Gi
+          source:
+            pvc:
+              name: ${SRC_PVC_NAME}
+              namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "windows2k19"
+          vm.kubevirt.io/workload: "highperformance"
+          vm.kubevirt.io/flavor: "medium"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: medium
+      spec:
+        domain:
+          clock:
+            utc: {}
+            timer:
+              hpet:
+                present: false
+              pit:
+                tickPolicy: delay
+              rtc:
+                tickPolicy: catchup
+              hyperv: {}
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+            dedicatedCpuPlacement: True
+            isolateEmulatorThread: True
+          resources:
+            requests:
+              memory: 4Gi
+          features:
+            acpi: {}
+            apic: {}
+            hyperv:
+              relaxed: {}
+              vapic: {}
+              vpindex: {}
+              spinlocks:
+                spinlocks: 8191
+              synic: {}
+              synictimer:
+                direct: {}
+              tlbflush: {}
+              frequencies: {}
+              reenlightenment: {}
+              ipi: {}
+              runtime: {}
+              reset: {}
+          devices:
+            networkInterfaceMultiqueue: True
+            disks:
+            - disk:
+                bus: sata
+              name: ${NAME}
+            interfaces:
+            - masquerade: {}
+              model: virtio
+              name: default
+            inputs:
+              - type: tablet
+                bus: usb
+                name: tablet
+        terminationGracePeriodSeconds: 3600
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        networks:
+        - name: default
+          pod: {}
+parameters:
+- name: NAME
+  description: VM name
+  generate: expression
+  from: "windows-[a-z0-9]{6}"
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: win2k19
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+---
+# Source: dist/templates/windows2k19-server-large.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: windows2k19-server-large
+  annotations:
+    openshift.io/display-name: "Microsoft Windows Server 2019 VM"
+    description: >-
+      Template for Microsoft Windows Server 2019 VM.
+      A PVC with the Windows disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,windows"
+    iconClass: "icon-windows"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    defaults.template.kubevirt.io/network: default
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/win2k19: Microsoft Windows Server 2019
+  labels:
+    os.template.kubevirt.io/win2k19: "true"
+    workload.template.kubevirt.io/server: "true"
+    flavor.template.kubevirt.io/large: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: windows2k19-server-large
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 536870912
+          }, {
+            "name": "windows-virtio-bus",
+            "path": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+            "valid": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+            "rule": "enum",
+            "message": "virto disk bus type has better performance, install virtio drivers in VM and change bus type",
+            "values": ["virtio"],
+            "justWarning": true
+          }, {
+            "name": "windows-disk-bus",
+            "path": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+            "valid": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+            "rule": "enum",
+            "message": "disk bus has to be either virtio or sata or scsi",
+            "values": ["virtio", "sata", "scsi"]
+          }, {
+            "name": "windows-cd-bus",
+            "path": "jsonpath::.spec.domain.devices.disks[*].cdrom.bus",
+            "valid": "jsonpath::.spec.domain.devices.disks[*].cdrom.bus",
+            "rule": "enum",
+            "message": "cd bus has to be sata",
+            "values": ["sata"]
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+      - apiVersion: cdi.kubevirt.io/v1beta1
+        kind: DataVolume
+        metadata:
+          name: ${NAME}
+        spec:
+          pvc:
+            accessModes:
+              - ReadWriteMany
+            resources:
+              requests:
+                storage: 60Gi
+          source:
+            pvc:
+              name: ${SRC_PVC_NAME}
+              namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "windows2k19"
+          vm.kubevirt.io/workload: "server"
+          vm.kubevirt.io/flavor: "large"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: large
+      spec:
+        domain:
+          clock:
+            utc: {}
+            timer:
+              hpet:
+                present: false
+              pit:
+                tickPolicy: delay
+              rtc:
+                tickPolicy: catchup
+              hyperv: {}
+          cpu:
+            sockets: 2
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 8Gi
+          features:
+            acpi: {}
+            apic: {}
+            hyperv:
+              relaxed: {}
+              vapic: {}
+              vpindex: {}
+              spinlocks:
+                spinlocks: 8191
+              synic: {}
+              synictimer:
+                direct: {}
+              tlbflush: {}
+              frequencies: {}
+              reenlightenment: {}
+              ipi: {}
+              runtime: {}
+              reset: {}
+          devices:
+            disks:
+            - disk:
+                bus: sata
+              name: ${NAME}
+            interfaces:
+            - masquerade: {}
+              model: e1000e
+              name: default
+            inputs:
+              - type: tablet
+                bus: usb
+                name: tablet
+        terminationGracePeriodSeconds: 3600
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        networks:
+        - name: default
+          pod: {}
+parameters:
+- name: NAME
+  description: VM name
+  generate: expression
+  from: "windows-[a-z0-9]{6}"
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: win2k19
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+---
+# Source: dist/templates/windows2k19-server-medium.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: windows2k19-server-medium
+  annotations:
+    openshift.io/display-name: "Microsoft Windows Server 2019 VM"
+    description: >-
+      Template for Microsoft Windows Server 2019 VM.
+      A PVC with the Windows disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,windows"
+    iconClass: "icon-windows"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    defaults.template.kubevirt.io/network: default
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/win2k19: Microsoft Windows Server 2019
+  labels:
+    os.template.kubevirt.io/win2k19: "true"
+    workload.template.kubevirt.io/server: "true"
+    flavor.template.kubevirt.io/medium: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.16.5"
+    template.kubevirt.io/default-os-variant: "true"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: windows2k19-server-medium
+      vm.kubevirt.io/template.version: "v0.16.5"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 536870912
+          }, {
+            "name": "windows-virtio-bus",
+            "path": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+            "valid": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+            "rule": "enum",
+            "message": "virto disk bus type has better performance, install virtio drivers in VM and change bus type",
+            "values": ["virtio"],
+            "justWarning": true
+          }, {
+            "name": "windows-disk-bus",
+            "path": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+            "valid": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+            "rule": "enum",
+            "message": "disk bus has to be either virtio or sata or scsi",
+            "values": ["virtio", "sata", "scsi"]
+          }, {
+            "name": "windows-cd-bus",
+            "path": "jsonpath::.spec.domain.devices.disks[*].cdrom.bus",
+            "valid": "jsonpath::.spec.domain.devices.disks[*].cdrom.bus",
+            "rule": "enum",
+            "message": "cd bus has to be sata",
+            "values": ["sata"]
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+      - apiVersion: cdi.kubevirt.io/v1beta1
+        kind: DataVolume
+        metadata:
+          name: ${NAME}
+        spec:
+          pvc:
+            accessModes:
+              - ReadWriteMany
+            resources:
+              requests:
+                storage: 60Gi
+          source:
+            pvc:
+              name: ${SRC_PVC_NAME}
+              namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "windows2k19"
+          vm.kubevirt.io/workload: "server"
+          vm.kubevirt.io/flavor: "medium"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: medium
+      spec:
+        domain:
+          clock:
+            utc: {}
+            timer:
+              hpet:
+                present: false
+              pit:
+                tickPolicy: delay
+              rtc:
+                tickPolicy: catchup
+              hyperv: {}
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 4Gi
+          features:
+            acpi: {}
+            apic: {}
+            hyperv:
+              relaxed: {}
+              vapic: {}
+              vpindex: {}
+              spinlocks:
+                spinlocks: 8191
+              synic: {}
+              synictimer:
+                direct: {}
+              tlbflush: {}
+              frequencies: {}
+              reenlightenment: {}
+              ipi: {}
+              runtime: {}
+              reset: {}
+          devices:
+            disks:
+            - disk:
+                bus: sata
+              name: ${NAME}
+            interfaces:
+            - masquerade: {}
+              model: e1000e
+              name: default
+            inputs:
+              - type: tablet
+                bus: usb
+                name: tablet
+        terminationGracePeriodSeconds: 3600
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        networks:
+        - name: default
+          pod: {}
+parameters:
+- name: NAME
+  description: VM name
+  generate: expression
+  from: "windows-[a-z0-9]{6}"
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: win2k19
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images

--- a/validator.Dockerfile
+++ b/validator.Dockerfile
@@ -1,6 +1,9 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal as builder
 
-RUN microdnf install -y golang-1.16.* && microdnf clean all
+RUN microdnf install -y tar gzip && microdnf clean all
+
+RUN curl -L https://go.dev/dl/go1.16.15.linux-amd64.tar.gz | tar -C /usr/local -xzf -
+ENV PATH=$PATH:/usr/local/go/bin
 
 ARG VERSION=latest
 ARG COMPONENT="kubevirt-template-validator"


### PR DESCRIPTION
**What this PR does / why we need it**:
change a way ho golang is installed in dockerfile
Because golang 1.16 is no longer available in ubi
image, all tests are failing. This commit downloads golang from official go site.

**Release note**:
```
NONE
```
