### PR TITLE
fix: Use defer when unlocking a lock

### DIFF
--- a/internal/template-validator/virtinformers/vmcache.go
+++ b/internal/template-validator/virtinformers/vmcache.go
@@ -231,7 +231,7 @@ func (v *vmCache) Replace(list []interface{}, _ string) error {
 	}
 
 	v.lock.Lock()
-	v.lock.Unlock()
+	defer v.lock.Unlock()
 
 	v.store = newStore
 	v.vmsForTemplate = newVmsForTemplate


### PR DESCRIPTION
**What this PR does / why we need it**:
A mutex was incorrectly unlocked right after locking it.

**Release note**:
```release-note
None
```
