### PR TITLE
[release-v0.16] crypto_policy_test.go: Do not hardcode SSP webhook service name

### DIFF
--- a/tests/crypto_policy_test.go
+++ b/tests/crypto_policy_test.go
@@ -182,10 +182,10 @@ func tryToAccessEndpoint(pod core.Pod, subpath string, port uint16, tlsConfig cl
 		subpath = "/" + subpath
 	}
 
-	// ssp-webhook-service.${deploymentNamespace}.svc is used to access the endpoints we are testing.
+	// ${webhookServiceName}.${deploymentNamespace}.svc is used to access the endpoints we are testing.
 	// It is used here for the metrics as well for simplicity, as it is the CN in the ca_cert
 	// and the metrics just sit on a different port on the same pod.
-	attemptedUrl = fmt.Sprintf("https://ssp-webhook-service.%s.svc:%d%s", strategy.GetSSPDeploymentNameSpace(), port, subpath)
+	attemptedUrl = fmt.Sprintf("https://%s.%s.svc:%d%s", strategy.GetSSPWebhookServiceName(), strategy.GetSSPDeploymentNameSpace(), port, subpath)
 	_, err = client.Get(attemptedUrl)
 	return attemptedUrl, err
 }

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -54,6 +54,7 @@ const (
 	envIsUpgradeLane          = "IS_UPGRADE_LANE"
 	envSspDeploymentName      = "SSP_DEPLOYMENT_NAME"
 	envSspDeploymentNamespace = "SSP_DEPLOYMENT_NAMESPACE"
+	envSspWebhookServiceName  = "SSP_WEBHOOK_SERVICE_NAME"
 )
 
 var (
@@ -65,6 +66,7 @@ var (
 	testScheme             *runtime.Scheme
 	sspDeploymentName      = "ssp-operator"
 	sspDeploymentNamespace = "kubevirt"
+	sspWebhookServiceName  = "ssp-webhook-service"
 )
 
 type TestSuiteStrategy interface {
@@ -77,6 +79,7 @@ type TestSuiteStrategy interface {
 	GetValidatorReplicas() int
 	GetSSPDeploymentName() string
 	GetSSPDeploymentNameSpace() string
+	GetSSPWebhookServiceName() string
 
 	GetVersionLabel() string
 	GetPartOfLabel() string
@@ -198,6 +201,10 @@ func (s *newSspStrategy) GetSSPDeploymentNameSpace() string {
 	return sspDeploymentNamespace
 }
 
+func (s *newSspStrategy) GetSSPWebhookServiceName() string {
+	return sspWebhookServiceName
+}
+
 func (s *newSspStrategy) RevertToOriginalSspCr() {
 	waitForSspDeletionIfNeeded(s.ssp)
 	createOrUpdateSsp(s.ssp)
@@ -313,6 +320,10 @@ func (s *existingSspStrategy) GetSSPDeploymentNameSpace() string {
 	return sspDeploymentNamespace
 }
 
+func (s *existingSspStrategy) GetSSPWebhookServiceName() string {
+	return sspWebhookServiceName
+}
+
 func (s *existingSspStrategy) RevertToOriginalSspCr() {
 	waitForSspDeletionIfNeeded(s.ssp)
 	createOrUpdateSsp(s.ssp)
@@ -392,6 +403,12 @@ var _ = BeforeSuite(func() {
 	if envSspDeploymentNamespace != "" {
 		sspDeploymentNamespace = envSspDeploymentNamespace
 		fmt.Println(fmt.Sprintf("SspDeploymentNamespace set to %s", envSspDeploymentNamespace))
+	}
+
+	envSspWebhookServiceName := os.Getenv(envSspWebhookServiceName)
+	if envSspWebhookServiceName != "" {
+		sspWebhookServiceName = envSspWebhookServiceName
+		fmt.Println(fmt.Sprintf("SspWebhookServiceName set to %s", envSspWebhookServiceName))
 	}
 
 	testScheme = runtime.NewScheme()


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a manual backport of #454 due to a conflict in `tests/env/env.go`.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
