### PR TITLE
[release-v0.15] CI: Fix Kubevirt and CDI versions

### DIFF
--- a/automation/common/deploy-kubevirt-and-cdi.sh
+++ b/automation/common/deploy-kubevirt-and-cdi.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+source $(dirname "$0")/versions.sh
+
 NAMESPACE=${1:-kubevirt}
 
 oc apply -f - <<EOF
@@ -10,11 +12,7 @@ metadata:
   name: ${NAMESPACE}
 EOF
 
-# Deploying kuebvirt
-LATEST_KUBEVIRT=$(curl -L https://api.github.com/repos/kubevirt/kubevirt/releases | \
-            jq '.[] | select(.prerelease==false) | .name' | sort -V | tail -n1 | tr -d '"')
-
-oc apply -n $NAMESPACE -f "https://github.com/kubevirt/kubevirt/releases/download/${LATEST_KUBEVIRT}/kubevirt-operator.yaml"
+oc apply -n $NAMESPACE -f "https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VERSION}/kubevirt-operator.yaml"
 
 # Using KubeVirt CR from version v0.35.0
 oc apply -n $NAMESPACE -f - <<EOF
@@ -51,11 +49,8 @@ metadata:
   name: $CDI_NAMESPACE
 EOF
 
-LATEST_CDI=$(curl -L https://api.github.com/repos/kubevirt/containerized-data-importer/releases | \
-             jq '.[] | select(.prerelease==false) | .tag_name' | sort -V | tail -n1 | tr -d '"')
-
-oc apply -n ${CDI_NAMESPACE} -f "https://github.com/kubevirt/containerized-data-importer/releases/download/${LATEST_CDI}/cdi-operator.yaml"
-oc apply -n ${CDI_NAMESPACE} -f "https://github.com/kubevirt/containerized-data-importer/releases/download/${LATEST_CDI}/cdi-cr.yaml"
+oc apply -n ${CDI_NAMESPACE} -f "https://github.com/kubevirt/containerized-data-importer/releases/download/${CDI_VERSION}/cdi-operator.yaml"
+oc apply -n ${CDI_NAMESPACE} -f "https://github.com/kubevirt/containerized-data-importer/releases/download/${CDI_VERSION}/cdi-cr.yaml"
 
 echo "Waiting for CDI to be ready..."
 

--- a/automation/common/versions.sh
+++ b/automation/common/versions.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+set -e
+set -o pipefail
+
+function latest_patch_version() {
+  local repo="$1"
+  local minor_version="$2"
+
+  # The loop is necessary, because GitHub API call cannot return more than 100 items
+  local latest_version=""
+  local page=1
+  while true ; do
+    # Declared separately to not mask return value
+    local versions_in_page
+    versions_in_page=$(
+      curl --fail -s "https://api.github.com/repos/kubevirt/${repo}/releases?per_page=100&page=${page}" |
+      jq '.[] | select(.prerelease==false) | .tag_name' |
+      tr -d '"'
+    )
+    if [ $? -ne 0 ]; then
+      return 1
+    fi
+
+    if [ -z "${versions_in_page}" ]; then
+      break
+    fi
+
+    latest_version=$(
+      echo "${versions_in_page} ${latest_version}" |
+      tr " " "\n" |
+      grep "^${minor_version}\\." |
+      sort --version-sort |
+      tail -n1
+    )
+
+    ((++page))
+  done
+
+  echo "${latest_version}"
+}
+
+# The version is fixed for release branch, because newer Kubevirt versions may be incompatible
+KUBEVIRT_VERSION="$(latest_patch_version "kubevirt" "v0.53")"
+
+# The version is fixed for release branch, because newer CDI versions may be incompatible
+CDI_VERSION="$(latest_patch_version "containerized-data-importer" "v1.50")"


### PR DESCRIPTION
The CI in this release branch uses fixed versions of Kubevirt and CDI, because it may be incompatible with newest versions.

Kubevirt version: `v0.53.2`
CDI version: `v1.50.0`


**Release note**:
```release-note
None
```
