### PR TITLE
fix: Disable functest for runbook reachability

### DIFF
--- a/tests/metrics_test.go
+++ b/tests/metrics_test.go
@@ -266,10 +266,21 @@ var _ = Describe("Metrics", func() {
 							fmt.Sprintf("%s summary is missing or empty", rule.Alert))
 						Expect(rule.Annotations).To(HaveKeyWithValue("runbook_url", Not(BeEmpty())),
 							fmt.Sprintf("%s runbook_url is missing or empty", rule.Alert))
-						resp, err := http.Head(rule.Annotations["runbook_url"])
-						Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("%s runbook is not available", rule.Alert))
-						Expect(resp.StatusCode).Should(Equal(http.StatusOK), fmt.Sprintf("%s runbook is not available", rule.Alert))
 					}
+				}
+			}
+		})
+
+		// Temporarily disabling this test, because it fails in downstream, where the URL does not exist yet.
+		// TODO: Enable when fixed.
+		PIt("[test_id:TODO]should be able to reach runbook_url", func() {
+			for _, group := range promRule.Spec.Groups {
+				for _, rule := range group.Rules {
+					Expect(rule.Annotations).To(HaveKeyWithValue("runbook_url", Not(BeEmpty())),
+						fmt.Sprintf("%s runbook_url is missing or empty", rule.Alert))
+					resp, err := http.Head(rule.Annotations["runbook_url"])
+					Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("%s runbook is not available", rule.Alert))
+					Expect(resp.StatusCode).Should(Equal(http.StatusOK), fmt.Sprintf("%s runbook is not available", rule.Alert))
 				}
 			}
 		})


### PR DESCRIPTION
**What this PR does / why we need it**:
The test fails in downstream, because the URL does not exist yet.

**Release note**:
```release-note
None
```
