### PR TITLE
Introduce support for deployments via kubevirtci and kubevirt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ bundle/*
 cover.out
 bundle.Dockerfile
 config/manager/manager.yaml
+cluster-up/
+

--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@ cover.out
 bundle.Dockerfile
 config/manager/manager.yaml
 cluster-up/
+_kubevirt/
 

--- a/Makefile
+++ b/Makefile
@@ -249,3 +249,12 @@ cluster-down:
 
 cluster-sync:
 	KUSTOMIZE=$(KUSTOMIZE) ./hack/kubevirtci.sh sync
+
+kubevirt-up:
+	./hack/kubevirt.sh up
+
+kubevirt-down:
+	./hack/kubevirt.sh down
+
+kubevirt-sync:
+	KUSTOMIZE=$(KUSTOMIZE) ./hack/kubevirt.sh sync

--- a/config/kubevirtci/kustomization.yaml
+++ b/config/kubevirtci/kustomization.yaml
@@ -1,0 +1,13 @@
+# Adds namespace to all resources.
+namespace: kubevirt
+
+# TODO - Reintroduce webhooks
+bases:
+- ../namespace
+- ../crd
+- ../rbac
+- ../manager
+
+patchesStrategicMerge:
+  - manager-disable-webhooks.yaml
+

--- a/config/kubevirtci/manager-disable-webhooks.yaml
+++ b/config/kubevirtci/manager-disable-webhooks.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: operator
+  namespace: kubevirt
+spec:
+  template:
+    spec:
+      containers:
+      - command:
+        - /manager
+        args: ["--leader-elect"]
+        env:
+          - name: ENABLE_WEBHOOKS
+            value: "false"
+        name: manager
+

--- a/docs/development.md
+++ b/docs/development.md
@@ -17,6 +17,25 @@ The CRDs can be removed using:
 make uninstall
 ```
 
+Alternatively developers can also deploy `kubevirtci` based clusters before
+building and deploying the operator. For convenience the following makefile
+targets are provided that automate this flow either directly through the
+`kubevirtci` project or indirectly using the main `kubevirt` project to
+launch an environment. The latter being useful when testing changes that
+rely on core changes in `kubevirt` itself:
+
+```shell
+make cluster-up   # Deploys the latest released version of KubeVirt
+make cluster-sync # Builds and deploys the SSP operator from source
+make cluster-down # Destroys the environment
+```
+
+```shell
+make kubevirt-up   # Deploys KubeVirt from source
+make kubevirt-sync # Builds and deploys the SSP operator from source
+make kubevirt-down # Destroys the environment
+```
+
 ## Testing
 
 To run unit tests, use this command:

--- a/hack/kubevirt.sh
+++ b/hack/kubevirt.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+#
+# Copyright 2022 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+export KUBEVIRT_TAG="${KUBEVIRT_TAG:-main}"
+
+_base_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+_kubectl="${_base_dir}/_kubevirt/cluster-up/kubectl.sh"
+_kubessh="${_base_dir}/_kubevirt/cluster-up/ssh.sh"
+_kubevirtcicli="${_base_dir}/_kubevirt/cluster-up/cli.sh"
+_action=$1
+shift
+
+function kubevirt::install() {
+  if [[ ! -d ${_base_dir}/_kubevirt ]]; then
+    git clone --depth 1 --branch "${KUBEVIRT_TAG}" https://github.com/kubevirt/kubevirt.git "${_base_dir}/_kubevirt"
+  fi
+}
+
+function kubevirt::up() {
+  make cluster-up -C "${_base_dir}/_kubevirt" && make cluster-sync -C "${_base_dir}/_kubevirt"
+}
+
+function kubevirt::down() {
+  make cluster-down -C "${_base_dir}/_kubevirt"
+}
+
+function kubevirt::kubeconfig() {
+  "${_base_dir}/_kubevirt/cluster-up/kubeconfig.sh"
+}
+
+function kubevirt::registry() {
+  port=$(${_kubevirtcicli} ports registry 2>/dev/null)
+  echo "localhost:${port}"
+}
+
+kubevirt::install
+
+case ${_action} in
+  "up")
+    kubevirt::up
+    ;;
+  "down")
+    kubevirt::down
+    ;;
+  "sync")
+    KUBECTL=${_kubectl} KUBESSH=${_kubessh} KUBEVIRTCI_REGISTERY=$(kubevirt::registry) "${_base_dir}/hack/sync.sh"
+    ;;
+  "ssh")
+    ${_kubessh} "$@"
+    ;;
+  "kubeconfig")
+    kubevirt::kubeconfig
+    ;;
+  "registry")
+    kubevirt::registry
+    ;;
+  "kubectl")
+    ${_kubectl} "$@"
+    ;;
+  *)
+    echo "No command provided, known commands are 'up', 'down', 'sync', 'ssh', 'kubeconfig', 'registry', 'kubectl'"
+    exit 1
+    ;;
+esac
+

--- a/hack/kubevirtci.sh
+++ b/hack/kubevirtci.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+#
+# Copyright 2022 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+export KUBEVIRTCI_TAG=${KUBEVIRTCI_TAG:-$(curl -sfL https://storage.googleapis.com/kubevirt-prow/release/kubevirt/kubevirtci/latest)}
+export KUBEVIRT_DEPLOY_CDI="true"
+
+_base_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+_kubectl="${_base_dir}/cluster-up/cluster-up/kubectl.sh"
+_kubessh="${_base_dir}/cluster-up/cluster-up/ssh.sh"
+_kubevirtcicli="${_base_dir}/cluster-up/cluster-up/cli.sh"
+_action=$1
+shift
+
+function kubevirtci::fetch_kubevirtci() {
+	if [[ ! -d ${_base_dir}/cluster-up ]]; then
+    git clone --depth 1 --branch "${KUBEVIRTCI_TAG}" https://github.com/kubevirt/kubevirtci.git "${_base_dir}"/cluster-up
+  fi
+}
+
+function kubevirtci::up() {
+  make cluster-up -C "${_base_dir}/cluster-up"
+  KUBECONFIG=$(kubevirtci::kubeconfig)
+  export KUBECONFIG
+  echo "adding kubevirtci registry to cdi-insecure-registries"
+  ${_kubectl} patch configmap cdi-insecure-registries -n cdi --type merge -p '{"data":{"kubevirtci": "registry:5000"}}'
+  echo "installing kubevirt..."
+  LATEST=$(curl -L https://storage.googleapis.com/kubevirt-prow/devel/release/kubevirt/kubevirt/stable.txt)
+  ${_kubectl} apply -f "https://github.com/kubevirt/kubevirt/releases/download/${LATEST}/kubevirt-operator.yaml"
+  ${_kubectl} apply -f "https://github.com/kubevirt/kubevirt/releases/download/${LATEST}/kubevirt-cr.yaml"
+  echo "waiting for kubevirt to become ready, this can take a few minutes..."
+  ${_kubectl} -n kubevirt wait kv kubevirt --for condition=Available --timeout=15m
+}
+
+function kubevirtci::down() {
+  make cluster-down -C "${_base_dir}/cluster-up"
+}
+
+function kubevirtci::registry() {
+  port=$(${_kubevirtcicli} ports registry 2>/dev/null)
+  echo "localhost:${port}"
+}
+
+function kubevirtci::sync() {
+  KUBECTL=${_kubectl} KUBESSH=${_kubessh} KUBEVIRTCI_REGISTERY=$(kubevirtci::registry) "${_base_dir}/hack/sync.sh"
+}
+
+function kubevirtci::kubeconfig() {
+  "${_base_dir}/cluster-up/cluster-up/kubeconfig.sh"
+}
+
+kubevirtci::fetch_kubevirtci
+
+case ${_action} in
+  "up")
+    kubevirtci::up
+    ;;
+  "down")
+    kubevirtci::down
+    ;;
+  "sync")
+    kubevirtci::sync
+    ;;
+  "ssh")
+    ${_kubessh} "$@"
+    ;;
+  "kubeconfig")
+    kubevirtci::kubeconfig
+    ;;
+  "registry")
+    kubevirtci::registry
+    ;;
+  "kubectl")
+    ${_kubectl} "$@"
+    ;;
+  *)
+    echo "No command provided, known commands are 'up', 'down', 'sync', 'ssh', 'kubeconfig', 'registry', 'kubectl'"
+    exit 1
+    ;;
+esac
+

--- a/hack/sync.sh
+++ b/hack/sync.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+#
+# Copyright 2022 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+source ./hack/common.sh
+
+# Please note that the validation webhooks are not currently deployed so take care when using a custom SSP CR
+export KUBEVIRT_SSP=${KUBEVIRT_SSP:-./config/samples/ssp_v1beta1_ssp.yaml}
+
+if [ -z "${KUBECTL}" ] || [ -z "${KUBESSH}" ] || [ -z "${KUSTOMIZE}" ] || [ -z "${KUBEVIRTCI_REGISTERY}" ]; then
+    echo "${BASH_SOURCE[0]} expects the following env variables to be provided: KUBECTL, KUBESSH, KUSTOMIZE and KUBEVIRTCI_REGISTERY."
+    exit 1
+fi
+
+# The ssps.ssp.kubevirt.io CRD might not be present if this is the first sync so check before attempting to delete any actual objects
+if "${KUBECTL}" get crd/ssps.ssp.kubevirt.io; then
+    "${KUBECTL}" delete --ignore-not-found=true ssps -n kubevirt --all
+    _found_ssps=$("${KUBECTL}" get ssps -n kubevirt -oname)
+    if [[ -n "${_found_ssps}" ]]; then
+        echo "SSP resources ${_found_ssps} still active, please delete manually and attempt to sync again."
+        exit 1
+    fi
+fi
+# The remaining CRDs should be present already from the k8s and KubeVirt installs so just ignore object not found failures
+"${KUBECTL}" delete --ignore-not-found=true deployment/ssp-operator -n kubevirt
+"${KUBECTL}" delete --ignore-not-found=true virtualmachineclusterinstancetype --all
+"${KUBECTL}" delete --ignore-not-found=true virtualmachineclusterpreference --all
+
+nodes=()
+for i in $(seq 1 "${KUBEVIRT_NUM_NODES}"); do
+    nodes+=("node$(printf "%02d" "${i}")")
+done
+
+IMG_REPOSITORY=${KUBEVIRTCI_REGISTERY}/kubevirt/ssp-operator make container-build container-push
+
+for node in "${nodes[@]}"; do
+    "${KUBESSH}" "${node}" "sudo docker pull registry:5000/kubevirt/ssp-operator"
+done
+
+# TODO - clean this up, move manifest generation out of the actual tree etc.
+cd config/manager && ${KUSTOMIZE} edit set image controller=registry:5000/kubevirt/ssp-operator && cd - || exit
+"${KUSTOMIZE}" build config/kubevirtci | "${KUBECTL}" apply -f -
+"${KUBECTL}" wait deployment/ssp-operator -n kubevirt --for=condition=Available --timeout="540s"
+"${KUBECTL}" apply -n kubevirt -f "${KUBEVIRT_SSP}"
+


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This change introduces support for deploying the SSP operator into a local kubevirtci deployed env, using the same 
 implementation as the core kubevirt/kubevirt project.

**Which issue(s) this PR fixes**: 
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
