### PR TITLE
fix(CNV-28185): add required labels

### DIFF
--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -4,4 +4,8 @@ metadata:
   name: operator
   namespace: system
   labels:
+    app.kubernetes.io/managed-by: "ssp-operator"
+    app.kubernetes.io/version: "0.0.0"
+    app.kubernetes.io/component: "ssp-operator"
+    app.kubernetes.io/part-of: "hyperconverged-cluster"
     control-plane: ssp-operator

--- a/controllers/services_controller.go
+++ b/controllers/services_controller.go
@@ -34,6 +34,13 @@ func ServiceObject(namespace string) *v1.Service {
 			Name:      MetricsServiceName,
 			Namespace: namespace,
 			Labels: map[string]string{
+				// Required Labels
+				common.AppKubernetesManagedByLabel: common.AppKubernetesManagedByValue,
+				common.AppKubernetesVersionLabel:   common.GetOperatorVersion(),
+				common.AppKubernetesComponentLabel: serviceControllerName,
+				common.AppKubernetesPartOfLabel:    common.AppKubernetesPartOfValue,
+
+				// Custom Labels
 				metrics.PrometheusLabelKey: metrics.PrometheusLabelValue,
 			},
 		},

--- a/internal/common/labels.go
+++ b/internal/common/labels.go
@@ -18,6 +18,7 @@ const (
 	AppComponentTektonTasks           AppComponent = "tektonTasks"
 	AppKubernetesManagedByValue       string       = "ssp-operator"
 	TektonAppKubernetesManagedByValue string       = "tekton-tasks-operator"
+	AppKubernetesPartOfValue          string       = "hyperconverged-cluster"
 )
 
 type AppComponent string

--- a/internal/operands/template-validator/resources.go
+++ b/internal/operands/template-validator/resources.go
@@ -42,6 +42,13 @@ const (
 
 func CommonLabels() map[string]string {
 	return map[string]string{
+		// Required Labels
+		common.AppKubernetesManagedByLabel: common.AppKubernetesManagedByValue,
+		common.AppKubernetesVersionLabel:   common.GetOperatorVersion(),
+		common.AppKubernetesComponentLabel: VirtTemplateValidator,
+		common.AppKubernetesPartOfLabel:    common.AppKubernetesPartOfValue,
+
+		// Custom Labels
 		KubevirtIo: VirtTemplateValidator,
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Add required labels:
- "app.kubernetes.io/managed-by"
- "app.kubernetes.io/version"
- "app.kubernetes.io/component"
- "app.kubernetes.io/part-of"

That are required by specific resources:
- ssp-operator (ServiceAccount)
- ssp-operator-metrics
- virt-template-validator

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add required labels to specific SSP resources.
```
