### PR TITLE
 Fix total_restored_common_templates metric update

### DIFF
--- a/internal/common/resource.go
+++ b/internal/common/resource.go
@@ -39,6 +39,7 @@ type ResourceStatus struct {
 
 type ReconcileResult struct {
 	Status          ResourceStatus
+	InitialResource client.Object
 	Resource        client.Object
 	OperationResult OperationResult
 }
@@ -192,7 +193,7 @@ func (r *reconcileBuilder) Reconcile() (ReconcileResult, error) {
 		return nil
 	}
 
-	res, err := r.createOrUpdateWithImmutableSpec(found, mutateFn)
+	res, existing, err := r.createOrUpdateWithImmutableSpec(found, mutateFn)
 	if err != nil {
 		r.request.Logger.Info(fmt.Sprintf("Resource create/update failed: %v", err))
 		return ReconcileResult{}, err
@@ -206,7 +207,7 @@ func (r *reconcileBuilder) Reconcile() (ReconcileResult, error) {
 	logOperation(res, found, r.request.Logger)
 
 	status := r.statusFunc(found)
-	return ReconcileResult{status, r.resource, res}, nil
+	return ReconcileResult{status, existing, r.resource, res}, nil
 }
 
 func CreateOrUpdate(request *Request) ReconcileBuilder {
@@ -285,43 +286,43 @@ func DeleteAll(request *Request, resources ...client.Object) ([]CleanupResult, e
 }
 
 // This function was initially copied from controllerutil.CreateOrUpdate
-func (r *reconcileBuilder) createOrUpdateWithImmutableSpec(obj client.Object, f controllerutil.MutateFn) (OperationResult, error) {
+func (r *reconcileBuilder) createOrUpdateWithImmutableSpec(obj client.Object, f controllerutil.MutateFn) (OperationResult, client.Object, error) {
 	key := client.ObjectKeyFromObject(obj)
 	if err := r.request.Client.Get(r.request.Context, key, obj); err != nil {
 		if !errors.IsNotFound(err) {
-			return OperationResultNone, err
+			return OperationResultNone, nil, err
 		}
 		if err := mutate(f, key, obj); err != nil {
-			return OperationResultNone, err
+			return OperationResultNone, nil, err
 		}
 		if err := r.request.Client.Create(r.request.Context, obj); err != nil {
-			return OperationResultNone, err
+			return OperationResultNone, nil, err
 		}
-		return OperationResultCreated, nil
+		return OperationResultCreated, nil, nil
 	}
 
-	existing := obj.DeepCopyObject()
+	existing := obj.DeepCopyObject().(client.Object)
 	if err := mutate(f, key, obj); err != nil {
-		return OperationResultNone, err
+		return OperationResultNone, existing, err
 	}
 
 	if equality.Semantic.DeepEqual(existing, obj) {
-		return OperationResultNone, nil
+		return OperationResultNone, existing, nil
 	}
 
 	// If the resource is immutable and specs are not equal, delete it.
 	// It will be recreated in the next iteration.
-	if r.immutableSpec && !equality.Semantic.DeepEqual(r.specGetter(existing.(client.Object)), r.specGetter(obj)) {
+	if r.immutableSpec && !equality.Semantic.DeepEqual(r.specGetter(existing), r.specGetter(obj)) {
 		if err := r.request.Client.Delete(r.request.Context, obj); err != nil {
-			return OperationResultNone, err
+			return OperationResultNone, existing, err
 		}
-		return OperationResultDeleted, nil
+		return OperationResultDeleted, existing, nil
 	}
 
 	if err := r.request.Client.Update(r.request.Context, obj); err != nil {
-		return OperationResultNone, err
+		return OperationResultNone, existing, err
 	}
-	return OperationResultUpdated, nil
+	return OperationResultUpdated, existing, nil
 }
 
 // This function is a copy of controllerutil.mutate

--- a/internal/operands/common-templates/reconcile_test.go
+++ b/internal/operands/common-templates/reconcile_test.go
@@ -7,10 +7,14 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	templatev1 "github.com/openshift/api/template/v1"
 	libhandler "github.com/operator-framework/operator-lib/handler"
+	"github.com/prometheus/client_golang/prometheus"
+	io_prometheus_client "github.com/prometheus/client_model/go"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	lifecycleapi "kubevirt.io/controller-lifecycle-operator-sdk/api"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -75,6 +79,11 @@ var _ = Describe("Common-Templates operand", func() {
 						Namespace: namespace,
 					},
 				},
+				Status: ssp.SSPStatus{
+					Status: lifecycleapi.Status{
+						ObservedVersion: common.GetOperatorVersion(),
+					},
+				},
 			},
 			Logger:       log,
 			VersionCache: common.VersionCache{},
@@ -88,9 +97,13 @@ var _ = Describe("Common-Templates operand", func() {
 			template.Namespace = namespace
 			ExpectResourceExists(&template, request)
 		}
+
+		desc, value := getCommonTemplatesRestoredMetric()
+		Expect(desc).To(ContainSubstring("total_restored_common_templates"))
+		Expect(value).To(BeZero())
 	})
 
-	It("should reconcle predefined labels", func() {
+	It("should reconcile predefined labels", func() {
 		const (
 			defaultOsLabel = "template.kubevirt.io/default-os-variant"
 			testLabel      = "some.test.label"
@@ -117,6 +130,10 @@ var _ = Describe("Common-Templates operand", func() {
 			Expect(template.Labels).ToNot(HaveKey(defaultOsLabel))
 			Expect(template.Labels).To(HaveKey(testLabel))
 		}
+
+		desc, value := getCommonTemplatesRestoredMetric()
+		Expect(desc).To(ContainSubstring("total_restored_common_templates"))
+		Expect(value).To(Equal(float64(len(testTemplates))))
 	})
 
 	Context("old templates", func() {
@@ -204,6 +221,7 @@ var _ = Describe("Common-Templates operand", func() {
 			Expect(updatedTpl.GetAnnotations()[libhandler.NamespacedNameAnnotation]).ToNot(Equal(""), "owner name annotation is empty for an older template")
 			Expect(updatedTpl.GetAnnotations()[libhandler.TypeAnnotation]).ToNot(Equal(""), "owner type annotation is empty for an older template")
 		})
+
 		It("should remove labels from old templates but keep future template untouched", func() {
 			_, err := operand.Reconcile(&request)
 			Expect(err).ToNot(HaveOccurred(), "reconciliation in order to update old template failed")
@@ -232,6 +250,7 @@ var _ = Describe("Common-Templates operand", func() {
 			Expect(newerTpl.Labels[TemplateVersionLabel]).To(Equal(futureVersion), TemplateVersionLabel+" should equal "+futureVersion)
 			Expect(newerTpl.Annotations[TemplateDeprecatedAnnotation]).To(Equal(""), TemplateDeprecatedAnnotation+" should be empty")
 		})
+
 		It("should not remove labels from latest templates", func() {
 			_, err := operand.Reconcile(&request)
 			Expect(err).ToNot(HaveOccurred(), "reconciliation in order to update old template failed")
@@ -256,6 +275,56 @@ var _ = Describe("Common-Templates operand", func() {
 				Expect(template.Annotations[TemplateDeprecatedAnnotation]).To(Equal(""), TemplateDeprecatedAnnotation+" should be empty")
 
 			}
+		})
+	})
+
+	Context("total_restored_common_templates metric", func() {
+		var template *templatev1.Template
+		var initialMetricValue float64
+
+		BeforeEach(func() {
+			_, err := operand.Reconcile(&request)
+			Expect(err).ToNot(HaveOccurred())
+
+			template = getTemplate(request, &testTemplates[0])
+			template.Namespace = namespace
+
+			desc, value := getCommonTemplatesRestoredMetric()
+			Expect(desc).To(ContainSubstring("total_restored_common_templates"))
+			initialMetricValue = value
+		})
+
+		It("should increase by 1 when one template is restored", func() {
+			template.Labels[TemplateTypeLabel] = "rand"
+			err := request.Client.Update(request.Context, template)
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = operand.Reconcile(&request)
+			Expect(err).ToNot(HaveOccurred())
+
+			updatedTpl := getTemplate(request, template)
+			Expect(updatedTpl.Labels[TemplateTypeLabel]).To(Equal(testTemplates[0].Labels[TemplateTypeLabel]))
+
+			desc, value := getCommonTemplatesRestoredMetric()
+			Expect(desc).To(ContainSubstring("total_restored_common_templates"))
+			Expect(value).To(Equal(initialMetricValue + 1))
+		})
+
+		It("should not increase when template restored is from previous version", func() {
+			template.Labels[TemplateTypeLabel] = "rand"
+			template.Labels[TemplateVersionLabel] = "rand"
+			err := request.Client.Update(request.Context, template)
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = operand.Reconcile(&request)
+			Expect(err).ToNot(HaveOccurred())
+
+			updatedTpl := getTemplate(request, template)
+			Expect(updatedTpl.Labels[TemplateTypeLabel]).To(Equal(testTemplates[0].Labels[TemplateTypeLabel]))
+
+			desc, value := getCommonTemplatesRestoredMetric()
+			Expect(desc).To(ContainSubstring("total_restored_common_templates"))
+			Expect(value).To(Equal(initialMetricValue))
 		})
 	})
 })
@@ -284,4 +353,25 @@ func getTestTemplates() []templatev1.Template {
 			},
 		},
 	}}
+}
+
+func getCommonTemplatesRestoredMetric() (string, float64) {
+	ch := make(chan prometheus.Metric, 1)
+	CommonTemplatesRestored.Collect(ch)
+	close(ch)
+	m := <-ch
+	metric := &io_prometheus_client.Metric{}
+	err := m.Write(metric)
+	Expect(err).ToNot(HaveOccurred())
+
+	return m.Desc().String(), metric.GetCounter().GetValue()
+}
+
+func getTemplate(req common.Request, template *templatev1.Template) *templatev1.Template {
+	key := client.ObjectKeyFromObject(template)
+	updatedTpl := &templatev1.Template{}
+	err := req.Client.Get(req.Context, key, updatedTpl)
+	Expect(err).ToNot(HaveOccurred())
+
+	return updatedTpl
 }

--- a/main.go
+++ b/main.go
@@ -29,7 +29,6 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	common_templates "kubevirt.io/ssp-operator/internal/operands/common-templates"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -38,6 +37,7 @@ import (
 
 	"kubevirt.io/ssp-operator/controllers"
 	"kubevirt.io/ssp-operator/internal/common"
+	common_templates "kubevirt.io/ssp-operator/internal/operands/common-templates"
 	"kubevirt.io/ssp-operator/webhooks"
 	// +kubebuilder:scaffold:imports
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

SSPCommonTemplatesModificationReverted is being triggered during upgrades.

**Which issue(s) this PR fixes**: 
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
 Fix total_restored_common_templates metric update
```
