### PR TITLE
[release-v0.17] fix: console proxy and tests: Stabilize functional tests

### DIFF
--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -202,6 +202,7 @@ func (s *newSspStrategy) GetSSPWebhookServiceName() string {
 func (s *newSspStrategy) RevertToOriginalSspCr() {
 	waitForSspDeletionIfNeeded(s.ssp)
 	createOrUpdateSsp(s.ssp)
+	waitUntilDeployed()
 }
 
 func (s *newSspStrategy) SkipSspUpdateTestsIfNeeded() {
@@ -347,6 +348,7 @@ func (s *existingSspStrategy) GetSSPWebhookServiceName() string {
 func (s *existingSspStrategy) RevertToOriginalSspCr() {
 	waitForSspDeletionIfNeeded(s.ssp)
 	createOrUpdateSsp(s.ssp)
+	waitUntilDeployed()
 }
 
 func (s *existingSspStrategy) SkipSspUpdateTestsIfNeeded() {


### PR DESCRIPTION
This is a backport of: https://github.com/kubevirt/ssp-operator/pull/527

**What this PR does / why we need it**:
This PR contains 2 changes to make functional tests less flaky:

Functions `RevertToOriginalSspCr()` now wait until SSP is deployed before returning.
This is useful, because reverting SSP may change TLS policy, which causes the pod to crash, and it may be some time before it is running again. If in the meantime, another test tries to update the SSP, it will fail, because the webhook cannot be reached.

When the annotation `ssp.kubevirt.io/vm-console-proxy-enabled` is removed from SSP CR, the operator waits for resources to be removed before setting the `status.phase` to `Deployed`.

**Release note**:
```release-note
None
```
