### PR TITLE
data_sources: Always run the operand

### DIFF
--- a/controllers/setup.go
+++ b/controllers/setup.go
@@ -57,6 +57,7 @@ func setupManager(ctx context.Context, cancel context.CancelFunc, mgr controller
 
 	sspOperands := []operands.Operand{
 		common_instancetypes_operand,
+		data_sources.New(templatesBundle.DataSources),
 	}
 
 	runningOnOpenShift, err := common.RunningOnOpenshift(ctx, mgr.GetAPIReader())
@@ -69,7 +70,6 @@ func setupManager(ctx context.Context, cancel context.CancelFunc, mgr controller
 			metrics.New(),
 			template_validator.New(),
 			common_templates.New(templatesBundle.Templates),
-			data_sources.New(templatesBundle.DataSources),
 			node_labeller.New(),
 		)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

The operand itself deploys DataImportCrons defined by the SSP CR and DataSources based on the provided common-templates bundle. While the latter functionality should likely reside in the common-templates operand the DataImportCrons functionaility is useful in non-OpenShift environments alongside that of the common-instancetypes operand.

This change now ensures the data_sources operand runs on both OpenShift and non-OpenShift environments.

**Which issue(s) this PR fixes**: 
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The `data_sources` operand is now always deployed, regardless of the underlying environment being OpenShift or OKD.
```
