### PR TITLE
ci: add release-vm-console-proxy workflow

### DIFF
--- a/.github/workflows/release-vm-console-proxy.yaml
+++ b/.github/workflows/release-vm-console-proxy.yaml
@@ -1,0 +1,40 @@
+name: Release VM Console Proxy
+
+on:
+  repository_dispatch:
+    types: [release-vm-console-proxy]
+
+jobs:
+  release-vm-console-proxy:
+    name: Release VM Console Proxy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        if: ${{ github.event.client_payload.release_version }} != ''
+        uses: actions/checkout@v3
+      - run: |
+          RELEASE_VERSION=${{ github.event.client_payload.release_version }}
+          OUTPUT_FILE=./data/vm-console-proxy-bundle/vm-console-proxy.yaml
+          mkdir -p ./data/vm-console-proxy-bundle
+          curl -L https://github.com/kubevirt/vm-console-proxy/releases/download/${RELEASE_VERSION}/vm-console-proxy.yaml > ${OUTPUT_FILE}
+
+      - name: Create pull request
+        if: ${{ github.event.client_payload.release_version }} != ''
+        uses: peter-evans/create-pull-request@v4
+        with:
+          token: ${{ github.token }}
+          commit-message: "chore: update vm-console-proxy manifests to ${{ github.event.client_payload.release_version }}"
+          committer: GitHub <noreply@github.com>
+          author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+          signoff: true
+          branch: "vm-console-proxy-${{ github.event.client_payload.release_version }}"
+          delete-branch: true
+          title: "Update vm-console-proxy manifests to ${{ github.event.client_payload.release_version }}"
+          body: |
+            Update vm-console-proxy manifests to version ${{ github.event.client_payload.release_version }}
+
+            **Release note**:
+            ```release-note
+            Update vm-console-proxy-bundle to ${{ github.event.client_payload.release_version }}
+            ```
+          draft: false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This will add release vm-console-proxy workflow. This workflow will be triggered by another release workflow in vm-console-proxy repository.

**Special notes for your reviewer**:

It should be merged before we merge https://github.com/kubevirt/vm-console-proxy/pull/2.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
