### PR TITLE
fix(CNV-28185): add required labels

### DIFF
--- a/tests/service_controller_test.go
+++ b/tests/service_controller_test.go
@@ -14,12 +14,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"kubevirt.io/ssp-operator/controllers"
+	"kubevirt.io/ssp-operator/internal/common"
 	"kubevirt.io/ssp-operator/internal/operands/metrics"
 	"kubevirt.io/ssp-operator/tests/env"
 )
 
 func getSspMetricsService() (*v1.Service, error) {
-	service := controllers.ServiceObject(strategy.GetSSPDeploymentNameSpace())
+	service := controllers.ServiceObject(strategy.GetSSPDeploymentNameSpace(), "")
 	err := apiClient.Get(ctx, client.ObjectKeyFromObject(service), service)
 	return service, err
 }
@@ -36,6 +37,16 @@ var _ = Describe("Service Controller", func() {
 	It("[test_id: 8807] Should create ssp-operator-metrics service", func() {
 		_, serviceErr := getSspMetricsService()
 		Expect(serviceErr).ToNot(HaveOccurred(), "Failed to get ssp-operator-metrics service")
+	})
+
+	It("[test_id: TODO] Service ssp-operator-metrics should contain required labels", func() {
+		service, serviceErr := getSspMetricsService()
+		Expect(serviceErr).ToNot(HaveOccurred(), "Failed to get ssp-operator-metrics service")
+
+		Expect(service.GetLabels()).To(HaveKeyWithValue(common.AppKubernetesManagedByLabel, controllers.ServiceManagedByLabelValue))
+		Expect(service.GetLabels()).To(HaveKeyWithValue(common.AppKubernetesVersionLabel, common.GetOperatorVersion()))
+		Expect(service.GetLabels()).To(HaveKeyWithValue(common.AppKubernetesComponentLabel, controllers.ServiceControllerName))
+		Expect(service.GetLabels()[common.AppKubernetesPartOfLabel]).To(BeEmpty())
 	})
 
 	It("[test_id: 8808] Should re-create ssp-operator-metrics service if deleted", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Add required labels:
- "app.kubernetes.io/managed-by"
- "app.kubernetes.io/version"
- "app.kubernetes.io/component"
- "app.kubernetes.io/part-of"

That are required by a specific resource:
- ssp-operator-metrics

Jira-Url: https://issues.redhat.com/browse/CNV-28185

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add required labels to SSP operator metrics
```