### PR TITLE
[release-v0.17] fix: correctly delete proxy resources if namespace is not "kubevirt"

### DIFF
--- a/internal/common/labels.go
+++ b/internal/common/labels.go
@@ -15,6 +15,10 @@ const (
 	AppKubernetesComponentLabel = "app.kubernetes.io/component"
 )
 
+const (
+	AppKubernetesManagedByLabelValue = "ssp-operator"
+)
+
 type AppComponent string
 
 func (a AppComponent) String() string {
@@ -37,7 +41,7 @@ func AddAppLabels(requestInstance *v1beta1.SSP, name string, component AppCompon
 
 	labels[AppKubernetesNameLabel] = name
 	labels[AppKubernetesComponentLabel] = component.String()
-	labels[AppKubernetesManagedByLabel] = "ssp-operator"
+	labels[AppKubernetesManagedByLabel] = AppKubernetesManagedByLabelValue
 
 	return obj
 }


### PR DESCRIPTION
This is a backport of: https://github.com/kubevirt/ssp-operator/pull/538

**What this PR does / why we need it**:
`Cleanup()` method of vm-console-proxy deletes resources from the correct namespace.

**Release note**:
```release-note
None
```
