### PR TITLE
fix: fix default instanceTypeName parameter in tekton pipelines

### DIFF
--- a/data/tekton-pipelines/windows-bios-installer-pipeline.yaml
+++ b/data/tekton-pipelines/windows-bios-installer-pipeline.yaml
@@ -11,7 +11,7 @@ spec:
     - name: instanceTypeName
       type: string
       description: Name of VirtualMachineClusterInstancetype object
-      default: n1.large
+      default: u1.large
     - name: instanceTypeKind
       type: string
       description: Kind of VirtualMachineInstancetype object

--- a/data/tekton-pipelines/windows-customize-pipeline.yaml
+++ b/data/tekton-pipelines/windows-customize-pipeline.yaml
@@ -10,7 +10,7 @@ spec:
     - name: instanceTypeName
       type: string
       description: Name of VirtualMachineClusterInstancetype object
-      default: n1.large
+      default: u1.large
     - name: instanceTypeKind
       type: string
       description: Kind of VirtualMachineInstancetype object

--- a/data/tekton-pipelines/windows-efi-installer-pipeline.yaml
+++ b/data/tekton-pipelines/windows-efi-installer-pipeline.yaml
@@ -11,7 +11,7 @@ spec:
     - name: instanceTypeName
       type: string
       description: Name of VirtualMachineClusterInstancetype object
-      default: n1.large
+      default: u1.large
     - name: instanceTypeKind
       type: string
       description: Kind of VirtualMachineInstancetype object


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: fix default instanceTypeName parameter in tekton pipelines

n1.large instance type was renamed to o1.large

**Release note**:
```
fix default instanceTypeName parameter in tekton pipelines
```
