### PR TITLE
metrics_test.go: Do not consider old ReplicaSets

### DIFF
--- a/tests/metrics_test.go
+++ b/tests/metrics_test.go
@@ -178,7 +178,10 @@ var _ = Describe("Metrics", func() {
 
 				for _, rs := range rsList.Items {
 					for _, env := range rs.Spec.Template.Spec.Containers[0].Env {
-						if env.Name == common.OperatorVersionKey && env.Value == version && rs.Status.ReadyReplicas == *rs.Spec.Replicas {
+						if env.Name == common.OperatorVersionKey &&
+							env.Value == version &&
+							*rs.Spec.Replicas > 0 &&
+							rs.Status.ReadyReplicas == *rs.Spec.Replicas {
 							return nil
 						}
 					}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This avoids picking up old ReplicaSets when waiting for a version update by checking if the desired count of pods is greater than 0.


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
