### PR TITLE
fix: stabilize functests of VM Console proxy

### DIFF
--- a/tests/vm_console_proxy_test.go
+++ b/tests/vm_console_proxy_test.go
@@ -37,7 +37,7 @@ var _ = Describe("VM Console Proxy Operand", func() {
 		routeResource              testResource
 	)
 
-	BeforeEach(func() {
+	BeforeEach(OncePerOrdered, func() {
 		strategy.SkipSspUpdateTestsIfNeeded()
 
 		updateSsp(func(foundSsp *ssp.SSP) {
@@ -144,7 +144,7 @@ var _ = Describe("VM Console Proxy Operand", func() {
 		waitUntilDeployed()
 	})
 
-	AfterEach(func() {
+	AfterEach(OncePerOrdered, func() {
 		strategy.RevertToOriginalSspCr()
 
 		// Similar workaround as in BeforeEach().
@@ -169,7 +169,7 @@ var _ = Describe("VM Console Proxy Operand", func() {
 		waitUntilDeployed()
 	})
 
-	Context("Resource creation", func() {
+	Context("Resource creation", Ordered, func() {
 		DescribeTable("created cluster resource", func(res *testResource) {
 			resource := res.NewResource()
 			err := apiClient.Get(ctx, res.GetKey(), resource)

--- a/tests/vm_console_proxy_test.go
+++ b/tests/vm_console_proxy_test.go
@@ -2,11 +2,12 @@ package tests
 
 import (
 	"crypto/tls"
+	"fmt"
 	"io"
-	"kubevirt.io/ssp-operator/tests/env"
 	"net/http"
 	"net/url"
 	"reflect"
+	"strconv"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -16,11 +17,13 @@ import (
 	apps "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
 	rbac "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/pointer"
 
 	ssp "kubevirt.io/ssp-operator/api/v1beta1"
 	vm_console_proxy "kubevirt.io/ssp-operator/internal/operands/vm-console-proxy"
+	"kubevirt.io/ssp-operator/tests/env"
 )
 
 var _ = Describe("VM Console Proxy Operand", func() {
@@ -130,11 +133,40 @@ var _ = Describe("VM Console Proxy Operand", func() {
 			},
 		}
 
+		// Waiting until the proxy deployment is created.
+		// This is a workaround, because the above updateSsp() function updates only annotations,
+		// which don't update the .metadata.generation field. So the waitUntilDeployed() call
+		// below succeeds immediately, and does not wait until proxy resources are created.
+		Eventually(func() error {
+			return apiClient.Get(ctx, deploymentResource.GetKey(), &apps.Deployment{})
+		}, env.ShortTimeout(), time.Second).Should(Succeed())
+
 		waitUntilDeployed()
 	})
 
 	AfterEach(func() {
 		strategy.RevertToOriginalSspCr()
+
+		// Similar workaround as in BeforeEach().
+		originalSspProxyAnnotation := getSsp().Annotations[vm_console_proxy.EnableAnnotation]
+		if isEnabled, _ := strconv.ParseBool(originalSspProxyAnnotation); !isEnabled {
+			Eventually(func() error {
+				deployment := &apps.Deployment{}
+				err := apiClient.Get(ctx, deploymentResource.GetKey(), deployment)
+				if errors.IsNotFound(err) {
+					return nil
+				}
+				if err != nil {
+					return err
+				}
+				if !deployment.DeletionTimestamp.IsZero() {
+					return nil
+				}
+				return fmt.Errorf("the console proxy deployment is not being deleted")
+			}, env.ShortTimeout(), time.Second).Should(Succeed())
+		}
+
+		waitUntilDeployed()
 	})
 
 	Context("Resource creation", func() {
@@ -187,10 +219,6 @@ var _ = Describe("VM Console Proxy Operand", func() {
 		)
 
 		Context("With pause", func() {
-			BeforeEach(func() {
-				strategy.SkipSspUpdateTestsIfNeeded()
-			})
-
 			JustAfterEach(func() {
 				unpauseSsp()
 			})


### PR DESCRIPTION
**What this PR does / why we need it**:
This change fixes a race, where the tests did not wait until console proxy resources were deployed.

**Release note**:
```release-note
None
```
