### PR TITLE
lint: Introduce Makefile target, introduce pre-commit config and fix issues

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -6,3 +6,4 @@ linters:
   enable:
     - whitespace
     - misspell
+    - ginkgolinter

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,7 @@
+linters:
+  # Disable all linters.
+  disable-all: true
+  # Enable specific linter
+  # https://golangci-lint.run/usage/linters/#enabled-by-default
+  enable:
+    - whitespace

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -5,3 +5,4 @@ linters:
   # https://golangci-lint.run/usage/linters/#enabled-by-default
   enable:
     - whitespace
+    - misspell

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -7,3 +7,4 @@ linters:
     - whitespace
     - misspell
     - ginkgolinter
+    - errcheck

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -11,3 +11,4 @@ linters:
     - ineffassign
     - staticcheck
     - unused
+    - errname

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -9,3 +9,4 @@ linters:
     - ginkgolinter
     - errcheck
     - ineffassign
+    - staticcheck

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -10,3 +10,4 @@ linters:
     - errcheck
     - ineffassign
     - staticcheck
+    - unused

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -8,3 +8,4 @@ linters:
     - misspell
     - ginkgolinter
     - errcheck
+    - ineffassign

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,19 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-yaml
+    -   id: check-added-large-files
+    -   id: check-merge-conflict
+    -   id: check-executables-have-shebangs
+    -   id: check-shebang-scripts-are-executable
+    -   id: detect-private-key
+    -   id: mixed-line-ending
+-   repo: local
+    hooks:
+    -   id: lint
+        name: lint
+        language: system
+        entry: make lint

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,9 @@ COPY webhooks/ webhooks/
 COPY hack/boilerplate.go.txt hack/boilerplate.go.txt
 COPY hack/csv-generator.go hack/csv-generator.go
 
+# Copy .golangci.yaml so we can run lint as part of the build process
+COPY .golangci.yaml .golangci.yaml
+
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on make manager
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on make csv-generator

