### PR TITLE
refactor: add default update and status functions

### DIFF
--- a/internal/operands/common-instancetypes/reconcile.go
+++ b/internal/operands/common-instancetypes/reconcile.go
@@ -331,9 +331,6 @@ func (c *CommonInstancetypes) reconcileVirtualMachineClusterInstancetypesFuncs()
 			return common.CreateOrUpdate(request).
 				ClusterResource(clusterInstancetype).
 				WithAppLabels(operandName, operandComponent).
-				UpdateFunc(func(newRes, foundRes client.Object) {
-					foundRes.(*instancetypev1alpha2.VirtualMachineClusterInstancetype).Spec = newRes.(*instancetypev1alpha2.VirtualMachineClusterInstancetype).Spec
-				}).
 				Reconcile()
 		})
 	}
@@ -348,9 +345,6 @@ func (c *CommonInstancetypes) reconcileVirtualMachineClusterPreferencesFuncs() [
 			return common.CreateOrUpdate(request).
 				ClusterResource(clusterPreference).
 				WithAppLabels(operandName, operandComponent).
-				UpdateFunc(func(newRes, foundRes client.Object) {
-					foundRes.(*instancetypev1alpha2.VirtualMachineClusterPreference).Spec = newRes.(*instancetypev1alpha2.VirtualMachineClusterPreference).Spec
-				}).
 				Reconcile()
 		})
 	}

--- a/internal/operands/data-sources/reconcile.go
+++ b/internal/operands/data-sources/reconcile.go
@@ -195,11 +195,6 @@ func reconcileViewRole(request *common.Request) (common.ReconcileResult, error) 
 	return common.CreateOrUpdate(request).
 		ClusterResource(newViewRole(internal.GoldenImagesNamespace)).
 		WithAppLabels(operandName, operandComponent).
-		UpdateFunc(func(newRes, foundRes client.Object) {
-			foundRole := foundRes.(*rbac.Role)
-			newRole := newRes.(*rbac.Role)
-			foundRole.Rules = newRole.Rules
-		}).
 		Reconcile()
 }
 
@@ -207,12 +202,6 @@ func reconcileViewRoleBinding(request *common.Request) (common.ReconcileResult, 
 	return common.CreateOrUpdate(request).
 		ClusterResource(newViewRoleBinding(internal.GoldenImagesNamespace)).
 		WithAppLabels(operandName, operandComponent).
-		UpdateFunc(func(newRes, foundRes client.Object) {
-			newBinding := newRes.(*rbac.RoleBinding)
-			foundBinding := foundRes.(*rbac.RoleBinding)
-			foundBinding.Subjects = newBinding.Subjects
-			foundBinding.RoleRef = newBinding.RoleRef
-		}).
 		Reconcile()
 }
 
@@ -220,11 +209,6 @@ func reconcileEditRole(request *common.Request) (common.ReconcileResult, error) 
 	return common.CreateOrUpdate(request).
 		ClusterResource(newEditRole()).
 		WithAppLabels(operandName, operandComponent).
-		UpdateFunc(func(newRes, foundRes client.Object) {
-			newRole := newRes.(*rbac.ClusterRole)
-			foundRole := foundRes.(*rbac.ClusterRole)
-			foundRole.Rules = newRole.Rules
-		}).
 		Reconcile()
 }
 

--- a/internal/operands/metrics/reconcile.go
+++ b/internal/operands/metrics/reconcile.go
@@ -6,7 +6,6 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"kubevirt.io/ssp-operator/internal/common"
 	"kubevirt.io/ssp-operator/internal/operands"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Define RBAC rules needed by this operand:
@@ -83,9 +82,6 @@ func reconcilePrometheusMonitor(request *common.Request) (common.ReconcileResult
 	return common.CreateOrUpdate(request).
 		NamespacedResource(newServiceMonitorCR(request.Namespace)).
 		WithAppLabels(operandName, operandComponent).
-		UpdateFunc(func(newRes, foundRes client.Object) {
-			foundRes.(*promv1.ServiceMonitor).Spec = newRes.(*promv1.ServiceMonitor).Spec
-		}).
 		Reconcile()
 }
 
