### PR TITLE
add gettext package to ci builder dockerfile

### DIFF
--- a/ci-builder/Dockerfile
+++ b/ci-builder/Dockerfile
@@ -5,7 +5,7 @@ RUN curl -L https://go.dev/dl/go1.19.2.linux-amd64.tar.gz | tar -C /usr/local -x
 ENV PATH=$PATH:/usr/local/go/bin
 
 # Install dependencies and tools
-RUN dnf install -y jq git make findutils which gcc && dnf clean all
+RUN dnf install -y jq git make findutils which gcc gettext && dnf clean all
 
 # Download latest stable oc client binary
 RUN curl -L https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/openshift-client-linux.tar.gz | tar -C /usr/local/bin -xzf - oc && \


### PR DESCRIPTION
**What this PR does / why we need it**:
add gettext package to ci builder dockerfile
this package is required due to command in makefile

**Release note**:
```
NONE

```
