### PR TITLE
fix(CNV-30284): rename tekton images env vars

### DIFF
--- a/internal/common/environment.go
+++ b/internal/common/environment.go
@@ -18,8 +18,8 @@ import (
 const (
 	OperatorVersionKey          = "OPERATOR_VERSION"
 	TemplateValidatorImageKey   = "VALIDATOR_IMAGE"
-	TektonTasksImageKey         = "TEKTON_TASKS_IMG"
-	TektonTasksDiskVirtImageKey = "TEKTON_TASKS_DISK_VIRT_IMG"
+	TektonTasksImageKey         = "TEKTON_TASKS_IMAGE"
+	TektonTasksDiskVirtImageKey = "TEKTON_TASKS_DISK_VIRT_IMAGE"
 	VirtioImageKey              = "VIRTIO_IMG"
 
 	DefaultTektonTasksIMG         = "quay.io/kubevirt/tekton-tasks:" + TektonTasksVersion


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Rename Tekton environment variables to be the
same as declared in CSV. Currently, they are not
the same as in CSV and no value is set.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix Tekton images enviroment variables.
```