### PR TITLE
Follow ups for common-instancetypes deployment

### DIFF
--- a/internal/operands/common-instancetypes/reconcile.go
+++ b/internal/operands/common-instancetypes/reconcile.go
@@ -120,9 +120,6 @@ func (c *commonInstancetypes) reconcileVirtualMachineClusterInstancetypesFuncs()
 				UpdateFunc(func(newRes, foundRes client.Object) {
 					foundRes.(*instancetypev1alpha2.VirtualMachineClusterInstancetype).Spec = newRes.(*instancetypev1alpha2.VirtualMachineClusterInstancetype).Spec
 				}).
-				ImmutableSpec(func(resource client.Object) interface{} {
-					return resource.(*instancetypev1alpha2.VirtualMachineClusterInstancetype).Spec
-				}).
 				Reconcile()
 		})
 	}
@@ -139,9 +136,6 @@ func (c *commonInstancetypes) reconcileVirtualMachineClusterPreferencesFuncs() [
 				WithAppLabels(operandName, operandComponent).
 				UpdateFunc(func(newRes, foundRes client.Object) {
 					foundRes.(*instancetypev1alpha2.VirtualMachineClusterPreference).Spec = newRes.(*instancetypev1alpha2.VirtualMachineClusterPreference).Spec
-				}).
-				ImmutableSpec(func(resource client.Object) interface{} {
-					return resource.(*instancetypev1alpha2.VirtualMachineClusterPreference).Spec
 				}).
 				Reconcile()
 		})

--- a/internal/operands/common-instancetypes/reconcile.go
+++ b/internal/operands/common-instancetypes/reconcile.go
@@ -99,7 +99,14 @@ func (c *commonInstancetypes) Reconcile(request *common.Request) ([]common.Recon
 }
 
 func (c *commonInstancetypes) Cleanup(request *common.Request) ([]common.CleanupResult, error) {
-	return nil, nil
+	var objects []client.Object
+	for i := range c.virtualMachineClusterInstancetypes {
+		objects = append(objects, &c.virtualMachineClusterInstancetypes[i])
+	}
+	for i := range c.virtualMachineClusterPreferences {
+		objects = append(objects, &c.virtualMachineClusterPreferences[i])
+	}
+	return common.DeleteAll(request, objects...)
 }
 
 func (c *commonInstancetypes) reconcileFuncs() []common.ReconcileFunc {

--- a/internal/operands/common-instancetypes/reconcile.go
+++ b/internal/operands/common-instancetypes/reconcile.go
@@ -87,7 +87,10 @@ func (c *commonInstancetypes) WatchTypes() []operands.WatchType {
 }
 
 func (c *commonInstancetypes) RequiredCrds() []string {
-	return nil
+	return []string{
+		instancetypeapi.ClusterPluralResourceName + "." + instancetypeapi.GroupName,
+		instancetypeapi.ClusterPluralPreferenceResourceName + "." + instancetypeapi.GroupName,
+	}
 }
 
 func (c *commonInstancetypes) Reconcile(request *common.Request) ([]common.ReconcileResult, error) {

--- a/internal/operands/common-instancetypes/reconcile_test.go
+++ b/internal/operands/common-instancetypes/reconcile_test.go
@@ -71,7 +71,7 @@ var _ = Describe("Common-Instancetypes operand", func() {
 		}
 	})
 
-	It("should create common-instancetypes resources", func() {
+	It("should create and cleanup common-instancetypes resources", func() {
 		_, err := operand.Reconcile(&request)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -89,6 +89,17 @@ var _ = Describe("Common-Instancetypes operand", func() {
 
 		for _, preference := range virtualMachineClusterPreferences {
 			ExpectResourceExists(&preference, request)
+		}
+
+		_, err = operand.Cleanup(&request)
+		Expect(err).ToNot(HaveOccurred())
+
+		for _, instancetype := range virtualMachineClusterInstancetypes {
+			ExpectResourceNotExists(&instancetype, request)
+		}
+
+		for _, preference := range virtualMachineClusterPreferences {
+			ExpectResourceNotExists(&preference, request)
 		}
 	})
 })


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR addresses a number of follow ups from #453 :

* `RequireCrds` are added for `VirtualMachineClusterInstancetype` and `VirtualMachineClusterPreference`
* The `ImmutableSpec` reconcile function is removed
* A `Cleanup` function is now provided that removes all cluster resources previously added by the operand 

**Which issue(s) this PR fixes**: 
Fixes #

**Special notes for your reviewer**:

Note that no functional coverage is introduced as we still use `4.11` in our jobs, functional coverage for these changes cannot be introduced until CI moves to `4.12`  and provides the above CRDs.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
