### PR TITLE
crypto_policy_test.go: Do not hardcode SSP deployment NS

### DIFF
--- a/tests/crypto_policy_test.go
+++ b/tests/crypto_policy_test.go
@@ -183,10 +183,10 @@ func tryToAccessEndpoint(pod core.Pod, subpath string, port uint16, tlsConfig cl
 		subpath = "/" + subpath
 	}
 
-	// ssp-webhook-service.kubevirt.svc is used to access the endpoints we are testing.
+	// ssp-webhook-service.${deploymentNamespace}.svc is used to access the endpoints we are testing.
 	// It is used here for the metrics as well for simplicity, as it is the CN in the ca_cert
 	// and the metrics just sit on a different port on the same pod.
-	attemptedUrl = fmt.Sprintf("https://ssp-webhook-service.kubevirt.svc:%d%s", port, subpath)
+	attemptedUrl = fmt.Sprintf("https://ssp-webhook-service.%s.svc:%d%s", strategy.GetSSPDeploymentNameSpace(), port, subpath)
 	_, err = client.Get(attemptedUrl)
 	return attemptedUrl, err
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Use the appropriate getter instead of hardcoding the deployment namespace to 'kubevirt'.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
