### PR TITLE
kubevirtci: Move to _cluster-up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,6 @@ bundle/*
 cover.out
 bundle.Dockerfile
 config/manager/manager.yaml
-cluster-up/
+_cluster-up/
 _kubevirt/
 

--- a/Makefile
+++ b/Makefile
@@ -280,20 +280,26 @@ generate-doc: build-docgen
 build-docgen:
 	go build -ldflags="-s -w" -o _out/metricsdocs ./tools/metricsdocs
 
+.PHONY: cluster-up
 cluster-up:
 	./hack/kubevirtci.sh up
 
+.PHONY: cluster-down
 cluster-down:
 	./hack/kubevirtci.sh down
 
+.PHONY: cluster-sync
 cluster-sync:
 	KUSTOMIZE=$(KUSTOMIZE) ./hack/kubevirtci.sh sync
 
+.PHONY: kubevirt-up
 kubevirt-up:
 	./hack/kubevirt.sh up
 
+.PHONY: kubevirt-down
 kubevirt-down:
 	./hack/kubevirt.sh down
 
+.PHONY: kubevirt-sync
 kubevirt-sync:
 	KUSTOMIZE=$(KUSTOMIZE) ./hack/kubevirt.sh sync

--- a/hack/kubevirtci.sh
+++ b/hack/kubevirtci.sh
@@ -20,20 +20,21 @@ export KUBEVIRTCI_TAG=${KUBEVIRTCI_TAG:-$(curl -sfL https://storage.googleapis.c
 export KUBEVIRT_DEPLOY_CDI="true"
 
 _base_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
-_kubectl="${_base_dir}/cluster-up/cluster-up/kubectl.sh"
-_kubessh="${_base_dir}/cluster-up/cluster-up/ssh.sh"
-_kubevirtcicli="${_base_dir}/cluster-up/cluster-up/cli.sh"
+_cluster_up_dir="${_base_dir}/_cluster_up"
+_kubectl="${_cluster_up_dir}/cluster-up/kubectl.sh"
+_kubessh="${_cluster_up_dir}/cluster-up/ssh.sh"
+_kubevirtcicli="${_cluster_up_dir}/cluster-up/cli.sh"
 _action=$1
 shift
 
 function kubevirtci::fetch_kubevirtci() {
-	if [[ ! -d ${_base_dir}/cluster-up ]]; then
-    git clone --depth 1 --branch "${KUBEVIRTCI_TAG}" https://github.com/kubevirt/kubevirtci.git "${_base_dir}"/cluster-up
+	if [[ ! -d ${_cluster_up_dir} ]]; then
+    git clone --depth 1 --branch "${KUBEVIRTCI_TAG}" https://github.com/kubevirt/kubevirtci.git "${_cluster_up_dir}"
   fi
 }
 
 function kubevirtci::up() {
-  make cluster-up -C "${_base_dir}/cluster-up"
+  make cluster-up -C "${_cluster_up_dir}"
   KUBECONFIG=$(kubevirtci::kubeconfig)
   export KUBECONFIG
   echo "adding kubevirtci registry to cdi-insecure-registries"
@@ -47,7 +48,7 @@ function kubevirtci::up() {
 }
 
 function kubevirtci::down() {
-  make cluster-down -C "${_base_dir}/cluster-up"
+  make cluster-down -C "${_cluster_up_dir}"
 }
 
 function kubevirtci::registry() {
@@ -60,7 +61,7 @@ function kubevirtci::sync() {
 }
 
 function kubevirtci::kubeconfig() {
-  "${_base_dir}/cluster-up/cluster-up/kubeconfig.sh"
+  "${_cluster_up_dir}/cluster-up/kubeconfig.sh"
 }
 
 kubevirtci::fetch_kubevirtci


### PR DESCRIPTION
**What this PR does / why we need it**:

Avoiding the situation where make thinks there's nothing to do because the directory of the same name as the target exists:

```
$ make cluster-up
make: 'cluster-up' is up to date.
```

**Which issue(s) this PR fixes**: 
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