@@ -93,9 +89,6 @@ func reconcileMonitoringRbacRole(request *common.Request) (common.ReconcileResul
 	return common.CreateOrUpdate(request).
 		ClusterResource(newMonitoringClusterRole()).
 		WithAppLabels(operandName, operandComponent).
-		UpdateFunc(func(newRes, foundRes client.Object) {
-			foundRes.(*rbac.ClusterRole).Rules = newRes.(*rbac.ClusterRole).Rules
-		}).
 		Reconcile()
 }
 
@@ -103,10 +96,6 @@ func reconcileMonitoringRbacRoleBinding(request *common.Request) (common.Reconci
 	return common.CreateOrUpdate(request).
 		ClusterResource(newMonitoringClusterRoleBinding()).
 		WithAppLabels(operandName, operandComponent).
-		UpdateFunc(func(newRes, foundRes client.Object) {
-			foundRes.(*rbac.ClusterRoleBinding).Subjects = newRes.(*rbac.ClusterRoleBinding).Subjects
-			foundRes.(*rbac.ClusterRoleBinding).RoleRef = newRes.(*rbac.ClusterRoleBinding).RoleRef
-		}).
 		Reconcile()
 }
 
@@ -119,8 +108,5 @@ func reconcilePrometheusRule(request *common.Request) (common.ReconcileResult, e
 	return common.CreateOrUpdate(request).
 		NamespacedResource(prometheusRule).
 		WithAppLabels(operandName, operandComponent).
-		UpdateFunc(func(newRes, foundRes client.Object) {
-			foundRes.(*promv1.PrometheusRule).Spec = newRes.(*promv1.PrometheusRule).Spec
-		}).
 		Reconcile()
 }

--- a/internal/operands/node-labeller/reconcile.go
+++ b/internal/operands/node-labeller/reconcile.go
@@ -129,9 +129,6 @@ func reconcileClusterRole(request *common.Request) (common.ReconcileResult, erro
 	return common.CreateOrUpdate(request).
 		ClusterResource(newClusterRole()).
 		WithAppLabels(operandName, operandComponent).
-		UpdateFunc(func(newRes, foundRes client.Object) {
-			foundRes.(*rbac.ClusterRole).Rules = newRes.(*rbac.ClusterRole).Rules
-		}).
 		Reconcile()
 }
 
@@ -146,12 +143,6 @@ func reconcileClusterRoleBinding(request *common.Request) (common.ReconcileResul
 	return common.CreateOrUpdate(request).
 		ClusterResource(newClusterRoleBinding(request.Namespace)).
 		WithAppLabels(operandName, operandComponent).
-		UpdateFunc(func(newRes, foundRes client.Object) {
-			newBinding := newRes.(*rbac.ClusterRoleBinding)
-			foundBinding := foundRes.(*rbac.ClusterRoleBinding)
-			foundBinding.RoleRef = newBinding.RoleRef
-			foundBinding.Subjects = newBinding.Subjects
-		}).
 		Reconcile()
 }
 
@@ -159,9 +150,6 @@ func reconcileConfigMap(request *common.Request) (common.ReconcileResult, error)
 	return common.CreateOrUpdate(request).
 		NamespacedResource(newConfigMap(request.Namespace)).
 		WithAppLabels(operandName, operandComponent).
-		UpdateFunc(func(newRes, foundRes client.Object) {
-			foundRes.(*v1.ConfigMap).Data = newRes.(*v1.ConfigMap).Data
-		}).
 		Reconcile()
 }
 
@@ -176,22 +164,6 @@ func createOrUpdateDaemonSet(request *common.Request, daemonSet *apps.DaemonSet)
 	return common.CreateOrUpdate(request).
 		NamespacedResource(daemonSet).
 		WithAppLabels(operandName, operandComponent).
-		UpdateFunc(func(newRes, foundRes client.Object) {
-			foundRes.(*apps.DaemonSet).Spec = newRes.(*apps.DaemonSet).Spec
-		}).
-		StatusFunc(func(res client.Object) common.ResourceStatus {
-			ds := res.(*apps.DaemonSet)
-			status := common.ResourceStatus{}
-			if ds.Status.NumberReady != ds.Status.DesiredNumberScheduled {
-				msg := fmt.Sprintf("Not all node-labeler pods are ready. (ready pods: %d, desired pods: %d)",
-					ds.Status.NumberReady,
-					ds.Status.DesiredNumberScheduled)
-				status.NotAvailable = &msg
-				status.Progressing = &msg
-				status.Degraded = &msg
-			}
-			return status
-		}).
 		Reconcile()
 }
 

