### PR TITLE
Allow running the SSP Operator on plain kubernetes

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -114,6 +114,7 @@ rules:
 - apiGroups:
   - config.openshift.io
   resources:
+  - clusterversions
   - infrastructures
   verbs:
   - get

--- a/controllers/ssp_controller.go
+++ b/controllers/ssp_controller.go
@@ -98,7 +98,7 @@ var _ reconcile.Reconciler = &sspReconciler{}
 // +kubebuilder:rbac:groups=ssp.kubevirt.io,resources=ssps,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=ssp.kubevirt.io,resources=ssps/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=ssp.kubevirt.io,resources=ssps/finalizers,verbs=update
-// +kubebuilder:rbac:groups=config.openshift.io,resources=infrastructures,verbs=get;list;watch
+// +kubebuilder:rbac:groups=config.openshift.io,resources=infrastructures;clusterversions,verbs=get;list;watch
 // +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=list
 // +kubebuilder:rbac:groups=ssp.kubevirt.io,resources=kubevirtcommontemplatesbundles,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=ssp.kubevirt.io,resources=kubevirtmetricsaggregations,verbs=get;list;watch;create;update;patch;delete


### PR DESCRIPTION
SSP can't run on a plain kubernetes, because it requires the `Infrastructure` kind to be present on the cluster.

When deploying KubeVirt with HCO using OLM on plain kubernetes, the deployment is never completed because SSP operator never becomes ready. More details and full description of the issue can be found here: https://github.com/kubevirt/hyperconverged-cluster-operator/issues/2129

This PR disables the reconcilers and all the watches, when running in a plain K8s cluster, instead of killing the process.

That way, the SSP operator is runing and responding to the health and ready checks, but does nothing else. The result is that SSP is still not working on plain kubernetest, but the OLM deployment is successfully completed.

Fixes kubevirt/hyperconverged-cluster-operator#2129

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
