### PR TITLE
add dockerfile for ci builds

### DIFF
--- a/ci-builder/Dockerfile
+++ b/ci-builder/Dockerfile
@@ -1,0 +1,12 @@
+# This Dockerfile is used in openshift CI
+FROM quay.io/fedora/fedora:37
+
+RUN curl -L https://go.dev/dl/go1.19.2.linux-amd64.tar.gz | tar -C /usr/local -xzf -
+ENV PATH=$PATH:/usr/local/go/bin
+
+# Install dependencies and tools
+RUN dnf install -y jq git make findutils which gcc && dnf clean all
+
+# Download latest stable oc client binary
+RUN curl -L https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/openshift-client-linux.tar.gz | tar -C /usr/local/bin -xzf - oc && \
+    chmod +x /usr/local/bin/oc


### PR DESCRIPTION
**What this PR does / why we need it**:
The new go 1.19 ci image does not contain packages which ssp operator needs for tests. This commit adds new dockerfile, which installs all necessary packages needed for ssp operator

Signed-off-by: Karel Šimon <ksimon@redhat.com>

**Release note**:
```
NONE
```