--- a/internal/operands/template-validator/reconcile.go
+++ b/internal/operands/template-validator/reconcile.go
@@ -1,8 +1,6 @@
 package template_validator
 
 import (
-	"fmt"
-
 	admission "k8s.io/api/admissionregistration/v1"
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -93,9 +91,6 @@ func reconcileClusterRole(request *common.Request) (common.ReconcileResult, erro
 	return common.CreateOrUpdate(request).
 		ClusterResource(newClusterRole()).
 		WithAppLabels(operandName, operandComponent).
-		UpdateFunc(func(newRes, foundRes client.Object) {
-			foundRes.(*rbac.ClusterRole).Rules = newRes.(*rbac.ClusterRole).Rules
-		}).
 		Reconcile()
 }
 
@@ -110,12 +105,6 @@ func reconcileClusterRoleBinding(request *common.Request) (common.ReconcileResul
 	return common.CreateOrUpdate(request).
 		ClusterResource(newClusterRoleBinding(request.Namespace)).
 		WithAppLabels(operandName, operandComponent).
-		UpdateFunc(func(newRes, foundRes client.Object) {
-			newBinding := newRes.(*rbac.ClusterRoleBinding)
-			foundBinding := foundRes.(*rbac.ClusterRoleBinding)
-			foundBinding.RoleRef = newBinding.RoleRef
-			foundBinding.Subjects = newBinding.Subjects
-		}).
 		Reconcile()
 }
 
@@ -123,25 +112,13 @@ func reconcileService(request *common.Request) (common.ReconcileResult, error) {
 	return common.CreateOrUpdate(request).
 		NamespacedResource(newService(request.Namespace)).
 		WithAppLabels(operandName, operandComponent).
-		UpdateFunc(updateServiceSpec).
 		Reconcile()
-}
-
-func updateServiceSpec(newRes, foundRes client.Object) {
-	newService := newRes.(*v1.Service)
-	foundService := foundRes.(*v1.Service)
-
-	// ClusterIP should not be updated
-	newService.Spec.ClusterIP = foundService.Spec.ClusterIP
-
-	foundService.Spec = newService.Spec
 }
 
 func reconcilePrometheusService(request *common.Request) (common.ReconcileResult, error) {
 	return common.CreateOrUpdate(request).
 		NamespacedResource(newPrometheusService(request.Namespace)).
 		WithAppLabels(operandName, operandComponent).
-		UpdateFunc(updateServiceSpec).
 		Reconcile()
 }
 
@@ -169,27 +146,6 @@ func reconcileDeployment(request *common.Request) (common.ReconcileResult, error
 	return common.CreateOrUpdate(request).
 		NamespacedResource(deployment).
 		WithAppLabels(operandName, operandComponent).
-		UpdateFunc(func(newRes, foundRes client.Object) {
-			foundRes.(*apps.Deployment).Spec = newRes.(*apps.Deployment).Spec
-		}).
-		StatusFunc(func(res client.Object) common.ResourceStatus {
-			dep := res.(*apps.Deployment)
-			status := common.ResourceStatus{}
-			if numberOfReplicas > 0 && dep.Status.AvailableReplicas == 0 {
-				msg := fmt.Sprintf("No validator pods are running. Expected: %d", dep.Status.Replicas)
-				status.NotAvailable = &msg
-			}
-			if dep.Status.AvailableReplicas != numberOfReplicas {
-				msg := fmt.Sprintf(
-					"Not all template validator pods are running. Expected: %d, running: %d",
-					numberOfReplicas,
-					dep.Status.AvailableReplicas,
-				)
-				status.Progressing = &msg
-				status.Degraded = &msg
-			}
-			return status
-		}).
 		Reconcile()
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Added default update and status functions for most resources that are reconciled by the operator.

**Release note**:
```release-note
None
```
