### PR TITLE
Cleanup fixes for tests waiting for DVs to succeed

### DIFF
--- a/tests/dataSources_test.go
+++ b/tests/dataSources_test.go
@@ -858,7 +858,7 @@ var _ = Describe("DataSources", func() {
 					logObject(dataImportCron.GetKey(), &cdiv1beta1.DataImportCron{})
 				})
 
-				PIt("[QUARANTINE][test_id:8112] should restore DataSource if DataImportCron removed from SSP CR", func() {
+				It("[test_id:8112] should restore DataSource if DataImportCron removed from SSP CR", func() {
 					// Wait until DataImportCron imports PVC and changes data source
 					Eventually(func() bool {
 						cron := &cdiv1beta1.DataImportCron{}
@@ -1134,7 +1134,7 @@ var _ = Describe("DataSources", func() {
 					}, env.Timeout(), time.Second).Should(Equal(metav1.StatusReasonNotFound), "DataImportCron should not exist.")
 				})
 
-				PIt("[QUARANTINE][test_id:8298] should restore DataSource, when CDI label is removed", func() {
+				It("[test_id:8298] should restore DataSource, when CDI label is removed", func() {
 					// Wait until DataImportCron imports PVC and changes data source
 					Eventually(func() (bool, error) {
 						cron := &cdiv1beta1.DataImportCron{}

--- a/tests/dataSources_test.go
+++ b/tests/dataSources_test.go
@@ -738,8 +738,6 @@ var _ = Describe("DataSources", func() {
 			pullMethod        = cdiv1beta1.RegistryPullNode
 			commonAnnotations = map[string]string{
 				"cdi.kubevirt.io/storage.bind.immediate.requested": "true",
-				// Remove this annotation once CDI handles DataImportCron and garbage collection properly
-				"cdi.kubevirt.io/storage.deleteAfterCompletion": "false",
 			}
 
 			cronTemplate   ssp.DataImportCronTemplate
@@ -1000,11 +998,20 @@ var _ = Describe("DataSources", func() {
 				}
 				Expect(apiClient.Create(ctx, dataVolume)).To(Succeed())
 
-				Eventually(func() cdiv1beta1.DataVolumePhase {
+				Eventually(func() bool {
 					foundDv := &cdiv1beta1.DataVolume{}
-					Expect(apiClient.Get(ctx, client.ObjectKeyFromObject(dataVolume), foundDv)).To(Succeed())
-					return foundDv.Status.Phase
-				}, env.Timeout(), time.Second).Should(Equal(cdiv1beta1.Succeeded), "DataVolume should successfully import.")
+					err := apiClient.Get(ctx, client.ObjectKeyFromObject(dataVolume), foundDv)
+
+					if errors.IsNotFound(err) {
+						foundPvc := &core.PersistentVolumeClaim{}
+						err = apiClient.Get(ctx, client.ObjectKeyFromObject(dataVolume), foundPvc)
+						Expect(err).ToNot(HaveOccurred())
+						return true
+					}
+
+					Expect(err).ToNot(HaveOccurred())
+					return foundDv.Status.Phase == cdiv1beta1.Succeeded
+				}, env.Timeout(), time.Second).Should(BeTrue(), "DataVolume should successfully import.")
 
 				Eventually(func() bool {
 					foundDs := &cdiv1beta1.DataSource{}
@@ -1023,12 +1030,23 @@ var _ = Describe("DataSources", func() {
 				waitUntilDeployed()
 			})
 
-			AfterEach(func() {
+			deleteDVAndPVC := func() {
 				err := apiClient.Delete(ctx, dataVolume)
 				if !errors.IsNotFound(err) {
 					Expect(err).ToNot(HaveOccurred(), "Failed to delete data volume")
 				}
 				waitForDeletion(client.ObjectKeyFromObject(dataVolume), &cdiv1beta1.DataVolume{})
+
+				pvc := &core.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: dataVolume.Name, Namespace: dataVolume.Namespace}}
+				err = apiClient.Delete(ctx, pvc)
+				if !errors.IsNotFound(err) {
+					Expect(err).ToNot(HaveOccurred(), "Failed to delete persistent volume claim")
+				}
+				waitForDeletion(client.ObjectKeyFromObject(pvc), &core.PersistentVolumeClaim{})
+			}
+
+			AfterEach(func() {
+				deleteDVAndPVC()
 			})
 
 			It("[test_id:8110] should not create DataImportCron", func() {
@@ -1059,8 +1077,7 @@ var _ = Describe("DataSources", func() {
 				Expect(err).To(HaveOccurred())
 				Expect(errors.ReasonForError(err)).To(Equal(metav1.StatusReasonNotFound), "DataImportCron should not exist.")
 
-				Expect(apiClient.Delete(ctx, dataVolume)).To(Succeed())
-				waitForDeletion(client.ObjectKeyFromObject(dataVolume), &cdiv1beta1.DataVolume{})
+				deleteDVAndPVC()
 
 				Eventually(func() error {
 					return apiClient.Get(ctx, dataImportCron.GetKey(), dataImportCron.NewResource())

--- a/tests/misc_test.go
+++ b/tests/misc_test.go
@@ -243,7 +243,6 @@ var _ = Describe("RHEL VM creation", func() {
 	})
 
 	table.DescribeTable("should be able to start VM", func(imageUrl string) {
-		const annPodPhase = "cdi.kubevirt.io/storage.pod.phase"
 		const diskName = "disk0"
 		const sshPort = 22
 
@@ -345,7 +344,6 @@ var _ = Describe("RHEL VM creation", func() {
 			foundPvc := &core.PersistentVolumeClaim{}
 			err = apiClient.Get(ctx, client.ObjectKey{Name: dvName, Namespace: vm.Namespace}, foundPvc)
 			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(foundPvc.Annotations[annPodPhase]).To(Equal(string(core.PodSucceeded)))
 		}, 2*env.Timeout(), time.Second).Should(Succeed())
 
 		// Wait for VMI to be ready


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This is a follow-up to https://github.com/kubevirt/ssp-operator/pull/418

1. Do not check PVC pod annotation because it might not be always present (i.e. when smartcloning).
2. Reenable CDI garbage collection in `dataSources_test.go`
3. Unquarantine no longer failing tests in `dataSources_test.go`

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
4. If no release note is required, just write "NONE".
-->
```release-note
None
```
