### PR TITLE
[release-v0.18] Fix env variables

### DIFF
--- a/config/manager/manager.template.yaml
+++ b/config/manager/manager.template.yaml
@@ -33,7 +33,7 @@ spec:
         env:
           - name: VALIDATOR_IMAGE
             value: "$VALIDATOR_IMG"
-          - name: VIRT_LAUNCHER_IMAGE
+          - name: VIRTIO_IMG
           - name: OPERATOR_VERSION
           - name: TEKTON_TASKS_IMAGE
           - name: TEKTON_TASKS_DISK_VIRT_IMAGE

--- a/data/olm-catalog/ssp-operator.clusterserviceversion.yaml
+++ b/data/olm-catalog/ssp-operator.clusterserviceversion.yaml
@@ -578,7 +578,7 @@ spec:
                 env:
                 - name: VALIDATOR_IMAGE
                   value: quay.io/kubevirt/kubevirt-template-validator:latest
-                - name: VIRT_LAUNCHER_IMAGE
+                - name: VIRTIO_IMG
                 - name: OPERATOR_VERSION
                   value: 0.14.0
                 - name: TEKTON_TASKS_IMAGE


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: add VIRTIO_IMG env variable to manager manifest
remove VIRT_LAUNCHER env variable, which is not used anywhere.

VIRTIO_IMG is needed for tekton pipelines

PR to main will follow after this PR
/cc @akrejcir 
**Release note**:
```
NONE

```
