### PR TITLE
fix: add validator image variable to pipeline test scripts

### DIFF
--- a/automation/e2e-tekton/example-pipelines-test.sh
+++ b/automation/e2e-tekton/example-pipelines-test.sh
@@ -2,6 +2,7 @@
 
 cp -L $KUBECONFIG /tmp/kubeconfig && export KUBECONFIG=/tmp/kubeconfig
 export IMG=${CI_OPERATOR_IMG}
+export VALIDATOR_IMG=${CI_VALIDATOR_IMG}
 
 # switch to faster storage class for example pipelines tests (slower storage class is causing timeouts due 
 # to not able to copy whole windows disk)


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: add validator image variable to pipeline test scripts

Add validator img link to example pipelines test script. Without this link, validator uses latest tag, which is 3 years old and ssp operator is in deploying phase, because validator is not working

**Release note**:
```
NONE
```
