### PR TITLE
Add `operator_health_impact` label to SSP alerts

### DIFF
--- a/internal/operands/metrics/resources.go
+++ b/internal/operands/metrics/resources.go
@@ -13,6 +13,7 @@ const (
 	MonitorNamespace             = "openshift-monitoring"
 	runbookURLBasePath           = "https://kubevirt.io/monitoring/runbooks/"
 	severityAlertLabelKey        = "severity"
+	healthImpactAlertLabelKey    = "operator_health_impact"
 	partOfAlertLabelKey          = "kubernetes_operator_part_of"
 	partOfAlertLabelValue        = "kubevirt"
 	componentAlertLabelKey       = "kubernetes_operator_component"
@@ -85,9 +86,10 @@ var alertRulesList = []promv1.Rule{
 			"runbook_url": runbookURLBasePath + "SSPOperatorDown",
 		},
 		Labels: map[string]string{
-			severityAlertLabelKey:  "critical",
-			partOfAlertLabelKey:    partOfAlertLabelValue,
-			componentAlertLabelKey: componentAlertLabelValue,
+			severityAlertLabelKey:     "critical",
+			healthImpactAlertLabelKey: "critical",
+			partOfAlertLabelKey:       partOfAlertLabelValue,
+			componentAlertLabelKey:    componentAlertLabelValue,
 		},
 	},
 	{
@@ -99,9 +101,10 @@ var alertRulesList = []promv1.Rule{
 			"runbook_url": runbookURLBasePath + "SSPTemplateValidatorDown",
 		},
 		Labels: map[string]string{
-			severityAlertLabelKey:  "critical",
-			partOfAlertLabelKey:    partOfAlertLabelValue,
-			componentAlertLabelKey: componentAlertLabelValue,
+			severityAlertLabelKey:     "critical",
+			healthImpactAlertLabelKey: "critical",
+			partOfAlertLabelKey:       partOfAlertLabelValue,
+			componentAlertLabelKey:    componentAlertLabelValue,
 		},
 	},
 	{
@@ -113,9 +116,10 @@ var alertRulesList = []promv1.Rule{
 			"runbook_url": runbookURLBasePath + "SSPFailingToReconcile",
 		},
 		Labels: map[string]string{
-			severityAlertLabelKey:  "critical",
-			partOfAlertLabelKey:    partOfAlertLabelValue,
-			componentAlertLabelKey: componentAlertLabelValue,
+			severityAlertLabelKey:     "critical",
+			healthImpactAlertLabelKey: "critical",
+			partOfAlertLabelKey:       partOfAlertLabelValue,
+			componentAlertLabelKey:    componentAlertLabelValue,
 		},
 	},
 	{
@@ -127,9 +131,10 @@ var alertRulesList = []promv1.Rule{
 			"runbook_url": runbookURLBasePath + "SSPHighRateRejectedVms",
 		},
 		Labels: map[string]string{
-			severityAlertLabelKey:  "warning",
-			partOfAlertLabelKey:    partOfAlertLabelValue,
-			componentAlertLabelKey: componentAlertLabelValue,
+			severityAlertLabelKey:     "warning",
+			healthImpactAlertLabelKey: "warning",
+			partOfAlertLabelKey:       partOfAlertLabelValue,
+			componentAlertLabelKey:    componentAlertLabelValue,
 		},
 	},
 	{
@@ -141,9 +146,10 @@ var alertRulesList = []promv1.Rule{
 			"runbook_url": runbookURLBasePath + "SSPCommonTemplatesModificationReverted",
 		},
 		Labels: map[string]string{
-			severityAlertLabelKey:  "warning",
-			partOfAlertLabelKey:    partOfAlertLabelValue,
-			componentAlertLabelKey: componentAlertLabelValue,
+			severityAlertLabelKey:     "warning",
+			healthImpactAlertLabelKey: "none",
+			partOfAlertLabelKey:       partOfAlertLabelValue,
+			componentAlertLabelKey:    componentAlertLabelValue,
 		},
 	},
 }

--- a/tests/metrics_test.go
+++ b/tests/metrics_test.go
@@ -277,6 +277,8 @@ var _ = Describe("Metrics", func() {
 					if rule.Alert != "" {
 						Expect(rule.Labels).To(HaveKeyWithValue("severity", BeElementOf("info", "warning", "critical")),
 							fmt.Sprintf("%s severity label is missing or not valid", rule.Alert))
+						Expect(rule.Labels).To(HaveKeyWithValue("operator_health_impact", BeElementOf("none", "warning", "critical")),
+							fmt.Sprintf("%s operator_health_impact label is missing or not valid", rule.Alert))
 						Expect(rule.Labels).To(HaveKeyWithValue("kubernetes_operator_part_of", "kubevirt"),
 							fmt.Sprintf("%s kubernetes_operator_part_of label is missing or not valid", rule.Alert))
 						Expect(rule.Labels).To(HaveKeyWithValue("kubernetes_operator_component", "ssp-operator"),


### PR DESCRIPTION
Signed-off-by: assafad <aadmi@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR adds to each of SSP alerts a label named `operator_health_impact`, which indicates how the alerts impact the operator health. This will enable us filtering alerts based on their impact on the operator health, and to later have an operator health metric, which will tell the user what is the aggregated operator health.

This label gets one of the following values:
- `critical` indicates that the alert fires due to an issue that impacts the operator's functionality badly, and an action must be taken immediately in order to solve it.
-  `warning` indicates that the alert fires due to an issue that soon might impact the operator's functionality badly, and the user should be warned in order to solve the issue.
- `none` indicates that the alert fires due to an issue that doesn't affect the operator health, and in most cases is related to the workload rather than the operator itself.

**Which issue(s) this PR fixes**: 
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
https://issues.redhat.com/browse/CNV-18923

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
