### PR TITLE
fix(CNV-29761): ensure that tekton crd exists

### DIFF
--- a/internal/common/labels.go
+++ b/internal/common/labels.go
@@ -14,9 +14,10 @@ const (
 	AppKubernetesManagedByLabel = "app.kubernetes.io/managed-by"
 	AppKubernetesComponentLabel = "app.kubernetes.io/component"
 
-	AppComponentTektonPipelines AppComponent = "tektonPipelines"
-	AppComponentTektonTasks     AppComponent = "tektonTasks"
-	AppKubernetesManagedByValue string       = "ssp-operator"
+	AppComponentTektonPipelines       AppComponent = "tektonPipelines"
+	AppComponentTektonTasks           AppComponent = "tektonTasks"
+	AppKubernetesManagedByValue       string       = "ssp-operator"
+	TektonAppKubernetesManagedByValue string       = "tekton-tasks-operator"
 )
 
 type AppComponent string


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Checks if Tekton CRD is installed during Tekton
operands reconciliation and during cleanup
process when listing deprecated ClusterTasks.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Ensure Tekton CRD exists during reconciliation and cleanup process.
```
