### PR TITLE
commonTemplates_test.go: Wait until restored templates increases

### DIFF
--- a/tests/commonTemplates_test.go
+++ b/tests/commonTemplates_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -357,5 +358,7 @@ var _ = Describe("Common templates", func() {
 func expectTemplateUpdateToIncreaseTotalRestoredTemplatesCount(testTemplate testResource) {
 	restoredCountBefore := totalRestoredTemplatesCount()
 	expectRestoreAfterUpdate(&testTemplate)
-	Expect(totalRestoredTemplatesCount() - restoredCountBefore).To(Equal(1))
+	Eventually(func() int {
+		return totalRestoredTemplatesCount() - restoredCountBefore
+	}, env.ShortTimeout(), time.Second).Should(Equal(1))
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This moves the check for the increased restored templates count into an Eventually block with a short timeout. This makes the test more robust by giving SSP some time to increase the count.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
