### PR TITLE
fix(CNV-29287): do not watch tekton crd

### DIFF
--- a/internal/operands/tekton-pipelines/tekton-pipelines.go
+++ b/internal/operands/tekton-pipelines/tekton-pipelines.go
@@ -34,7 +34,9 @@ func init() {
 
 func WatchClusterTypes() []operands.WatchType {
 	return []operands.WatchType{
-		{Object: &pipeline.Pipeline{}, Crd: tektonCrd, WatchFullObject: true},
+		// Solution to optional Tekton CRD is not implemented yet.
+		// Until then, do not watch to Tekton CRD.
+		// {Object: &pipeline.Pipeline{}, Crd: tektonCrd, WatchFullObject: true},
 		{Object: &v1.ConfigMap{}},
 		{Object: &rbac.RoleBinding{}},
 		{Object: &v1.ServiceAccount{}},
@@ -83,9 +85,11 @@ func (t *tektonPipelines) Reconcile(request *common.Request) ([]common.Reconcile
 		request.Logger.V(1).Info("Tekton Pipelines resources were not deployed, because spec.featureGates.deployTektonTaskResources is set to false")
 		return nil, nil
 	}
-	if !request.CrdList.CrdExists(tektonCrd) {
-		return nil, fmt.Errorf("Tekton CRD %s does not exist", tektonCrd)
-	}
+	// Solution to optional Tekton CRD is not implemented yet.
+	// Until then, do not check if Tekton CRD exists.
+	// if !request.CrdList.CrdExists(tektonCrd) {
+	// 	return nil, fmt.Errorf("Tekton CRD %s does not exist", tektonCrd)
+	// }
 
 	var reconcileFunc []common.ReconcileFunc
 	reconcileFunc = append(reconcileFunc, reconcileClusterRolesFuncs(t.clusterRoles)...)

--- a/internal/operands/tekton-tasks/tekton-tasks.go
+++ b/internal/operands/tekton-tasks/tekton-tasks.go
@@ -69,7 +69,9 @@ func init() {
 
 func WatchClusterTypes() []operands.WatchType {
 	return []operands.WatchType{
-		{Object: &pipeline.Task{}, Crd: tektonCrd, WatchFullObject: true},
+		// Solution to optional Tekton CRD is not implemented yet.
+		// Until then, do not watch to Tekton CRD.
+		// {Object: &pipeline.Task{}, Crd: tektonCrd, WatchFullObject: true},
 		{Object: &rbac.ClusterRole{}},
 		{Object: &rbac.RoleBinding{}},
 		{Object: &v1.ServiceAccount{}},
@@ -147,9 +149,11 @@ func (t *tektonTasks) Reconcile(request *common.Request) ([]common.ReconcileResu
 		request.Logger.V(1).Info("Tekton Tasks resources were not deployed, because spec.featureGates.deployTektonTaskResources is set to false")
 		return nil, nil
 	}
-	if !request.CrdList.CrdExists(tektonCrd) {
-		return nil, fmt.Errorf("Tekton CRD %s does not exist", tektonCrd)
-	}
+	// Solution to optional Tekton CRD is not implemented yet.
+	// Until then, do not check if Tekton CRD exists.
+	// if !request.CrdList.CrdExists(tektonCrd) {
+	// 	return nil, fmt.Errorf("Tekton CRD %s does not exist", tektonCrd)
+	// }
 
 	var reconcileFunc []common.ReconcileFunc
 	reconcileFunc = append(reconcileFunc, reconcileTektonTasksFuncs(t.tasks)...)

--- a/tests/tekton-pipelines_test.go
+++ b/tests/tekton-pipelines_test.go
@@ -5,7 +5,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	pipeline "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+
+	// pipeline "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	v1 "k8s.io/api/core/v1"
 	rbac "k8s.io/api/rbac/v1"
 	ssp "kubevirt.io/ssp-operator/api/v1beta1"
@@ -33,25 +34,25 @@ var _ = Describe("Tekton Pipelines Operand", func() {
 			strategy.RevertToOriginalSspCr()
 		})
 
-		It("[test_id:TODO] should create pipelines", func() {
-			pipelineList := &pipeline.PipelineList{}
+		// It("[test_id:TODO] should create pipelines", func() {
+		// 	pipelineList := &pipeline.PipelineList{}
 
-			Eventually(func() bool {
-				err := apiClient.List(ctx, pipelineList,
-					client.MatchingLabels{
-						common.AppKubernetesManagedByLabel: common.AppKubernetesManagedByValue,
-						common.AppKubernetesComponentLabel: string(common.AppComponentTektonPipelines),
-					},
-				)
-				Expect(err).ToNot(HaveOccurred())
-				return len(pipelineList.Items) > 0
-			}, env.ShortTimeout(), time.Second).Should(BeTrue())
+		// 	Eventually(func() bool {
+		// 		err := apiClient.List(ctx, pipelineList,
+		// 			client.MatchingLabels{
+		// 				common.AppKubernetesManagedByLabel: common.AppKubernetesManagedByValue,
+		// 				common.AppKubernetesComponentLabel: string(common.AppComponentTektonPipelines),
+		// 			},
+		// 		)
+		// 		Expect(err).ToNot(HaveOccurred())
+		// 		return len(pipelineList.Items) > 0
+		// 	}, env.ShortTimeout(), time.Second).Should(BeTrue())
 
-			for _, pipeline := range pipelineList.Items {
-				Expect(pipeline.Labels[common.AppKubernetesManagedByLabel]).To(Equal(common.AppKubernetesManagedByValue), "managed by label should equal")
-				Expect(pipeline.Labels[common.AppKubernetesComponentLabel]).To(Equal(string(common.AppComponentTektonPipelines)), "component label should equal")
-			}
-		})
+		// 	for _, pipeline := range pipelineList.Items {
+		// 		Expect(pipeline.Labels[common.AppKubernetesManagedByLabel]).To(Equal(common.AppKubernetesManagedByValue), "managed by label should equal")
+		// 		Expect(pipeline.Labels[common.AppKubernetesComponentLabel]).To(Equal(string(common.AppComponentTektonPipelines)), "component label should equal")
+		// 	}
+		// })
 
 		It("[test_id:TODO] should create cluster roles", func() {
 			clusterRoleList := &rbac.ClusterRoleList{}
@@ -133,31 +134,31 @@ var _ = Describe("Tekton Pipelines Operand", func() {
 			strategy.RevertToOriginalSspCr()
 		})
 
-		It("[test_id:TODO] should revert user update on pipeline", func() {
-			pipelineList := &pipeline.PipelineList{}
+		// It("[test_id:TODO] should revert user update on pipeline", func() {
+		// 	pipelineList := &pipeline.PipelineList{}
 
-			Eventually(func() bool {
-				err := apiClient.List(ctx, pipelineList,
-					client.MatchingLabels{
-						common.AppKubernetesManagedByLabel: common.AppKubernetesManagedByValue,
-						common.AppKubernetesComponentLabel: string(common.AppComponentTektonPipelines),
-					},
-				)
-				Expect(err).ToNot(HaveOccurred())
-				return len(pipelineList.Items) > 0
-			}, env.ShortTimeout(), time.Second).Should(BeTrue())
+		// 	Eventually(func() bool {
+		// 		err := apiClient.List(ctx, pipelineList,
+		// 			client.MatchingLabels{
+		// 				common.AppKubernetesManagedByLabel: common.AppKubernetesManagedByValue,
+		// 				common.AppKubernetesComponentLabel: string(common.AppComponentTektonPipelines),
+		// 			},
+		// 		)
+		// 		Expect(err).ToNot(HaveOccurred())
+		// 		return len(pipelineList.Items) > 0
+		// 	}, env.ShortTimeout(), time.Second).Should(BeTrue())
 
-			pipeline := pipelineList.Items[0]
-			pipeline.Spec.Description = "test"
-			err := apiClient.Update(ctx, &pipeline)
-			Expect(err).ToNot(HaveOccurred())
+		// 	pipeline := pipelineList.Items[0]
+		// 	pipeline.Spec.Description = "test"
+		// 	err := apiClient.Update(ctx, &pipeline)
+		// 	Expect(err).ToNot(HaveOccurred())
 
-			Eventually(func() bool {
-				err := apiClient.Get(ctx, client.ObjectKeyFromObject(&pipeline), &pipeline)
-				Expect(err).ToNot(HaveOccurred())
-				return pipeline.Spec.Description != "test"
-			}, env.ShortTimeout(), time.Second).Should(BeTrue())
-		})
+		// 	Eventually(func() bool {
+		// 		err := apiClient.Get(ctx, client.ObjectKeyFromObject(&pipeline), &pipeline)
+		// 		Expect(err).ToNot(HaveOccurred())
+		// 		return pipeline.Spec.Description != "test"
+		// 	}, env.ShortTimeout(), time.Second).Should(BeTrue())
+		// })
 
 		It("[test_id:TODO] should revert user update on configMap", func() {
 			configMapList := &v1.ConfigMapList{}

--- a/tests/tekton-tasks_test.go
+++ b/tests/tekton-tasks_test.go
@@ -6,7 +6,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	pipeline "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+
+	// pipeline "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	v1 "k8s.io/api/core/v1"
 	rbac "k8s.io/api/rbac/v1"
 	ssp "kubevirt.io/ssp-operator/api/v1beta1"
@@ -35,30 +36,30 @@ var _ = Describe("Tekton Tasks Operand", func() {
 			strategy.RevertToOriginalSspCr()
 		})
 
-		It("[test_id:TODO] should create tasks", func() {
-			taskList := &pipeline.TaskList{}
+		// It("[test_id:TODO] should create tasks", func() {
+		// 	taskList := &pipeline.TaskList{}
 
-			Eventually(func() bool {
-				err := apiClient.List(ctx, taskList,
-					client.MatchingLabels{
-						common.AppKubernetesManagedByLabel: common.AppKubernetesManagedByValue,
-						common.AppKubernetesComponentLabel: string(common.AppComponentTektonTasks),
-					},
-				)
-				Expect(err).ToNot(HaveOccurred())
-				return len(taskList.Items) > 0
-			}, env.ShortTimeout(), time.Second).Should(BeTrue())
+		// 	Eventually(func() bool {
+		// 		err := apiClient.List(ctx, taskList,
+		// 			client.MatchingLabels{
+		// 				common.AppKubernetesManagedByLabel: common.AppKubernetesManagedByValue,
+		// 				common.AppKubernetesComponentLabel: string(common.AppComponentTektonTasks),
+		// 			},
+		// 		)
+		// 		Expect(err).ToNot(HaveOccurred())
+		// 		return len(taskList.Items) > 0
+		// 	}, env.ShortTimeout(), time.Second).Should(BeTrue())
 
-			for _, task := range taskList.Items {
-				if _, found := tekton_tasks.AllowedTasks[strings.TrimSuffix(task.Name, "-task")]; found {
-					Expect(found).To(BeTrue(), "only allowed task is deployed - "+task.Name)
-				}
+		// 	for _, task := range taskList.Items {
+		// 		if _, found := tekton_tasks.AllowedTasks[strings.TrimSuffix(task.Name, "-task")]; found {
+		// 			Expect(found).To(BeTrue(), "only allowed task is deployed - "+task.Name)
+		// 		}
 
-				Expect(task.Labels[tekton_tasks.TektonTasksVersionLabel]).To(Equal(common.TektonTasksVersion), "version label should equal")
-				Expect(task.Labels[common.AppKubernetesManagedByLabel]).To(Equal(common.AppKubernetesManagedByValue), "managed by label should equal")
-				Expect(task.Labels[common.AppKubernetesComponentLabel]).To(Equal(string(common.AppComponentTektonTasks)), "component label should equal")
-			}
-		})
+		// 		Expect(task.Labels[tekton_tasks.TektonTasksVersionLabel]).To(Equal(common.TektonTasksVersion), "version label should equal")
+		// 		Expect(task.Labels[common.AppKubernetesManagedByLabel]).To(Equal(common.AppKubernetesManagedByValue), "managed by label should equal")
+		// 		Expect(task.Labels[common.AppKubernetesComponentLabel]).To(Equal(string(common.AppComponentTektonTasks)), "component label should equal")
+		// 	}
+		// })
 
 		It("[test_id:TODO] should create service accounts", func() {
 			serviceAccountList := &v1.ServiceAccountList{}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Currently, we're watching to Tekton CRD which
means it's required CRD. This is not always the
case if the Feature Gate is disabled.

This is a quick workaround to the required
Tekton CRD even when Feature Gate is disabled.

**Special notes for your reviewer**:

A solution to that issue is tracked in #560.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Do not watch Tekton CRD.
```