--- a/controllers/ssp_controller.go
+++ b/controllers/ssp_controller.go
@@ -627,7 +627,7 @@ func updateStatus(request *common.Request, reconcileResults []common.ReconcileRe
 func updateStatusMissingCrds(request *common.Request, missingCrds []string) error {
 	sspStatus := &request.Instance.Status
 
-	message := fmt.Sprintf("Requred CRDs are missing: %s", strings.Join(missingCrds, ", "))
+	message := fmt.Sprintf("Required CRDs are missing: %s", strings.Join(missingCrds, ", "))
 	conditionsv1.SetStatusCondition(&sspStatus.Conditions, conditionsv1.Condition{
 		Type:    conditionsv1.ConditionAvailable,
 		Status:  v1.ConditionFalse,

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	k8s.io/apiextensions-apiserver v0.25.0
 	k8s.io/apimachinery v0.25.0
 	k8s.io/client-go v12.0.0+incompatible
-	k8s.io/klog/v2 v2.70.1
+	k8s.io/klog/v2 v2.70.1 // indirect
 	k8s.io/kube-aggregator v0.24.2
 	k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed
 	kubevirt.io/api v0.58.0

--- a/hack/csv-generator.go
+++ b/hack/csv-generator.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 
 	"github.com/blang/semver/v4"
@@ -97,7 +96,7 @@ func init() {
 }
 
 func runGenerator() error {
-	csvFile, err := ioutil.ReadFile(f.file)
+	csvFile, err := os.ReadFile(f.file)
 	if err != nil {
 		return err
 	}
@@ -130,14 +129,19 @@ func runGenerator() error {
 	if !f.dumpCRDs {
 		return nil
 	}
-	files, err := ioutil.ReadDir("data/crd")
+	files, err := os.ReadDir("data/crd")
 	if err != nil {
 		return err
 	}
 	for _, file := range files {
 		crd := extv1.CustomResourceDefinition{}
 
-		err := readAndDecodeToCRD(file, &crd)
+		fsInfo, err := file.Info()
+		if err != nil {
+			return err
+		}
+
+		err = readAndDecodeToCRD(fsInfo, &crd)
 		if err != nil {
 			return err
 		}
@@ -151,7 +155,7 @@ func runGenerator() error {
 }
 
 func readAndDecodeToCRD(file os.FileInfo, crd *extv1.CustomResourceDefinition) error {
-	crdFile, err := ioutil.ReadFile(fmt.Sprintf("data/crd/%s", file.Name()))
+	crdFile, err := os.ReadFile(fmt.Sprintf("data/crd/%s", file.Name()))
 	if err != nil {
 		return err
 	}

--- a/hack/csv-generator_test.go
+++ b/hack/csv-generator_test.go
@@ -51,12 +51,12 @@ var _ = Describe("csv generator", func() {
 	}
 	It("should update csv", func() {
 		err := replaceVariables(flags, &csv)
-		Expect(err).To(BeNil())
+		Expect(err).ToNot(HaveOccurred())
 		//test csv name
 		Expect(csv.Name).To(Equal("ssp-operator.v9.9.9"))
 		//test csv version
 		v, err := semver.New(flags.csvVersion)
-		Expect(err).To(BeNil())
+		Expect(err).ToNot(HaveOccurred())
 		Expect(csv.Spec.Version).To(Equal(version.OperatorVersion{Version: *v}))
 
 		for _, container := range csv.Spec.InstallStrategy.StrategySpec.DeploymentSpecs[0].Spec.Template.Spec.Containers {

--- a/internal/common/environment.go
+++ b/internal/common/environment.go
@@ -3,7 +3,6 @@ package common
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -63,7 +62,7 @@ func GetInfrastructureTopology(ctx context.Context, c client.Reader) (osconfv1.T
 }
 
 func GetOperatorNamespace(logger logr.Logger) (string, error) {
-	nsBytes, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+	nsBytes, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
 	if err != nil {
 		return "", fmt.Errorf("in getOperatorNamespace failed in call to downward API: %w", err)
 	}

--- a/internal/common/resource_test.go
+++ b/internal/common/resource_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Resource", func() {
 		s := scheme.Scheme
 		Expect(ssp.AddToScheme(s)).ToNot(HaveOccurred())
 
-		client := fake.NewFakeClientWithScheme(s)
+		client := fake.NewClientBuilder().WithScheme(s).Build()
 		request = Request{
 			Request: reconcile.Request{
 				NamespacedName: types.NamespacedName{

--- a/internal/operands/common-instancetypes/reconcile.go
+++ b/internal/operands/common-instancetypes/reconcile.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -103,7 +102,7 @@ func decodeResources[C clusterType](b []byte) ([]C, error) {
 }
 
 func FetchBundleResource[C clusterType](path string) ([]C, error) {
-	file, err := ioutil.ReadFile(path)
+	file, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/operands/common-templates/reconcile_test.go
+++ b/internal/operands/common-templates/reconcile_test.go
@@ -200,7 +200,7 @@ var _ = Describe("Common-Templates operand", func() {
 			err = request.Client.Get(request.Context, key, updatedTpl)
 			Expect(err).ToNot(HaveOccurred(), "failed fetching updated template")
 
-			Expect(len(updatedTpl.GetOwnerReferences())).To(Equal(0), "ownerReferences exist for an older template")
+			Expect(updatedTpl.GetOwnerReferences()).To(BeEmpty(), "ownerReferences exist for an older template")
 			Expect(updatedTpl.GetAnnotations()[libhandler.NamespacedNameAnnotation]).ToNot(Equal(""), "owner name annotation is empty for an older template")
 			Expect(updatedTpl.GetAnnotations()[libhandler.TypeAnnotation]).ToNot(Equal(""), "owner type annotation is empty for an older template")
 		})

--- a/internal/operands/common-templates/reconcile_test.go
+++ b/internal/operands/common-templates/reconcile_test.go
@@ -51,7 +51,7 @@ var _ = Describe("Common-Templates operand", func() {
 		testTemplates = getTestTemplates()
 		operand = New(testTemplates)
 
-		client := fake.NewFakeClientWithScheme(common.Scheme)
+		client := fake.NewClientBuilder().WithScheme(common.Scheme).Build()
 		request = common.Request{
 			Request: reconcile.Request{
 				NamespacedName: types.NamespacedName{

--- a/internal/operands/common-templates/reconcile_test.go
+++ b/internal/operands/common-templates/reconcile_test.go
@@ -126,7 +126,7 @@ var _ = Describe("Common-Templates operand", func() {
 
 		BeforeEach(func() {
 			// Create a dummy template to act as an owner for the test template
-			// we can't use the SSP CR as an owner for these tests because the tempaltes
+			// we can't use the SSP CR as an owner for these tests because the templates
 			// might be deployed in a different namespace than the CR, and will be immediately
 			// removed by the GC, the choice to use a template as an owner object was arbitrary
 			parentTpl = &templatev1.Template{

--- a/internal/operands/data-sources/reconcile_test.go
+++ b/internal/operands/data-sources/reconcile_test.go
@@ -44,7 +44,7 @@ var _ = Describe("Data-Sources operand", func() {
 
 		operand = New(testDataSources)
 
-		client := fake.NewFakeClientWithScheme(common.Scheme)
+		client := fake.NewClientBuilder().WithScheme(common.Scheme).Build()
 		request = common.Request{
 			Request: reconcile.Request{
 				NamespacedName: types.NamespacedName{

--- a/internal/operands/metrics/reconcile_test.go
+++ b/internal/operands/metrics/reconcile_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Metrics operand", func() {
 	)
 
 	It("should create metrics resources", func() {
-		client := fake.NewFakeClientWithScheme(common.Scheme)
+		client := fake.NewClientBuilder().WithScheme(common.Scheme).Build()
 		request = common.Request{
 			Request: reconcile.Request{
 				NamespacedName: types.NamespacedName{

--- a/internal/operands/node-labeller/reconcile_test.go
+++ b/internal/operands/node-labeller/reconcile_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Node Labeller operand", func() {
 		Expect(ssp.AddToScheme(s)).ToNot(HaveOccurred())
 		Expect(secv1.Install(s)).ToNot(HaveOccurred())
 
-		client := fake.NewFakeClientWithScheme(s)
+		client := fake.NewClientBuilder().WithScheme(s).Build()
 		request = common.Request{
 			Request: reconcile.Request{
 				NamespacedName: types.NamespacedName{

--- a/internal/operands/node-labeller/reconcile_test.go
+++ b/internal/operands/node-labeller/reconcile_test.go
@@ -62,14 +62,20 @@ var _ = Describe("Node Labeller operand", func() {
 	})
 
 	It("should delete node-labeller during reconcile", func() {
-		reconcileClusterRole(&request)
-		reconcileServiceAccount(&request)
-		reconcileClusterRoleBinding(&request)
-		reconcileConfigMap(&request)
-		reconcileDaemonSet(&request)
-		reconcileSecurityContextConstraint(&request)
+		_, err := reconcileClusterRole(&request)
+		Expect(err).ToNot(HaveOccurred())
+		_, err = reconcileServiceAccount(&request)
+		Expect(err).ToNot(HaveOccurred())
+		_, err = reconcileClusterRoleBinding(&request)
+		Expect(err).ToNot(HaveOccurred())
+		_, err = reconcileConfigMap(&request)
+		Expect(err).ToNot(HaveOccurred())
+		_, err = reconcileDaemonSet(&request)
+		Expect(err).ToNot(HaveOccurred())
+		_, err = reconcileSecurityContextConstraint(&request)
+		Expect(err).ToNot(HaveOccurred())
 
-		_, err := operand.Reconcile(&request)
+		_, err = operand.Reconcile(&request)
 		Expect(err).ToNot(HaveOccurred())
 
 		ExpectResourceNotExists(newClusterRole(), request)

--- a/internal/operands/template-validator/reconcile_test.go
+++ b/internal/operands/template-validator/reconcile_test.go
@@ -149,7 +149,7 @@ var _ = Describe("Template validator operand", func() {
 	})
 
 	It("should report status", func() {
-		reconcileResults, err := operand.Reconcile(&request)
+		_, err := operand.Reconcile(&request)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Set status for deployment
@@ -162,7 +162,7 @@ var _ = Describe("Template validator operand", func() {
 			deployment.Status.UnavailableReplicas = replicas
 		})
 
-		reconcileResults, err = operand.Reconcile(&request)
+		reconcileResults, err := operand.Reconcile(&request)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Only deployment should be progressing

--- a/internal/operands/template-validator/reconcile_test.go
+++ b/internal/operands/template-validator/reconcile_test.go
@@ -44,7 +44,7 @@ var _ = Describe("Template validator operand", func() {
 		s := scheme.Scheme
 		Expect(ssp.AddToScheme(s)).ToNot(HaveOccurred())
 
-		client := fake.NewFakeClientWithScheme(s)
+		client := fake.NewClientBuilder().WithScheme(s).Build()
 		request = common.Request{
 			Request: reconcile.Request{
 				NamespacedName: types.NamespacedName{

--- a/internal/operands/vm-console-proxy/reconcile_test.go
+++ b/internal/operands/vm-console-proxy/reconcile_test.go
@@ -59,7 +59,7 @@ var _ = Describe("VM Console Proxy Operand", func() {
 		Expect(name).To(Equal(operandName), "should return correct name")
 	})
 
-	It("should return functions from reconcile correclty", func() {
+	It("should return functions from reconcile correctly", func() {
 		functions, err := operand.Reconcile(&request)
 		Expect(err).ToNot(HaveOccurred(), "should not throw err")
 		Expect(len(functions)).To(Equal(7), "should return correct number of reconcile functions")

--- a/internal/operands/vm-console-proxy/reconcile_test.go
+++ b/internal/operands/vm-console-proxy/reconcile_test.go
@@ -125,7 +125,7 @@ var _ = Describe("VM Console Proxy Operand", func() {
 	})
 
 	It("should report status", func() {
-		reconcileResults, err := operand.Reconcile(&request)
+		_, err := operand.Reconcile(&request)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Set status for deployment
@@ -138,7 +138,7 @@ var _ = Describe("VM Console Proxy Operand", func() {
 			deployment.Status.UnavailableReplicas = replicas
 		})
 
-		reconcileResults, err = operand.Reconcile(&request)
+		reconcileResults, err := operand.Reconcile(&request)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Only deployment should be progressing

--- a/internal/operands/vm-console-proxy/reconcile_test.go
+++ b/internal/operands/vm-console-proxy/reconcile_test.go
@@ -62,7 +62,7 @@ var _ = Describe("VM Console Proxy Operand", func() {
 	It("should return functions from reconcile correctly", func() {
 		functions, err := operand.Reconcile(&request)
 		Expect(err).ToNot(HaveOccurred(), "should not throw err")
-		Expect(len(functions)).To(Equal(7), "should return correct number of reconcile functions")
+		Expect(functions).To(HaveLen(7), "should return correct number of reconcile functions")
 	})
 
 	It("should create vm-console-proxy resources", func() {

--- a/internal/template-bundle/bundle.go
+++ b/internal/template-bundle/bundle.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 
 	templatev1 "github.com/openshift/api/template/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -37,7 +37,7 @@ func ReadBundle(filename string) (Bundle, error) {
 
 func readTemplates(filename string) ([]templatev1.Template, error) {
 	var bundle []templatev1.Template
-	file, err := ioutil.ReadFile(filename)
+	file, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/template-validator/service/service.go
+++ b/internal/template-validator/service/service.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 
 	flag "github.com/spf13/pflag"
-	"k8s.io/klog/v2"
 )
 
 var (
@@ -55,18 +54,8 @@ func Setup(service Service) {
 		panic(fmt.Sprintf("%v", err))
 	}
 
+	// FIXME - Remove call to AddGoFlagSet once glog is no longer an indirect dependency
+	// https://github.com/spf13/pflag/blob/master/README.md#supporting-go-flags-when-using-pflag
+	flag.CommandLine.AddGoFlagSet(goflag.CommandLine)
 	flag.Parse()
-
-	// borrowed from cdi/apiserver 1.9.5
-	klogFlags := goflag.NewFlagSet("klog", goflag.ExitOnError)
-	klog.InitFlags(klogFlags)
-	flag.CommandLine.VisitAll(func(f1 *flag.Flag) {
-		f2 := klogFlags.Lookup(f1.Name)
-		if f2 != nil {
-			value := f1.Value.String()
-			if err := f2.Value.Set(value); err != nil {
-				panic(fmt.Sprintf("%v", err))
-			}
-		}
-	})
 }

--- a/internal/template-validator/service/service.go
+++ b/internal/template-validator/service/service.go
@@ -48,8 +48,12 @@ func (service *ServiceLibvirt) AddLibvirtFlags() {
 func Setup(service Service) {
 	service.AddFlags()
 
-	flag.Set("v", defaultServiceVerbosity)
-	flag.Set("logtostderr", "true")
+	if err := flag.Set("v", defaultServiceVerbosity); err != nil {
+		panic(fmt.Sprintf("%v", err))
+	}
+	if err := flag.Set("logtostderr", "true"); err != nil {
+		panic(fmt.Sprintf("%v", err))
+	}
 
 	flag.Parse()
 
@@ -60,7 +64,9 @@ func Setup(service Service) {
 		f2 := klogFlags.Lookup(f1.Name)
 		if f2 != nil {
 			value := f1.Value.String()
-			f2.Value.Set(value)
+			if err := f2.Value.Set(value); err != nil {
+				panic(fmt.Sprintf("%v", err))
+			}
 		}
 	})
 }

--- a/internal/template-validator/tlsinfo/tlsinfo.go
+++ b/internal/template-validator/tlsinfo/tlsinfo.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -151,11 +150,11 @@ func loadCertificates(directory string) (serverCrt *tls.Certificate, err error) 
 	certPath := filepath.Join(directory, CertFilename)
 	keyPath := filepath.Join(directory, KeyFilename)
 
-	certBytes, err := ioutil.ReadFile(certPath)
+	certBytes, err := os.ReadFile(certPath)
 	if err != nil {
 		return nil, err
 	}
-	keyBytes, err := ioutil.ReadFile(keyPath)
+	keyBytes, err := os.ReadFile(keyPath)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/template-validator/tlsinfo/tlsinfo_test.go
+++ b/internal/template-validator/tlsinfo/tlsinfo_test.go
@@ -7,7 +7,6 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
-	"io/ioutil"
 	"math/big"
 	"os"
 	"path/filepath"
@@ -23,7 +22,7 @@ var _ = Describe("TlsInfo", func() {
 
 	BeforeEach(func() {
 		var err error
-		certDir, err = ioutil.TempDir("", "certs")
+		certDir, err = os.MkdirTemp("", "certs")
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -80,7 +79,7 @@ var _ = Describe("TlsInfo", func() {
 			return tlsConfig.GetCertificate(nil)
 		}, time.Second).ShouldNot(BeNil())
 
-		Expect(ioutil.WriteFile(filepath.Join(certDir, CertFilename), []byte{}, 0777)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(certDir, CertFilename), []byte{}, 0777)).To(Succeed())
 
 		Consistently(func() (*tls.Certificate, error) {
 			return tlsConfig.GetCertificate(nil)
@@ -123,8 +122,8 @@ func writeCertificate(dir string) {
 		Bytes: x509.MarshalPKCS1PrivateKey(key),
 	})
 
-	Expect(ioutil.WriteFile(filepath.Join(dir, CertFilename), certPEM, 0777)).To(Succeed())
-	Expect(ioutil.WriteFile(filepath.Join(dir, KeyFilename), keyPEM, 0777)).To(Succeed())
+	Expect(os.WriteFile(filepath.Join(dir, CertFilename), certPEM, 0777)).To(Succeed())
+	Expect(os.WriteFile(filepath.Join(dir, KeyFilename), keyPEM, 0777)).To(Succeed())
 }
 
 func TestTlsInfo(t *testing.T) {

--- a/internal/template-validator/validation/eval.go
+++ b/internal/template-validator/validation/eval.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -132,7 +131,7 @@ type Evaluator struct {
 }
 
 func NewEvaluator() *Evaluator {
-	return &Evaluator{Sink: ioutil.Discard}
+	return &Evaluator{Sink: io.Discard}
 }
 
 func validateRule(r *Rule) error {

--- a/internal/template-validator/validation/eval_test.go
+++ b/internal/template-validator/validation/eval_test.go
@@ -34,8 +34,8 @@ var _ = Describe("Eval", func() {
 
 			res := NewEvaluator().Evaluate(rules, &vm)
 			Expect(res.Succeeded()).To(BeFalse())
-			Expect(len(res.Status)).To(Equal(2))
-			Expect(res.Status[0].Error).To(BeNil())
+			Expect(res.Status).To(HaveLen(2))
+			Expect(res.Status[0].Error).ToNot(HaveOccurred())
 			Expect(res.Status[1].Error).To(Equal(ErrDuplicateRuleName))
 
 		})
@@ -51,7 +51,7 @@ var _ = Describe("Eval", func() {
 
 			res := NewEvaluator().Evaluate(rules, &vm)
 			Expect(res.Succeeded()).To(BeFalse())
-			Expect(len(res.Status)).To(Equal(1))
+			Expect(res.Status).To(HaveLen(1))
 			Expect(res.Status[0].Error).To(Equal(ErrMissingRequiredKey))
 		})
 
@@ -67,7 +67,7 @@ var _ = Describe("Eval", func() {
 
 			res := NewEvaluator().Evaluate(rules, &vm)
 			Expect(res.Succeeded()).To(BeFalse())
-			Expect(len(res.Status)).To(Equal(1))
+			Expect(res.Status).To(HaveLen(1))
 			Expect(res.Status[0].Error).To(Equal(ErrUnrecognizedRuleType))
 		})
 		It("Should detect unappliable rules", func() {
@@ -85,10 +85,10 @@ var _ = Describe("Eval", func() {
 			res := ev.Evaluate(rules, &vm)
 
 			Expect(res.Succeeded()).To(BeTrue())
-			Expect(len(res.Status)).To(Equal(1))
+			Expect(res.Status).To(HaveLen(1))
 			Expect(res.Status[0].Skipped).To(BeTrue())
 			Expect(res.Status[0].Satisfied).To(BeFalse())
-			Expect(res.Status[0].Error).To(BeNil())
+			Expect(res.Status[0].Error).ToNot(HaveOccurred())
 		})
 
 		It("Should not fail, when justWarning is set", func() {
@@ -109,10 +109,10 @@ var _ = Describe("Eval", func() {
 			res := ev.Evaluate(rules, &vm)
 
 			Expect(res.Succeeded()).To(BeTrue(), "succeeded")
-			Expect(len(res.Status)).To(Equal(1), "status length")
+			Expect(res.Status).To(HaveLen(1), "status length")
 			Expect(res.Status[0].Skipped).To(BeFalse(), "skipped")
 			Expect(res.Status[0].Satisfied).To(BeFalse(), "satisfied")
-			Expect(res.Status[0].Error).To(BeNil(), "error")
+			Expect(res.Status[0].Error).ToNot(HaveOccurred(), "error")
 		})
 	})
 
@@ -140,10 +140,10 @@ var _ = Describe("Eval", func() {
 			res := ev.Evaluate(rules, vmCirros)
 
 			Expect(res.Succeeded()).To(BeTrue())
-			Expect(len(res.Status)).To(Equal(1))
+			Expect(res.Status).To(HaveLen(1))
 			Expect(res.Status[0].Skipped).To(BeTrue())
 			Expect(res.Status[0].Satisfied).To(BeFalse())
-			Expect(res.Status[0].Error).To(BeNil())
+			Expect(res.Status[0].Error).ToNot(HaveOccurred())
 
 		})
 
@@ -193,7 +193,7 @@ var _ = Describe("Eval", func() {
 			Expect(res.Succeeded()).To(BeFalse())
 
 			causes := res.ToStatusCauses()
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 		})
 
 		It("should not fail, when justWarning is set", func() {
@@ -212,10 +212,10 @@ var _ = Describe("Eval", func() {
 			res := ev.Evaluate(rules, vmCirros)
 
 			Expect(res.Succeeded()).To(BeTrue(), "succeeded")
-			Expect(len(res.Status)).To(Equal(1), "status length")
+			Expect(res.Status).To(HaveLen(1), "status length")
 			Expect(res.Status[0].Skipped).To(BeFalse(), "skipped")
 			Expect(res.Status[0].Satisfied).To(BeFalse(), "satisfied")
-			Expect(res.Status[0].Error).To(BeNil(), "error")
+			Expect(res.Status[0].Error).ToNot(HaveOccurred(), "error")
 		})
 
 		It("should fail, when one rule does not have justWarning set", func() {
@@ -242,13 +242,13 @@ var _ = Describe("Eval", func() {
 			res := ev.Evaluate(rules, vmCirros)
 
 			Expect(res.Succeeded()).To(BeFalse(), "succeeded")
-			Expect(len(res.Status)).To(Equal(2), "status length")
+			Expect(res.Status).To(HaveLen(2), "status length")
 			Expect(res.Status[0].Skipped).To(BeFalse(), "skipped")
 			Expect(res.Status[0].Satisfied).To(BeFalse(), "satisfied")
-			Expect(res.Status[0].Error).To(BeNil(), "error")
+			Expect(res.Status[0].Error).ToNot(HaveOccurred(), "error")
 			Expect(res.Status[1].Skipped).To(BeFalse(), "skipped")
 			Expect(res.Status[1].Satisfied).To(BeFalse(), "satisfied")
-			Expect(res.Status[1].Error).To(BeNil(), "error")
+			Expect(res.Status[1].Error).ToNot(HaveOccurred(), "error")
 		})
 	})
 
@@ -288,10 +288,10 @@ var _ = Describe("Eval", func() {
 				fmt.Fprintf(GinkgoWriter, "%+#v", res.Status[ix])
 			}
 
-			Expect(len(res.Status)).To(Equal(len(rules)))
+			Expect(res.Status).To(HaveLen(len(rules)))
 			for ix := range res.Status {
 				Expect(res.Status[ix].Satisfied).To(BeTrue())
-				Expect(res.Status[ix].Error).To(BeNil())
+				Expect(res.Status[ix].Error).ToNot(HaveOccurred())
 			}
 		})
 
@@ -346,15 +346,15 @@ var _ = Describe("Eval", func() {
 			}
 
 			Expect(res.Succeeded()).To(BeFalse(), "succeeded")
-			Expect(len(res.Status)).To(Equal(2), "status length")
+			Expect(res.Status).To(HaveLen(2), "status length")
 			//status for second rule which should pass
 			Expect(res.Status[0].Skipped).To(BeFalse(), "skipped")
 			Expect(res.Status[0].Satisfied).To(BeFalse(), "satisfied")
-			Expect(res.Status[0].Error).NotTo(BeNil(), "error") // expects invalid JSONPath
+			Expect(res.Status[0].Error).To(HaveOccurred(), "error") // expects invalid JSONPath
 
 			Expect(res.Status[1].Skipped).To(BeFalse(), "skipped")
 			Expect(res.Status[1].Satisfied).To(BeTrue(), "satisfied")
-			Expect(res.Status[1].Error).To(BeNil(), "error")
+			Expect(res.Status[1].Error).ToNot(HaveOccurred(), "error")
 		})
 	})
 })

--- a/internal/template-validator/validation/path/path_test.go
+++ b/internal/template-validator/validation/path/path_test.go
@@ -44,7 +44,7 @@ var _ = Describe("Path", func() {
 			for _, s := range testStrings {
 				p, err := NewJSONPathFromString(s)
 				Expect(p).To(Equal(expected))
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 			}
 		})
 	})
@@ -62,7 +62,7 @@ var _ = Describe("Path", func() {
 		It("Should return error", func() {
 			p, err := New("jsonpath::.spec.this.path.does.not.exist")
 			Expect(p).To(Not(BeNil()))
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 
 			_, err = p.Find(vmCirros)
 			Expect(err).To(Equal(ErrInvalidJSONPath))
@@ -71,7 +71,7 @@ var _ = Describe("Path", func() {
 		It("Should detect malformed path", func() {
 			p, err := New("jsonpath::random56junk%(*$%&*()")
 			Expect(p).To(BeNil())
-			Expect(err).To(Not(BeNil()))
+			Expect(err).To(HaveOccurred())
 		})
 	})
 
@@ -89,15 +89,15 @@ var _ = Describe("Path", func() {
 			s := "jsonpath::.spec.domain.resources.requests.memory"
 			p, err := New(s)
 			Expect(p).To(Not(BeNil()))
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 
 			results, err := p.Find(vmCirros)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(results.Len()).To(BeNumerically(">=", 1))
 
 			vals, err := results.AsInt64()
-			Expect(err).To(BeNil())
-			Expect(len(vals)).To(Equal(1))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(vals).To(HaveLen(1))
 			Expect(vals[0]).To(BeNumerically(">", 1024))
 		})
 
@@ -105,15 +105,15 @@ var _ = Describe("Path", func() {
 			s := "jsonpath::.spec.domain.machine.type"
 			p, err := New(s)
 			Expect(p).To(Not(BeNil()))
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 
 			results, err := p.Find(vmCirros)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(results.Len()).To(BeNumerically(">=", 1))
 
 			vals, err := results.AsString()
-			Expect(err).To(BeNil())
-			Expect(len(vals)).To(Equal(1))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(vals).To(HaveLen(1))
 			Expect(vals[0]).To(Equal("q35"))
 		})
 

--- a/internal/template-validator/validation/rules_test.go
+++ b/internal/template-validator/validation/rules_test.go
@@ -14,7 +14,7 @@ var _ = Describe("Rules", func() {
 			rules, err := ParseRules([]byte(""))
 
 			Expect(err).To(Not(HaveOccurred()))
-			Expect(len(rules)).To(Equal(0))
+			Expect(rules).To(BeEmpty())
 		})
 	})
 
@@ -32,7 +32,7 @@ var _ = Describe("Rules", func() {
 			rules, err := ParseRules([]byte(text))
 
 			Expect(err).To(Not(HaveOccurred()))
-			Expect(len(rules)).To(Equal(1))
+			Expect(rules).To(HaveLen(1))
 		})
 
 		It("Should parse multiple rules", func() {
@@ -54,7 +54,7 @@ var _ = Describe("Rules", func() {
 			rules, err := ParseRules([]byte(text))
 
 			Expect(err).To(Not(HaveOccurred()))
-			Expect(len(rules)).To(Equal(2))
+			Expect(rules).To(HaveLen(2))
 		})
 		It("Should apply on a relevant VM", func() {
 			vm := test_utils.NewVMCirros()

--- a/internal/template-validator/validation/specialized_test.go
+++ b/internal/template-validator/validation/specialized_test.go
@@ -118,7 +118,7 @@ var _ = Describe("Specialized", func() {
 			}
 
 			ra, err := r.Specialize(vmCirros, vmRef)
-			Expect(err).To(Not(BeNil()))
+			Expect(err).To(HaveOccurred())
 			Expect(ra).To(BeNil())
 		})
 
@@ -246,12 +246,12 @@ var _ = Describe("Specialized", func() {
 				Max:     &path.IntOrPath{Int: 512 * 1024 * 1024},
 			}
 			ra, err := r.Specialize(vmCirros, vmRef)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(ra).To(Not(BeNil()))
 
 			ok, err := ra.Apply(vmCirros, vmRef)
-			Expect(err).To(BeNil())
-			Expect(ok).To(Equal(false))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ok).To(BeFalse())
 
 			result := ra.String()
 			Expect(result).To(Equal("value 1000000 is lower than minimum [67108864]"))
@@ -271,12 +271,12 @@ var _ = Describe("Specialized", func() {
 				Max:     &path.IntOrPath{Int: 512 * 1024 * 1024},
 			}
 			ra, err := r.Specialize(vmCirros, vmRef)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(ra).To(Not(BeNil()))
 
 			ok, err := ra.Apply(vmCirros, vmRef)
-			Expect(err).To(BeNil())
-			Expect(ok).To(Equal(false))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ok).To(BeFalse())
 
 			result := ra.String()
 			Expect(result).To(Equal("value 10000000000 is higher than maximum [536870912]"))
@@ -296,12 +296,12 @@ var _ = Describe("Specialized", func() {
 				Max:     &path.IntOrPath{Int: 512 * 1024 * 1024},
 			}
 			ra, err := r.Specialize(vmCirros, vmRef)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(ra).To(Not(BeNil()))
 
 			ok, err := ra.Apply(vmCirros, vmRef)
-			Expect(err).To(BeNil())
-			Expect(ok).To(Equal(true))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ok).To(BeTrue())
 
 			result := ra.String()
 			Expect(result).To(Equal("All values [68000000] are in interval [67108864, 536870912]"))
@@ -320,7 +320,7 @@ func expectRuleApplicationFailure(r *Rule, vm, ref *kubevirtv1.VirtualMachine) {
 
 func expectRuleApplicationError(r *Rule, vm, ref *kubevirtv1.VirtualMachine) {
 	ra, err := r.Specialize(vm, ref)
-	Expect(err).To(BeNil())
+	Expect(err).ToNot(HaveOccurred())
 	Expect(ra).To(Not(BeNil()))
 
 	_, err = ra.Apply(vm, ref)
@@ -329,10 +329,10 @@ func expectRuleApplicationError(r *Rule, vm, ref *kubevirtv1.VirtualMachine) {
 
 func checkRuleApplication(r *Rule, vm, ref *kubevirtv1.VirtualMachine, expected bool) {
 	ra, err := r.Specialize(vm, ref)
-	Expect(err).To(BeNil())
+	Expect(err).ToNot(HaveOccurred())
 	Expect(ra).To(Not(BeNil()))
 
 	ok, err := ra.Apply(vm, ref)
-	Expect(err).To(BeNil())
+	Expect(err).ToNot(HaveOccurred())
 	Expect(ok).To(Equal(expected))
 }

--- a/internal/template-validator/virtinformers/vmcache.go
+++ b/internal/template-validator/virtinformers/vmcache.go
@@ -231,7 +231,7 @@ func (v *vmCache) Replace(list []interface{}, _ string) error {
 	}
 
 	v.lock.Lock()
-	v.lock.Unlock()
+	defer v.lock.Unlock()
 
 	v.store = newStore
 	v.vmsForTemplate = newVmsForTemplate

--- a/internal/template-validator/virtinformers/vmcache_test.go
+++ b/internal/template-validator/virtinformers/vmcache_test.go
@@ -224,7 +224,6 @@ func keyFromObject(obj metav1.Object) string {
 }
 
 func newObject(name, template string) metav1.Object {
-
 	return &metav1.ObjectMeta{
 		Name:      name,
 		Namespace: testVmNamespace,

--- a/internal/template-validator/webhooks/admission_test.go
+++ b/internal/template-validator/webhooks/admission_test.go
@@ -22,7 +22,7 @@ var _ = Describe("Admission", func() {
 
 			causes := ValidateVm(rules, &newVM)
 
-			Expect(len(causes)).To(Equal(0))
+			Expect(causes).To(BeEmpty())
 		})
 	})
 
@@ -56,7 +56,7 @@ var _ = Describe("Admission", func() {
 			}}
 
 			causes := ValidateVm(rules, &vm)
-			Expect(len(causes)).To(Equal(0))
+			Expect(causes).To(BeEmpty())
 		})
 
 		It("should set default cores", func() {
@@ -69,7 +69,7 @@ var _ = Describe("Admission", func() {
 			}}
 
 			causes := ValidateVm(rules, &vm)
-			Expect(len(causes)).To(Equal(0))
+			Expect(causes).To(BeEmpty())
 		})
 
 		It("should set default threads", func() {
@@ -82,7 +82,7 @@ var _ = Describe("Admission", func() {
 			}}
 
 			causes := ValidateVm(rules, &vm)
-			Expect(len(causes)).To(Equal(0))
+			Expect(causes).To(BeEmpty())
 		})
 	})
 
@@ -108,7 +108,7 @@ var _ = Describe("Admission", func() {
 			vmRules, err := getValidationRulesForVM(vm, nil)
 			Expect(err).ToNot(HaveOccurred())
 
-			Expect(len(vmRules)).To(Equal(1))
+			Expect(vmRules).To(HaveLen(1))
 			Expect(vmRules[0].Name).To(Equal(ruleName))
 			Expect(vmRules[0].Path.Expr()).To(Equal(".test.path"))
 		})

--- a/internal/template-validator/webhooks/utils.go
+++ b/internal/template-validator/webhooks/utils.go
@@ -3,7 +3,7 @@ package validating
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	templatev1 "github.com/openshift/api/template/v1"
@@ -16,7 +16,7 @@ import (
 func GetAdmissionReview(r *http.Request) (*admissionv1.AdmissionReview, error) {
 	var body []byte
 	if r.Body != nil {
-		if data, err := ioutil.ReadAll(r.Body); err == nil {
+		if data, err := io.ReadAll(r.Body); err == nil {
 			body = data
 		}
 	}

--- a/tests/commonTemplates_test.go
+++ b/tests/commonTemplates_test.go
@@ -231,7 +231,7 @@ var _ = Describe("Common templates", func() {
 
 		BeforeEach(func() {
 			// Create a dummy template to act as an owner for the test template
-			// we can't use the SSP CR as an owner for these tests because the tempaltes
+			// we can't use the SSP CR as an owner for these tests because the templates
 			// might be deployed in a different namespace than the CR, and will be immediately
 			// removed by the GC, the choice to use a template as an owner object was arbitrary
 			ownerTemplate = &templatev1.Template{

--- a/tests/commonTemplates_test.go
+++ b/tests/commonTemplates_test.go
@@ -155,7 +155,7 @@ var _ = Describe("Common templates", func() {
 
 				namespaceObj = &v1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: "ssp-operator-functests-new-templates"}}
 				err := apiClient.Create(ctx, namespaceObj)
-				Expect(err).To(BeNil(), "err should be nil")
+				Expect(err).ToNot(HaveOccurred(), "err should be nil")
 
 				newTemplateNamespace = namespaceObj.GetName()
 			})
@@ -163,7 +163,7 @@ var _ = Describe("Common templates", func() {
 			AfterEach(func() {
 				strategy.RevertToOriginalSspCr()
 				err := apiClient.Delete(ctx, namespaceObj)
-				Expect(err).To(BeNil(), "err should be nil")
+				Expect(err).ToNot(HaveOccurred(), "err should be nil")
 			})
 
 			It("[test_id:6057] should update commonTemplates.namespace", func() {
@@ -325,7 +325,7 @@ var _ = Describe("Common templates", func() {
 					commonTemplates.TemplateVersionLabel: commonTemplates.Version,
 				})
 			Expect(err).ToNot(HaveOccurred())
-			Expect(len(latestTemplates.Items)).To(BeNumerically(">", 0), "Latest templates are missing")
+			Expect(latestTemplates.Items).ToNot(BeEmpty(), "Latest templates are missing")
 
 			for _, template := range latestTemplates.Items {
 				for label, value := range template.Labels {

--- a/tests/crypto_policy_test.go
+++ b/tests/crypto_policy_test.go
@@ -125,7 +125,7 @@ func operatorPod() core.Pod {
 	err := apiClient.List(context.TODO(), pods, client.MatchingLabels{"control-plane": "ssp-operator"})
 	Expect(err).ToNot(HaveOccurred())
 	Expect(pods.Items).ToNot(BeEmpty())
-	Expect(len(pods.Items)).To(Equal(1))
+	Expect(pods.Items).To(HaveLen(1))
 	return pods.Items[0]
 }
 

--- a/tests/metrics_test_utils.go
+++ b/tests/metrics_test_utils.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"regexp"
@@ -35,7 +35,7 @@ func intMetricValue(metricName string, metricsPort uint16, pod *v1.Pod) int {
 	resp, err := client.Get(fmt.Sprintf("https://localhost:%d/metrics", metricsPort))
 	Expect(err).ToNot(HaveOccurred(), "Can't get metrics from %s", pod.Name)
 	defer resp.Body.Close()
-	body, _ := ioutil.ReadAll(resp.Body)
+	body, _ := io.ReadAll(resp.Body)
 	regex, ok := regexpForMetrics[metricName]
 	if !ok {
 		panic(fmt.Sprintf("metricName %s does not have a defined regexp string, please add one to the regexpForMetrics map", metricName))

--- a/tools/metricsdocs/metricsdocs.go
+++ b/tools/metricsdocs/metricsdocs.go
@@ -2,9 +2,9 @@ package main
 
 import (
 	"fmt"
-	"kubevirt.io/ssp-operator/internal/operands/metrics"
 	"sort"
-	"strings"
+
+	"kubevirt.io/ssp-operator/internal/operands/metrics"
 )
 
 const (
@@ -81,14 +81,6 @@ func (m metricList) Less(i, j int) bool {
 // Swap implements sort.Interface.Swap
 func (m metricList) Swap(i, j int) {
 	m[i], m[j] = m[j], m[i]
-}
-
-func (m *metricList) add(line string) {
-	split := strings.Split(line, " ")
-	name := split[2]
-	split[3] = strings.Title(split[3])
-	description := strings.Join(split[3:], " ")
-	*m = append(*m, metric{name: name, description: description})
 }
 
 func (m metricList) writeOut() {

--- a/webhooks/ssp_webhook_test.go
+++ b/webhooks/ssp_webhook_test.go
@@ -47,9 +47,9 @@ var _ = Describe("SSP Validation", func() {
 	JustBeforeEach(func() {
 		scheme := runtime.NewScheme()
 		// add our own scheme
-		sspv1beta1.SchemeBuilder.AddToScheme(scheme)
+		Expect(sspv1beta1.SchemeBuilder.AddToScheme(scheme)).To(Succeed())
 		// add more schemes
-		v1.AddToScheme(scheme)
+		Expect(v1.AddToScheme(scheme)).To(Succeed())
 
 		client = fake.NewFakeClientWithScheme(scheme, objects...)
 

--- a/webhooks/ssp_webhook_test.go
+++ b/webhooks/ssp_webhook_test.go
@@ -264,14 +264,6 @@ var _ = Describe("SSP Validation", func() {
 	})
 })
 
-func checkExpectedError(err error, shouldFail bool) {
-	if shouldFail {
-		ExpectWithOffset(1, err).To(HaveOccurred())
-	} else {
-		ExpectWithOffset(1, err).NotTo(HaveOccurred())
-	}
-}
-
 func TestWebhook(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "API Suite")

--- a/webhooks/ssp_webhook_test.go
+++ b/webhooks/ssp_webhook_test.go
@@ -51,7 +51,7 @@ var _ = Describe("SSP Validation", func() {
 		// add more schemes
 		Expect(v1.AddToScheme(scheme)).To(Succeed())
 
-		client = fake.NewFakeClientWithScheme(scheme, objects...)
+		client = fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objects...).Build()
 
 		validator = newSspValidator(client)
 		ctx = context.Background()


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a `lint` Makefile target using `golangci-lint` initially with the following plugins enabled:

* whitespace
* misspell
* ginkgolinter
* errcheck
* ineffassign
* staticcheck
* unused
* errname

Additionally provides a `pre-commit` config users can opt into using to help catch issues before committing changes locally.

**Which issue(s) this PR fixes**: 
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
