### PR TITLE
fix: add virtualMachine.kubevirt.io crd to required crds

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The following resource types and CRDs are needed by `ssp-operator` when deployed
 | `virtualmachineclusterpreferences.instancetypes.kubevirt.io/v1alpha2`   | `common-instancetypes` operand (Kind `VirtualMachineClusterPreference`)   |
 | `pipelines.tekton.dev`                                                  | `tekton-pipelines` operand (Kind `Pipeline`)                              |
 | `tasks.tekton.dev`                                                      | `tekton-tasks` operand (Kind `Task`)                                      |
+| `virtualMachine.kubevirt.io`                                            | `vm-controller` operand (Kind `VirtualMachine`)                           |
 
 The following resource types and CRDs are needed by `ssp-operator` when deployed on a vanilla k8s environment:
 
@@ -41,6 +42,7 @@ The following resource types and CRDs are needed by `ssp-operator` when deployed
 | `virtualmachineclusterpreferences.instancetypes.kubevirt.io/v1alpha2`   | `common-instancetypes` operand (Kind `VirtualMachineClusterPreference`)   |
 | `pipelines.tekton.dev`                                                  | `tekton-pipelines` operand (Kind `Pipeline`)                              |
 | `tasks.tekton.dev`                                                      | `tekton-tasks` operand (Kind `Task`)                                      |
+| `virtualMachine.kubevirt.io`                                            | `vm-controller` operand (Kind `VirtualMachine`)                           |
 
 ### Using HCO
 

--- a/controllers/setup.go
+++ b/controllers/setup.go
@@ -99,7 +99,8 @@ func setupManager(ctx context.Context, cancel context.CancelFunc, mgr controller
 		)
 	}
 
-	var requiredCrds []string
+	requiredCrds := []string{getVMControllerRequiredCRD()}
+
 	for i := range sspOperands {
 		requiredCrds = append(requiredCrds, getRequiredCrds(sspOperands[i])...)
 	}
@@ -145,8 +146,10 @@ func setupManager(ctx context.Context, cancel context.CancelFunc, mgr controller
 		return fmt.Errorf("failed to create vm controller: %w", err)
 	}
 
-	if err = mgr.Add(getRunnable(mgr, vmController)); err != nil {
-		return fmt.Errorf("error adding vm controller: %w", err)
+	if crdWatch.CrdExists(getVMControllerRequiredCRD()) {
+		if err = mgr.Add(getRunnable(mgr, vmController)); err != nil {
+			return fmt.Errorf("error adding vm controller: %w", err)
+		}
 	}
 
 	reconciler := NewSspReconciler(mgr.GetClient(), mgr.GetAPIReader(), infrastructureTopology, sspOperands, crdWatch)

--- a/controllers/vm_controller.go
+++ b/controllers/vm_controller.go
@@ -2,6 +2,8 @@ package controllers
 
 import (
 	"context"
+	"strings"
+
 	"github.com/go-logr/logr"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -12,12 +14,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	"strings"
 )
 
 const (
 	vmControllerName = "vm-controller"
 	rhel6MetricName  = "kubevirt_vm_rhel6"
+	kubevirtVMCRD    = "virtualmachines.kubevirt.io"
 )
 
 var (
@@ -37,6 +39,10 @@ var (
 
 func CreateVmController(mgr ctrl.Manager) (*vmReconciler, error) {
 	return newVmReconciler(mgr)
+}
+
+func getVMControllerRequiredCRD() string {
+	return kubevirtVMCRD
 }
 
 func (r *vmReconciler) Name() string {


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: add virtualMachine.kubevirt.io crd to required crds

vm-controller is not checking if virtualMachine.kubevirt.io crd exists. this is causing troubles, when kubevirt crds are uninstalled when ssp oeprator
is running.

/hold

**Release note**:
```
fix: add virtualMachine.kubevirt.io crd to required crds
```
