### PR TITLE
Add e2e tests for total_restored_common_templates metric

### DIFF
--- a/tests/metrics_test.go
+++ b/tests/metrics_test.go
@@ -2,15 +2,21 @@ package tests
 
 import (
 	"fmt"
+	templatev1 "github.com/openshift/api/template/v1"
+	"kubevirt.io/ssp-operator/tests/env"
 	"net/http"
 	"reflect"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	apps "k8s.io/api/apps/v1"
 	rbac "k8s.io/api/rbac/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"kubevirt.io/ssp-operator/internal/common"
 	"kubevirt.io/ssp-operator/internal/operands/metrics"
@@ -24,6 +30,13 @@ func mergeMaps(maps ...map[string]string) map[string]string {
 		}
 	}
 	return targetMap
+}
+
+func getDeployment(name string, namespace string) *apps.Deployment {
+	deployment := &apps.Deployment{}
+	err := apiClient.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, deployment)
+	Expect(err).ToNot(HaveOccurred())
+	return deployment
 }
 
 var _ = Describe("Metrics", func() {
@@ -153,6 +166,88 @@ var _ = Describe("Metrics", func() {
 		)
 	})
 
+	Context("SSP metrics", func() {
+		var originalVersion string
+
+		waitForVersionUpdate := func(version string) {
+			Eventually(func() error {
+				rsList := &apps.ReplicaSetList{}
+				err := apiClient.List(ctx, rsList, client.InNamespace(sspDeploymentNamespace),
+					client.MatchingLabels{"name": "ssp-operator"})
+				Expect(err).ToNot(HaveOccurred())
+
+				for _, rs := range rsList.Items {
+					for _, env := range rs.Spec.Template.Spec.Containers[0].Env {
+						if env.Name == common.OperatorVersionKey && env.Value == version && rs.Status.ReadyReplicas == *rs.Spec.Replicas {
+							return nil
+						}
+					}
+				}
+
+				return fmt.Errorf("operator version not yet updated")
+			}, env.ShortTimeout(), time.Second).Should(Succeed())
+		}
+
+		updateVersion := func(version string) {
+			Eventually(func() error {
+				deployment := getDeployment(sspDeploymentName, sspDeploymentNamespace)
+
+				envs := deployment.Spec.Template.Spec.Containers[0].Env
+
+				for i, env := range envs {
+					if env.Name == common.OperatorVersionKey {
+						envs[i].Value = version
+						break
+					}
+				}
+
+				return apiClient.Update(ctx, deployment)
+			}, env.ShortTimeout(), time.Second).ShouldNot(HaveOccurred())
+
+			waitForVersionUpdate(version)
+		}
+
+		BeforeEach(func() {
+			strategy.SkipSspUpdateTestsIfNeeded()
+
+			By("saving original version")
+			originalVersion = ""
+			deployment := getDeployment(sspDeploymentName, sspDeploymentNamespace)
+			envs := deployment.Spec.Template.Spec.Containers[0].Env
+			for _, env := range envs {
+				if env.Name == common.OperatorVersionKey {
+					originalVersion = env.Value
+				}
+			}
+
+			waitUntilDeployed()
+		})
+
+		AfterEach(func() {
+			updateVersion(originalVersion)
+			strategy.RevertToOriginalSspCr()
+		})
+
+		It("[test_id:TODO]should not increment total_restored_common_templates during upgrades", func() {
+			testTemplate := createTestTemplate()
+
+			pauseSsp()
+			version := "test-" + rand.String(5)
+			updateVersion(version)
+
+			template := &templatev1.Template{}
+			Expect(apiClient.Get(ctx, testTemplate.GetKey(), template)).To(Succeed())
+			testTemplate.Update(template)
+			Expect(apiClient.Update(ctx, template)).To(Succeed())
+
+			unpauseSsp()
+			waitUntilDeployed()
+
+			newRestoredCount := totalRestoredTemplatesCount()
+			Expect(newRestoredCount).To(BeZero())
+		})
+	})
+
 	Context("SSP alerts rules", func() {
 		var promRule promv1.PrometheusRule
 
@@ -160,7 +255,7 @@ var _ = Describe("Metrics", func() {
 			Expect(apiClient.Get(ctx, prometheusRuleRes.GetKey(), &promRule)).To(Succeed())
 		})
 
-		It("[test_id:7851]should have all the requried annotations", func() {
+		It("[test_id:7851]should have all the required annotations", func() {
 			for _, group := range promRule.Spec.Groups {
 				for _, rule := range group.Rules {
 					if rule.Alert != "" {
@@ -176,7 +271,7 @@ var _ = Describe("Metrics", func() {
 			}
 		})
 
-		It("[test_id:8955]should have all the requried labels", func() {
+		It("[test_id:8955]should have all the required labels", func() {
 			for _, group := range promRule.Spec.Groups {
 				for _, rule := range group.Rules {
 					if rule.Alert != "" {


### PR DESCRIPTION
Signed-off-by: João Vilaça <jvilaca@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This PR adds an e2e test to ensure the `total_restored_common_templates` metric is not incremented if a template is created/edited during and SSP operator upgrade

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add e2e tests for total_restored_common_templates metric
```
