### PR TITLE
common-instancetypes: Add watched cluster CRDs to cleanup func test 

### DIFF
--- a/internal/operands/common-instancetypes/reconcile.go
+++ b/internal/operands/common-instancetypes/reconcile.go
@@ -77,11 +77,15 @@ func (c *commonInstancetypes) Name() string {
 	return operandName
 }
 
-func (c *commonInstancetypes) WatchClusterTypes() []operands.WatchType {
+func WatchClusterTypes() []operands.WatchType {
 	return []operands.WatchType{
 		{Object: &instancetypev1alpha2.VirtualMachineClusterInstancetype{}, Crd: instancetypeapi.ClusterPluralResourceName, WatchFullObject: true},
 		{Object: &instancetypev1alpha2.VirtualMachineClusterPreference{}, Crd: instancetypeapi.ClusterPluralPreferenceResourceName, WatchFullObject: true},
 	}
+}
+
+func (c *commonInstancetypes) WatchClusterTypes() []operands.WatchType {
+	return WatchClusterTypes()
 }
 
 func (c *commonInstancetypes) WatchTypes() []operands.WatchType {

--- a/tests/cleanup_test.go
+++ b/tests/cleanup_test.go
@@ -3,7 +3,6 @@ package tests
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	data_sources "kubevirt.io/ssp-operator/internal/operands/data-sources"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -12,7 +11,9 @@ import (
 	sspv1beta1 "kubevirt.io/ssp-operator/api/v1beta1"
 	"kubevirt.io/ssp-operator/internal/common"
 	"kubevirt.io/ssp-operator/internal/operands"
+	common_instancetypes "kubevirt.io/ssp-operator/internal/operands/common-instancetypes"
 	common_templates "kubevirt.io/ssp-operator/internal/operands/common-templates"
+	data_sources "kubevirt.io/ssp-operator/internal/operands/data-sources"
 	"kubevirt.io/ssp-operator/internal/operands/metrics"
 	nodelabeller "kubevirt.io/ssp-operator/internal/operands/node-labeller"
 	template_validator "kubevirt.io/ssp-operator/internal/operands/template-validator"
@@ -31,6 +32,7 @@ var _ = Describe("Cleanup", func() {
 		var allWatchTypes []operands.WatchType
 		for _, f := range []func() []operands.WatchType{
 			common_templates.WatchClusterTypes,
+			common_instancetypes.WatchClusterTypes,
 			data_sources.WatchClusterTypes,
 			metrics.WatchTypes,
 			metrics.WatchClusterTypes,

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -31,6 +31,7 @@ import (
 
 	"k8s.io/utils/pointer"
 	kubevirtv1 "kubevirt.io/api/core/v1"
+	instancetypev1alpha2 "kubevirt.io/api/instancetype/v1alpha2"
 	cdiv1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	lifecycleapi "kubevirt.io/controller-lifecycle-operator-sdk/api"
 	qe_reporters "kubevirt.io/qe-tools/pkg/ginkgo-reporters"
@@ -408,6 +409,7 @@ func setupApiClient() {
 	Expect(clientgoscheme.AddToScheme(testScheme)).ToNot(HaveOccurred())
 	Expect(os.Setenv(kubevirtv1.KubeVirtClientGoSchemeRegistrationVersionEnvVar, "v1")).ToNot(HaveOccurred())
 	Expect(kubevirtv1.AddToScheme(testScheme)).ToNot(HaveOccurred())
+	Expect(instancetypev1alpha2.AddToScheme(testScheme)).ToNot(HaveOccurred())
 
 	cfg, err := config.GetConfig()
 	Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
**What this PR does / why we need it**:

A quick follow up to https://github.com/kubevirt/ssp-operator/pull/467 to provide functional test coverage of the
behaviour through some existing but previously missed cleanup tests.

**Which issue(s) this PR fixes**: 
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

Fixes #

**Special notes for your reviewer**:
Draft until #467 lands.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
