### PR TITLE
common-instancetypes: Update to v0.0.2-rc

### DIFF
--- a/data/common-instancetypes-bundle/common-clusterinstancetypes-bundle.yaml
+++ b/data/common-instancetypes-bundle/common-clusterinstancetypes-bundle.yaml
@@ -3,11 +3,11 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterInstancetype
 metadata:
   labels:
+    instancetype.kubevirt.io/vendor: kubevirt.io
     kubevirt.io/size: large
   name: highperformance.large
 spec:
   cpu:
-    dedicatedCPUPlacement: true
     guest: 2
     isolateEmulatorThread: true
   ioThreadsPolicy: shared
@@ -18,11 +18,11 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterInstancetype
 metadata:
   labels:
+    instancetype.kubevirt.io/vendor: kubevirt.io
     kubevirt.io/size: medium
   name: highperformance.medium
 spec:
   cpu:
-    dedicatedCPUPlacement: true
     guest: 1
     isolateEmulatorThread: true
   ioThreadsPolicy: shared
@@ -33,11 +33,11 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterInstancetype
 metadata:
   labels:
+    instancetype.kubevirt.io/vendor: kubevirt.io
     kubevirt.io/size: small
   name: highperformance.small
 spec:
   cpu:
-    dedicatedCPUPlacement: true
     guest: 1
     isolateEmulatorThread: true
   ioThreadsPolicy: shared
@@ -48,6 +48,7 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterInstancetype
 metadata:
   labels:
+    instancetype.kubevirt.io/vendor: kubevirt.io
     kubevirt.io/size: large
   name: server.large
 spec:
@@ -60,6 +61,7 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterInstancetype
 metadata:
   labels:
+    instancetype.kubevirt.io/vendor: kubevirt.io
     kubevirt.io/size: medium
   name: server.medium
 spec:
@@ -72,6 +74,20 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterInstancetype
 metadata:
   labels:
+    instancetype.kubevirt.io/vendor: kubevirt.io
+    kubevirt.io/size: micro
+  name: server.micro
+spec:
+  cpu:
+    guest: 1
+  memory:
+    guest: 256Mi
+---
+apiVersion: instancetype.kubevirt.io/v1alpha2
+kind: VirtualMachineClusterInstancetype
+metadata:
+  labels:
+    instancetype.kubevirt.io/vendor: kubevirt.io
     kubevirt.io/size: small
   name: server.small
 spec:
@@ -84,6 +100,7 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterInstancetype
 metadata:
   labels:
+    instancetype.kubevirt.io/vendor: kubevirt.io
     kubevirt.io/size: tiny
   name: server.tiny
 spec:

--- a/data/common-instancetypes-bundle/common-clusterpreferences-bundle.yaml
+++ b/data/common-instancetypes-bundle/common-clusterpreferences-bundle.yaml
@@ -2,6 +2,8 @@
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  labels:
+    instancetype.kubevirt.io/vendor: kubevirt.io
   name: alpine
 spec:
   devices:
@@ -11,6 +13,8 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  labels:
+    instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.7
 spec:
   devices:
@@ -20,6 +24,8 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  labels:
+    instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.7.desktop
 spec:
   devices:
@@ -32,7 +38,9 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
-  name: centos.8
+  labels:
+    instancetype.kubevirt.io/vendor: kubevirt.io
+  name: centos.8.stream
 spec:
   devices:
     preferredDiskBus: virtio
@@ -41,7 +49,9 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
-  name: centos.8.desktop
+  labels:
+    instancetype.kubevirt.io/vendor: kubevirt.io
+  name: centos.8.stream.desktop
 spec:
   devices:
     preferredAutoattachInputDevice: true
@@ -53,7 +63,9 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
-  name: centos.9
+  labels:
+    instancetype.kubevirt.io/vendor: kubevirt.io
+  name: centos.9.stream
 spec:
   devices:
     preferredDiskBus: virtio
@@ -69,7 +81,9 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
-  name: centos.9.desktop
+  labels:
+    instancetype.kubevirt.io/vendor: kubevirt.io
+  name: centos.9.stream.desktop
 spec:
   devices:
     preferredAutoattachInputDevice: true
@@ -88,6 +102,8 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  labels:
+    instancetype.kubevirt.io/vendor: kubevirt.io
   name: cirros
 spec:
   devices:
@@ -97,7 +113,9 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
-  name: fedora.35
+  labels:
+    instancetype.kubevirt.io/vendor: kubevirt.io
+  name: fedora
 spec:
   devices:
     preferredDiskBus: virtio
@@ -113,22 +131,8 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
-  name: fedora.36
-spec:
-  devices:
-    preferredDiskBus: virtio
-    preferredInterfaceModel: virtio
-    preferredNetworkInterfaceMultiQueue: true
-    preferredRng: {}
-  features:
-    preferredSmm: {}
-  firmware:
-    preferredUseEfi: true
-    preferredUseSecureBoot: true
----
-apiVersion: instancetype.kubevirt.io/v1alpha2
-kind: VirtualMachineClusterPreference
-metadata:
+  labels:
+    instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.7
 spec:
   devices:
@@ -138,6 +142,8 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  labels:
+    instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.7.desktop
 spec:
   devices:
@@ -150,6 +156,8 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  labels:
+    instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.8
 spec:
   devices:
@@ -159,6 +167,8 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  labels:
+    instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.8.desktop
 spec:
   devices:
