### PR TITLE
fix: fix setting namespace for example pipelines role binding

### DIFF
--- a/internal/operands/tekton-pipelines/tekton-pipelines.go
+++ b/internal/operands/tekton-pipelines/tekton-pipelines.go
@@ -229,7 +229,9 @@ func reconcileRoleBindingsFuncs(rolebindings []rbac.RoleBinding) []common.Reconc
 		roleBinding := &rolebindings[i]
 		funcs = append(funcs, func(request *common.Request) (common.ReconcileResult, error) {
 			namespace := getTektonPipelinesNamespace(request)
-			roleBinding.Namespace = namespace
+			if roleBinding.Namespace == "" {
+				roleBinding.Namespace = namespace
+			}
 			for j := range roleBinding.Subjects {
 				subject := &roleBinding.Subjects[j]
 				subject.Namespace = namespace


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: fix setting namespace for example pipelines role binding

one role binding for example pipeline has to be deployed to the kubevirt-os-images namespace. SSP operator will not set namespace for roleBindings if they have namespace defined.

**Release note**:
```
NONE
```
