### PR TITLE
Use `RUNBOOK_URL_TEMPLATE` env for the runbooks URL template

### DIFF
--- a/internal/operands/metrics/reconcile.go
+++ b/internal/operands/metrics/reconcile.go
@@ -111,8 +111,13 @@ func reconcileMonitoringRbacRoleBinding(request *common.Request) (common.Reconci
 }
 
 func reconcilePrometheusRule(request *common.Request) (common.ReconcileResult, error) {
+	prometheusRule, err := newPrometheusRule(request.Namespace)
+	if err != nil {
+		return common.ReconcileResult{}, err
+	}
+
 	return common.CreateOrUpdate(request).
-		NamespacedResource(newPrometheusRule(request.Namespace)).
+		NamespacedResource(prometheusRule).
 		WithAppLabels(operandName, operandComponent).
 		UpdateFunc(func(newRes, foundRes client.Object) {
 			foundRes.(*promv1.PrometheusRule).Spec = newRes.(*promv1.PrometheusRule).Spec

--- a/internal/operands/metrics/reconcile_test.go
+++ b/internal/operands/metrics/reconcile_test.go
@@ -2,6 +2,9 @@ package metrics
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"strings"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -30,7 +33,7 @@ var _ = Describe("Metrics operand", func() {
 		operand = New()
 	)
 
-	It("should create metrics resources", func() {
+	BeforeEach(func() {
 		client := fake.NewClientBuilder().WithScheme(common.Scheme).Build()
 		request = common.Request{
 			Request: reconcile.Request{
@@ -54,14 +57,55 @@ var _ = Describe("Metrics operand", func() {
 			Logger:       log,
 			VersionCache: common.VersionCache{},
 		}
+	})
 
+	AfterEach(func() {
+		os.Unsetenv(runbookURLTemplateEnv)
+	})
+
+	It("should create metrics resources", func() {
 		_, err := operand.Reconcile(&request)
 		Expect(err).ToNot(HaveOccurred())
-		ExpectResourceExists(newPrometheusRule(namespace), request)
+
+		prometheusRule, err := newPrometheusRule(namespace)
+		Expect(err).ToNot(HaveOccurred())
+
+		ExpectResourceExists(prometheusRule, request)
 		ExpectResourceExists(newServiceMonitorCR(namespace), request)
 		ExpectResourceExists(newMonitoringClusterRole(), request)
 		ExpectResourceExists(newMonitoringClusterRoleBinding(), request)
 	})
+
+	DescribeTable("runbook URL template",
+		func(template string) {
+			if template != defaultRunbookURLTemplate {
+				os.Setenv(runbookURLTemplateEnv, template)
+			}
+
+			prometheusRule, err := newPrometheusRule(namespace)
+
+			if strings.Count(template, "%s") != 1 || strings.Count(template, "%") != 1 {
+				Expect(err).To(HaveOccurred())
+				return
+			}
+
+			Expect(err).ToNot(HaveOccurred())
+
+			for _, group := range prometheusRule.Spec.Groups {
+				for _, rule := range group.Rules {
+					if rule.Alert != "" {
+						if rule.Annotations["runbook_url"] != "" {
+							Expect(rule.Annotations["runbook_url"]).To(Equal(fmt.Sprintf(template, rule.Alert)))
+						}
+					}
+				}
+			}
+		},
+		Entry("should use the default template when no ENV variable is set", defaultRunbookURLTemplate),
+		Entry("should use the ENV variable when a valid value is set", "valid/runbookURL/template/%s"),
+		Entry("should throw an error when the ENV variable value doesn't contain a string format placeholder", "invalid/runbookURL/template/"),
+		Entry("should throw an error when the ENV variable value contains an integer format placeholder", "invalid/runbookURL/template/%d"),
+	)
 })
 
 func TestMetrics(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
When `RUNBOOK_URL_TEMPLATE` env variable is set, its value will be used as the runbooks URL template. Otherwise, keep using the default runbook URL template `https://kubevirt.io/monitoring/runbooks/%s`. 
This allows using different runbooks versions, in accordance with the installation.

**Which issue(s) this PR fixes**: 
Jira-ticket - https://issues.redhat.com/browse/CNV-14382

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
