### PR TITLE
feat: bump golang version in ssp and validator containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal as builder
 
 RUN microdnf install -y make tar gzip which && microdnf clean all
 
-RUN curl -L https://go.dev/dl/go1.19.2.linux-amd64.tar.gz | tar -C /usr/local -xzf -
+RUN curl -L https://go.dev/dl/go1.19.5.linux-amd64.tar.gz | tar -C /usr/local -xzf -
 ENV PATH=$PATH:/usr/local/go/bin
 
 # Consume required variables so we can work with make

--- a/validator.Dockerfile
+++ b/validator.Dockerfile
@@ -1,7 +1,7 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal as builder
 
 RUN microdnf install -y make tar gzip which && microdnf clean all
-RUN curl -L https://go.dev/dl/go1.18.1.linux-amd64.tar.gz | tar -C /usr/local -xzf -
+RUN curl -L https://go.dev/dl/go1.19.5.linux-amd64.tar.gz | tar -C /usr/local -xzf -
 ENV PATH=$PATH:/usr/local/go/bin
 
 ARG VERSION=latest


### PR DESCRIPTION
**What this PR does / why we need it**:
feat: bump golang version in ssp and validator containers
this commit updates go version to latest available 1.19.5 in ssp and validator containers

Signed-off-by: Karel Šimon <ksimon@redhat.com>

**Release note**:
```
NONE
```
