### PR TITLE
fix: Do not set GOARCH to amd64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,8 @@ COPY hack/boilerplate.go.txt hack/boilerplate.go.txt
 COPY hack/csv-generator.go hack/csv-generator.go
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on make manager
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on make csv-generator
+RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on make manager
+RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on make csv-generator
 
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal

--- a/validator.Dockerfile
+++ b/validator.Dockerfile
@@ -22,7 +22,7 @@ COPY api/ api/
 COPY controllers/ controllers/
 COPY internal/ internal/
 
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -ldflags="-X 'kubevirt.io/ssp-operator/internal/template-validator/version.COMPONENT=$COMPONENT'\
+RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build -a -ldflags="-X 'kubevirt.io/ssp-operator/internal/template-validator/version.COMPONENT=$COMPONENT'\
 -X 'kubevirt.io/ssp-operator/internal/template-validator/version.VERSION=$VERSION'\
 -X 'kubevirt.io/ssp-operator/internal/template-validator/version.BRANCH=$BRANCH'\
 -X 'kubevirt.io/ssp-operator/internal/template-validator/version.REVISION=$REVISION'" -o kubevirt-template-validator internal/template-validator/main.go


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove the `GOARCH` variable when building container. It may be build for a different architecture.

**Release note**:
```release-note
None
```
