### PR TITLE
refactor: Remove RequiredCrds() method from operands

### DIFF
--- a/controllers/setup.go
+++ b/controllers/setup.go
@@ -82,7 +82,7 @@ func setupManager(ctx context.Context, cancel context.CancelFunc, mgr controller
 
 	var requiredCrds []string
 	for i := range sspOperands {
-		requiredCrds = append(requiredCrds, sspOperands[i].RequiredCrds()...)
+		requiredCrds = append(requiredCrds, getRequiredCrds(sspOperands[i])...)
 	}
 
 	crdWatch := crd_watch.New(requiredCrds...)
@@ -133,6 +133,21 @@ func setupManager(ctx context.Context, cancel context.CancelFunc, mgr controller
 	reconciler := NewSspReconciler(mgr.GetClient(), mgr.GetAPIReader(), infrastructureTopology, sspOperands, crdWatch)
 
 	return reconciler.setupController(mgr)
+}
+
+func getRequiredCrds(operand operands.Operand) []string {
+	var result []string
+	for _, watchType := range operand.WatchTypes() {
+		if watchType.Crd != "" {
+			result = append(result, watchType.Crd)
+		}
+	}
+	for _, watchType := range operand.WatchClusterTypes() {
+		if watchType.Crd != "" {
+			result = append(result, watchType.Crd)
+		}
+	}
+	return result
 }
 
 func getRunnable(mgr controllerruntime.Manager, ctrl ControllerReconciler) manager.Runnable {

--- a/internal/common/request.go
+++ b/internal/common/request.go
@@ -22,7 +22,7 @@ type Request struct {
 	VersionCache   VersionCache
 	TopologyMode   osconfv1.TopologyMode
 
-	CrdWatch *crd_watch.CrdWatch
+	CrdList crd_watch.CrdList
 }
 
 func (r *Request) IsSingleReplicaTopologyMode() bool {

--- a/internal/crd-watch/crd-watch.go
+++ b/internal/crd-watch/crd-watch.go
@@ -14,6 +14,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
 )
 
+type CrdList interface {
+	CrdExists(crdName string) bool
+	MissingCrds() []string
+}
+
 type CrdWatch struct {
 	AllCrdsAddedHandler   func()
 	SomeCrdRemovedHandler func()

--- a/internal/operands/common-instancetypes/reconcile.go
+++ b/internal/operands/common-instancetypes/reconcile.go
@@ -298,12 +298,12 @@ func (c *CommonInstancetypes) Cleanup(request *common.Request) ([]common.Cleanup
 	var objects []client.Object
 
 	// Before collecting resources to clean up ensure the corresponding CRD is available
-	if request.CrdWatch.CrdExists(virtualMachineClusterInstancetypeCrd) {
+	if request.CrdList.CrdExists(virtualMachineClusterInstancetypeCrd) {
 		for i := range c.virtualMachineClusterInstancetypes {
 			objects = append(objects, &c.virtualMachineClusterInstancetypes[i])
 		}
 	}
-	if request.CrdWatch.CrdExists(virtualMachineClusterPreferenceCrd) {
+	if request.CrdList.CrdExists(virtualMachineClusterPreferenceCrd) {
 		for i := range c.virtualMachineClusterPreferences {
 			objects = append(objects, &c.virtualMachineClusterPreferences[i])
 		}

--- a/internal/operands/common-instancetypes/reconcile.go
+++ b/internal/operands/common-instancetypes/reconcile.go
@@ -56,8 +56,8 @@ func (c *CommonInstancetypes) Name() string {
 
 func WatchClusterTypes() []operands.WatchType {
 	return []operands.WatchType{
-		{Object: &instancetypev1alpha2.VirtualMachineClusterInstancetype{}, Crd: instancetypeapi.ClusterPluralResourceName, WatchFullObject: true},
-		{Object: &instancetypev1alpha2.VirtualMachineClusterPreference{}, Crd: instancetypeapi.ClusterPluralPreferenceResourceName, WatchFullObject: true},
+		{Object: &instancetypev1alpha2.VirtualMachineClusterInstancetype{}, Crd: virtualMachineClusterInstancetypeCrd, WatchFullObject: true},
+		{Object: &instancetypev1alpha2.VirtualMachineClusterPreference{}, Crd: virtualMachineClusterPreferenceCrd, WatchFullObject: true},
 	}
 }
 
@@ -67,13 +67,6 @@ func (c *CommonInstancetypes) WatchClusterTypes() []operands.WatchType {
 
 func (c *CommonInstancetypes) WatchTypes() []operands.WatchType {
 	return nil
-}
-
-func (c *CommonInstancetypes) RequiredCrds() []string {
-	return []string{
-		virtualMachineClusterInstancetypeCrd,
-		virtualMachineClusterPreferenceCrd,
-	}
 }
 
 func New(virtualMachineClusterInstancetypeBundlePath, virtualMachineClusterPreferenceBundlePath string) *CommonInstancetypes {

--- a/internal/operands/common-templates/reconcile.go
+++ b/internal/operands/common-templates/reconcile.go
@@ -73,10 +73,6 @@ func (c *commonTemplates) WatchTypes() []operands.WatchType {
 	return nil
 }
 
-func (c *commonTemplates) RequiredCrds() []string {
-	return nil
-}
-
 func (c *commonTemplates) Reconcile(request *common.Request) ([]common.ReconcileResult, error) {
 	reconcileTemplatesResults, err := common.CollectResourceStatus(request, reconcileTemplatesFuncs(c.templatesBundle)...)
 	if err != nil {

--- a/internal/operands/data-sources/reconcile.go
+++ b/internal/operands/data-sources/reconcile.go
@@ -81,14 +81,6 @@ func (d *dataSources) WatchClusterTypes() []operands.WatchType {
 	return WatchClusterTypes()
 }
 
-func (d *dataSources) RequiredCrds() []string {
-	return []string{
-		dataVolumeCrd,
-		dataSourceCrd,
-		dataImportCronCrd,
-	}
-}
-
 type dataSourceInfo struct {
 	dataSource         *cdiv1beta1.DataSource
 	autoUpdateEnabled  bool

--- a/internal/operands/data-sources/reconcile.go
+++ b/internal/operands/data-sources/reconcile.go
@@ -141,7 +141,7 @@ func (d *dataSources) Reconcile(request *common.Request) ([]common.ReconcileResu
 }
 
 func (d *dataSources) Cleanup(request *common.Request) ([]common.CleanupResult, error) {
-	if request.CrdWatch.CrdExists(dataImportCronCrd) {
+	if request.CrdList.CrdExists(dataImportCronCrd) {
 		ownedCrons, err := listAllOwnedDataImportCrons(request)
 		if err != nil {
 			return nil, err
@@ -167,7 +167,7 @@ func (d *dataSources) Cleanup(request *common.Request) ([]common.CleanupResult, 
 	}
 
 	var objects []client.Object
-	if request.CrdWatch.CrdExists(dataSourceCrd) {
+	if request.CrdList.CrdExists(dataSourceCrd) {
 		for i := range d.sources {
 			ds := d.sources[i]
 			ds.Namespace = internal.GoldenImagesNamespace

--- a/internal/operands/metrics/reconcile.go
+++ b/internal/operands/metrics/reconcile.go
@@ -48,10 +48,6 @@ func (m *metrics) WatchClusterTypes() []operands.WatchType {
 	return WatchClusterTypes()
 }
 
-func (m *metrics) RequiredCrds() []string {
-	return []string{prometheusRulesCrd}
-}
-
 func (m *metrics) Reconcile(request *common.Request) ([]common.ReconcileResult, error) {
 	return common.CollectResourceStatus(request,
 		reconcilePrometheusMonitor,

--- a/internal/operands/node-labeller/reconcile.go
+++ b/internal/operands/node-labeller/reconcile.go
@@ -66,10 +66,6 @@ func (nl *nodeLabeller) WatchClusterTypes() []operands.WatchType {
 	return WatchClusterTypes()
 }
 
-func (nl *nodeLabeller) RequiredCrds() []string {
-	return nil
-}
-
 // Reconsile deletes all node-labeller component, because labeller is migrated into kubevirt core.
 func (nl *nodeLabeller) Reconcile(request *common.Request) ([]common.ReconcileResult, error) {
 	// Not using common.DeleteAll(), because these resources

--- a/internal/operands/operand.go
+++ b/internal/operands/operand.go
@@ -13,9 +13,6 @@ type Operand interface {
 	// WatchClusterTypes returns a slice of cluster resources, that the operator should watch.
 	WatchClusterTypes() []WatchType
 
-	// RequiredCrds returns names of CRDs, that need to be installed for the operand to work.
-	RequiredCrds() []string
-
 	// Reconcile creates and updates resources.
 	Reconcile(*common.Request) ([]common.ReconcileResult, error)
 

--- a/internal/operands/template-validator/reconcile.go
+++ b/internal/operands/template-validator/reconcile.go
@@ -54,10 +54,6 @@ func (t *templateValidator) WatchClusterTypes() []operands.WatchType {
 	return WatchClusterTypes()
 }
 
-func (t *templateValidator) RequiredCrds() []string {
-	return nil
-}
-
 func (t *templateValidator) Reconcile(request *common.Request) ([]common.ReconcileResult, error) {
 	return common.CollectResourceStatus(request,
 		reconcileClusterRole,

--- a/internal/operands/vm-console-proxy/reconcile.go
+++ b/internal/operands/vm-console-proxy/reconcile.go
@@ -89,10 +89,6 @@ func (v *vmConsoleProxy) WatchClusterTypes() []operands.WatchType {
 	return WatchClusterTypes()
 }
 
-func (v *vmConsoleProxy) RequiredCrds() []string {
-	return nil
-}
-
 func (v *vmConsoleProxy) Reconcile(request *common.Request) ([]common.ReconcileResult, error) {
 	if !isEnabled(request) {
 		cleanupResults, err := v.Cleanup(request)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR does 2 changes:
- Create an interface for `CrdWatch` that can only be used to get missing CRDs.
- Remove `RequiredCrds()` method from operands. Needed CRDs are read from `WatchTypes`.

**Release note**:
```release-note
None
```
