### PR TITLE
Use ImagePullPolicy: IfNotPresent instead of Always

### DIFF
--- a/internal/operands/template-validator/resources.go
+++ b/internal/operands/template-validator/resources.go
@@ -184,7 +184,7 @@ func newDeployment(namespace string, replicas int32, image string, sspTLSOptions
 					Containers: []core.Container{{
 						Name:            "webhook",
 						Image:           image,
-						ImagePullPolicy: core.PullAlways,
+						ImagePullPolicy: core.PullIfNotPresent,
 						Resources: core.ResourceRequirements{
 							Requests: core.ResourceList{
 								core.ResourceCPU:    resource.MustParse("50m"),

--- a/internal/operands/vm-console-proxy/reconcile_test.go
+++ b/internal/operands/vm-console-proxy/reconcile_test.go
@@ -355,7 +355,7 @@ func getMockedTestBundle() *vm_console_proxy_bundle.Bundle {
 						Containers: []core.Container{{
 							Name:            "console",
 							Image:           image,
-							ImagePullPolicy: core.PullAlways,
+							ImagePullPolicy: core.PullIfNotPresent,
 							Resources: core.ResourceRequirements{
 								Requests: core.ResourceList{
 									core.ResourceCPU:    resource.MustParse("200m"),


### PR DESCRIPTION
Currently, if the registry is temporarily unavailable, the virt-template validator pod fails to launch, although the image was pulled onto the cluster earlier. By changing the ImagePullPolicy to IfNotPresent, the cluster won't try to pull again the image if the same image was pulled before.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**: 
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

Fixes #
https://issues.redhat.com/browse/CNV-26764

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Use ImagePullPolicy: IfNotPresent instead of Always
```
