### PR TITLE
fix: fix source template namespace in tekton pipeline tests

### DIFF
--- a/automation/e2e-tekton/test-files/windows10-customize-pipelinerun.yaml
+++ b/automation/e2e-tekton/test-files/windows10-customize-pipelinerun.yaml
@@ -10,6 +10,8 @@ spec:
       value: true
     - name: allowReplaceCustomizationTemplate
       value: true
+    - name: sourceTemplateNamespace
+      value: kubevirt
   pipelineRef:
     name: windows-customize
   taskRunSpecs:

--- a/automation/e2e-tekton/test-files/windows10-installer-pipelinerun.yaml
+++ b/automation/e2e-tekton/test-files/windows10-installer-pipelinerun.yaml
@@ -8,6 +8,8 @@ spec:
   params:
   - name: winImageDownloadURL
     value: http://http-server/disk.img
+  - name: sourceTemplateNamespace
+    value: kubevirt
   pipelineRef:
     name: windows-bios-installer
   taskRunSpecs:

--- a/automation/e2e-tekton/test-files/windows11-customize-pipelinerun.yaml
+++ b/automation/e2e-tekton/test-files/windows11-customize-pipelinerun.yaml
@@ -8,6 +8,8 @@ spec:
   params:
     - name: sourceTemplateName
       value: windows11-desktop-large
+    - name: sourceTemplateNamespace
+      value: kubevirt
     - name: customizeTemplateName
       value: windows11-desktop-large-customize-sqlserver
     - name: goldenTemplateName

--- a/automation/e2e-tekton/test-files/windows11-installer-pipelinerun.yaml
+++ b/automation/e2e-tekton/test-files/windows11-installer-pipelinerun.yaml
@@ -8,6 +8,8 @@ spec:
   params:
   - name: winImageDownloadURL
     value: http://http-server/disk.img
+  - name: sourceTemplateNamespace
+    value: kubevirt
   pipelineRef:
     name: windows-efi-installer
   taskRunSpecs:

--- a/automation/e2e-tekton/test-files/windows2k22-customize-pipelinerun.yaml
+++ b/automation/e2e-tekton/test-files/windows2k22-customize-pipelinerun.yaml
@@ -14,6 +14,8 @@ spec:
       value: windows2k22-desktop-large-golden-sqlserver
     - name: customizeConfigMapName
       value: windows-sqlserver
+    - name: sourceTemplateNamespace
+      value: kubevirt
   pipelineRef:
     name: windows-customize
   taskRunSpecs:

--- a/automation/e2e-tekton/test-files/windows2k22-installer-pipelinerun.yaml
+++ b/automation/e2e-tekton/test-files/windows2k22-installer-pipelinerun.yaml
@@ -12,6 +12,8 @@ spec:
     value: windows2k22-autounattend
   - name: sourceTemplateName
     value: windows2k22-server-large
+  - name: sourceTemplateNamespace
+    value: kubevirt
   - name: baseDvName
     value: win2k22
   pipelineRef:


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: fix source template namespace in tekton pipeline tests

Default template namespace in example pipelines is openshift. Namespace defined in ssp sample CR is kubevirt. This commit changes the template namespace in tests from openshift to kubevirt

**Release note**:
```
NONE
```
