### PR TITLE
fix(CNV-29287): consider tekton crd as an optional

### DIFF
--- a/controllers/setup.go
+++ b/controllers/setup.go
@@ -15,11 +15,8 @@ import (
 	data_sources "kubevirt.io/ssp-operator/internal/operands/data-sources"
 	"kubevirt.io/ssp-operator/internal/operands/metrics"
 	node_labeller "kubevirt.io/ssp-operator/internal/operands/node-labeller"
-	tekton_pipelines "kubevirt.io/ssp-operator/internal/operands/tekton-pipelines"
-	tekton_tasks "kubevirt.io/ssp-operator/internal/operands/tekton-tasks"
 	template_validator "kubevirt.io/ssp-operator/internal/operands/template-validator"
 	vm_console_proxy "kubevirt.io/ssp-operator/internal/operands/vm-console-proxy"
-	tekton_bundle "kubevirt.io/ssp-operator/internal/tekton-bundle"
 	template_bundle "kubevirt.io/ssp-operator/internal/template-bundle"
 	vm_console_proxy_bundle "kubevirt.io/ssp-operator/internal/vm-console-proxy-bundle"
 	controllerruntime "sigs.k8s.io/controller-runtime"
@@ -64,19 +61,6 @@ func setupManager(ctx context.Context, cancel context.CancelFunc, mgr controller
 		return fmt.Errorf("failed to read vm-console-proxy bundle: %w", err)
 	}
 
-	tektonPipelinesBundle, err := tekton_bundle.ReadPipelineBundle(runningOnOpenShift)
-	if err != nil {
-		return err
-	}
-
-	tektonTasksBundle, err := tekton_bundle.ReadTasksBundle(runningOnOpenShift)
-	if err != nil {
-		return err
-	}
-
-	tektonPipelinesOperand := tekton_pipelines.New(tektonPipelinesBundle)
-	tektonTasksOperand := tekton_tasks.New(tektonTasksBundle)
-
 	sspOperands := []operands.Operand{
 		// The bundle paths are not hardcoded within New to allow tests to use a different path
 		common_instancetypes.New(
@@ -84,9 +68,6 @@ func setupManager(ctx context.Context, cancel context.CancelFunc, mgr controller
 			common_instancetypes.BundleDir+common_instancetypes.ClusterPreferencesBundle,
 		),
 		data_sources.New(templatesBundle.DataSources),
-		// Tekton Tasks Operand should be before Pipelines to avoid errors
-		tektonTasksOperand,
-		tektonPipelinesOperand,
 	}
 
 	if runningOnOpenShift {
@@ -149,7 +130,7 @@ func setupManager(ctx context.Context, cancel context.CancelFunc, mgr controller
 		return fmt.Errorf("error adding vm controller: %w", err)
 	}
 
-	reconciler := NewSspReconciler(mgr.GetClient(), mgr.GetAPIReader(), infrastructureTopology, sspOperands, crdWatch)
+	reconciler := NewSspReconciler(mgr.GetClient(), mgr.GetAPIReader(), infrastructureTopology, sspOperands, crdWatch, runningOnOpenShift)
 
 	return reconciler.setupController(mgr)
 }

--- a/internal/crd-watch/crd-watch.go
+++ b/internal/crd-watch/crd-watch.go
@@ -15,6 +15,7 @@ import (
 )
 
 type CrdList interface {
+	AddCrd(crdNames []string)
 	CrdExists(crdName string) bool
 	MissingCrds() []string
 }
@@ -54,6 +55,20 @@ func (c *CrdWatch) Init(ctx context.Context, reader client.Reader) error {
 
 	c.initialized = true
 	return nil
+}
+
+func (c *CrdWatch) AddCrd(crdNames []string) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	if !c.initialized {
+		panic("crd watch not initialized")
+	}
+
+	for _, crdName := range crdNames {
+		c.requiredCrds[crdName] = struct{}{}
+		c.missingCrds[crdName] = struct{}{}
+	}
 }
 
 func (c *CrdWatch) CrdExists(crdName string) bool {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

Currently if the Tekton Feature Gate is set to false, ssp-controller will  consider
Tekton CRD as required. But, since it's not needed, then consider it as not required.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Consider Tekton CRD as an optional.
```
