### PR TITLE
WIP resource: Correctly return `Deleted: true` from Cleanup

### DIFF
--- a/internal/common/resource.go
+++ b/internal/common/resource.go
@@ -262,6 +262,17 @@ func Cleanup(request *Request, resource client.Object) (CleanupResult, error) {
 			request.Logger.Error(err, fmt.Sprintf("Error deleting \"%s\": %s", resource.GetName(), err))
 			return CleanupResult{}, err
 		}
+		err = request.Client.Get(request.Context, client.ObjectKeyFromObject(resource), found)
+		if errors.IsNotFound(err) {
+			return CleanupResult{
+				Resource: resource,
+				Deleted:  true,
+			}, nil
+		}
+		if err != nil {
+			request.Logger.Error(err, fmt.Sprintf("Error checking if \"%s\" has been deleted: %s", resource.GetName(), err))
+			return CleanupResult{}, err
+		}
 	}
 
 	return CleanupResult{

--- a/internal/common/resource_test.go
+++ b/internal/common/resource_test.go
@@ -282,11 +282,6 @@ var _ = Describe("Resource", func() {
 			resource := newTestResource(namespace)
 			cleanupResult, err := Cleanup(&request, resource)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(cleanupResult.Deleted).To(BeFalse())
-
-			// Deleting second time will make sure that the resource does not exist
-			cleanupResult, err = Cleanup(&request, resource)
-			Expect(err).ToNot(HaveOccurred())
 			Expect(cleanupResult.Deleted).To(BeTrue())
 		})
 	})


### PR DESCRIPTION
Previously Cleanup would return a CleanupResult suggesting that the resource had not been deleted when it had. This change corrects this by preforming another client lookup of the resource after the initial delete ensuring the correct result is returned to the caller.

Signed-off-by: Lee Yarwood <lyarwood@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**: 
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