@@ -171,6 +181,8 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  labels:
+    instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.9
 spec:
   devices:
@@ -187,6 +199,8 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  labels:
+    instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.9.desktop
 spec:
   devices:
@@ -206,7 +220,9 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
-  name: ubuntu.18.04
+  labels:
+    instancetype.kubevirt.io/vendor: kubevirt.io
+  name: ubuntu
 spec:
   devices:
     preferredDiskBus: virtio
@@ -216,26 +232,8 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
-  name: ubuntu.20.04
-spec:
-  devices:
-    preferredDiskBus: virtio
-    preferredInterfaceModel: virtio
-    preferredRng: {}
----
-apiVersion: instancetype.kubevirt.io/v1alpha2
-kind: VirtualMachineClusterPreference
-metadata:
-  name: ubuntu.22.04
-spec:
-  devices:
-    preferredDiskBus: virtio
-    preferredInterfaceModel: virtio
-    preferredRng: {}
----
-apiVersion: instancetype.kubevirt.io/v1alpha2
-kind: VirtualMachineClusterPreference
-metadata:
+  labels:
+    instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.10
 spec:
   clock:
@@ -277,6 +275,8 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  labels:
+    instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.10.virtio
 spec:
   clock:
@@ -320,6 +320,8 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  labels:
+    instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.11
 spec:
   clock:
@@ -366,6 +368,8 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  labels:
+    instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.11.virtio
 spec:
   clock:
@@ -414,6 +418,8 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  labels:
+    instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k12
 spec:
   clock:
@@ -455,6 +461,8 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  labels:
+    instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k12.virtio
 spec:
   clock:
@@ -498,6 +506,8 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  labels:
+    instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k16
 spec:
   clock:
@@ -539,6 +549,8 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  labels:
+    instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k16.virtio
 spec:
   clock:
@@ -582,6 +594,8 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  labels:
+    instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k19
 spec:
   clock:
@@ -623,6 +637,8 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  labels:
+    instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k19.virtio
 spec:
   clock:
@@ -662,3 +678,101 @@ spec:
       tlbflush: {}
       vapic: {}
       vpindex: {}
+---
+apiVersion: instancetype.kubevirt.io/v1alpha2
+kind: VirtualMachineClusterPreference
+metadata:
+  labels:
+    instancetype.kubevirt.io/vendor: kubevirt.io
+  name: windows.2k22
+spec:
+  clock:
+    preferredClockOffset:
+      utc: {}
+    preferredTimer:
+      hpet:
+        present: false
+      hyperv: {}
+      pit:
+        tickPolicy: delay
+      rtc:
+        tickPolicy: catchup
+  cpu:
+    preferredCPUTopology: preferSockets
+  devices:
+    preferredAutoattachInputDevice: true
+    preferredDiskBus: sata
+    preferredInterfaceModel: e1000e
+    preferredTPM: {}
+  features:
+    preferredAcpi: {}
+    preferredApic: {}
+    preferredHyperv:
+      frequencies: {}
+      ipi: {}
+      reenlightenment: {}
+      relaxed: {}
+      reset: {}
+      runtime: {}
+      spinlocks:
+        spinlocks: 8191
+      synic: {}
+      synictimer:
+        direct: {}
+      tlbflush: {}
+      vapic: {}
+      vpindex: {}
+    preferredSmm: {}
+  firmware:
+    preferredUseEfi: true
+    preferredUseSecureBoot: true
+---
+apiVersion: instancetype.kubevirt.io/v1alpha2
+kind: VirtualMachineClusterPreference
+metadata:
+  labels:
+    instancetype.kubevirt.io/vendor: kubevirt.io
+  name: windows.2k22.virtio
+spec:
+  clock:
+    preferredClockOffset:
+      utc: {}
+    preferredTimer:
+      hpet:
+        present: false
+      hyperv: {}
+      pit:
+        tickPolicy: delay
+      rtc:
+        tickPolicy: catchup
+  cpu:
+    preferredCPUTopology: preferSockets
+  devices:
+    preferredAutoattachInputDevice: true
+    preferredDiskBus: virtio
+    preferredInputBus: virtio
+    preferredInputType: tablet
+    preferredInterfaceModel: virtio
+    preferredTPM: {}
+  features:
+    preferredAcpi: {}
+    preferredApic: {}
+    preferredHyperv:
+      frequencies: {}
+      ipi: {}
+      reenlightenment: {}
+      relaxed: {}
+      reset: {}
+      runtime: {}
+      spinlocks:
+        spinlocks: 8191
+      synic: {}
+      synictimer:
+        direct: {}
+      tlbflush: {}
+      vapic: {}
+      vpindex: {}
+    preferredSmm: {}
+  firmware:
+    preferredUseEfi: true
+    preferredUseSecureBoot: true


### PR DESCRIPTION
**What this PR does / why we need it**:

This is required as https://github.com/kubevirt/kubevirt/pull/8886 recently landed and blocks new instance types from being created with the `dedicatedCPUPlacement` attribute set.

https://github.com/kubevirt/common-instancetypes/releases/tag/v0.0.2-rc

**Which issue(s) this PR fixes**: 
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

Fixes #465

**Special notes for your reviewer**:

I've not had time to wrap this process in automation yet so this is a manual update. Hopefully automated by the next update.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
common-instancetypes has been updated to the v0.0.2-rc release.
```
