### PR TITLE
Don't override autoupdated datasources that point to a snapshot instead of PVC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,8 +167,8 @@ vet:
 # Update vendor modules
 .PHONY: vendor
 vendor:
-	go mod vendor
 	go mod tidy
+	go mod vendor
 
 # Validate that this repository does not contain offensive language
 .PHONY: validate-no-offensive-lang

--- a/hack/kubevirtci.sh
+++ b/hack/kubevirtci.sh
@@ -38,7 +38,8 @@ function kubevirtci::up() {
   KUBECONFIG=$(kubevirtci::kubeconfig)
   export KUBECONFIG
   echo "adding kubevirtci registry to cdi-insecure-registries"
-  ${_kubectl} patch configmap cdi-insecure-registries -n cdi --type merge -p '{"data":{"kubevirtci": "registry:5000"}}'
+  ${_kubectl} get cdis --output='name' --ignore-not-found \
+  | xargs -r ${_kubectl} patch --type merge -p '{"spec": {"config": {"insecureRegistries": ["registry:5000"]}}}'
   echo "installing kubevirt..."
   LATEST=$(curl -L https://storage.googleapis.com/kubevirt-prow/devel/release/kubevirt/kubevirt/stable.txt)
   ${_kubectl} apply -f "https://github.com/kubevirt/kubevirt/releases/download/${LATEST}/kubevirt-operator.yaml"

--- a/internal/operands/data-sources/reconcile.go
+++ b/internal/operands/data-sources/reconcile.go
@@ -396,7 +396,7 @@ func reconcileDataSource(dsInfo dataSourceInfo, request *common.Request) (common
 
 			foundDs := foundRes.(*cdiv1beta1.DataSource)
 			newDs := newRes.(*cdiv1beta1.DataSource)
-			if !dsInfo.autoUpdateEnabled || foundDs.Spec.Source.PVC == nil {
+			if !dsInfo.autoUpdateEnabled || (foundDs.Spec.Source.PVC == nil && foundDs.Spec.Source.Snapshot == nil) {
 				foundDs.Spec.Source.PVC = newDs.Spec.Source.PVC
 			}
 		}).


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
With CDI 1.57.0 we have a new [feature](https://github.com/kubevirt/containerized-data-importer/blob/main/doc/os-image-poll-and-update.md#dataimportcron-source-formats) that introduces datasources that point to snapshot objects instead of PVCs.
We want to not override those, since this is the correct source to be pointing at.

**Which issue(s) this PR fixes**: 
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

Fixes #
https://bugzilla.redhat.com/show_bug.cgi?id=2215285

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: SSP resets datasource reference to initial state
```
