### PR TITLE
Audit RBAC rules

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -59,9 +59,7 @@ rules:
   verbs:
   - create
   - delete
-  - get
   - list
-  - patch
   - update
   - watch
 - apiGroups:
@@ -69,7 +67,6 @@ rules:
   resources:
   - customresourcedefinitions
   verbs:
-  - get
   - list
   - watch
 - apiGroups:
@@ -81,7 +78,6 @@ rules:
   - delete
   - get
   - list
-  - patch
   - update
   - watch
 - apiGroups:
@@ -146,20 +142,15 @@ rules:
   - infrastructures
   verbs:
   - get
-  - list
-  - watch
 - apiGroups:
   - ""
   resources:
   - configmaps
   - serviceaccounts
-  - services
   verbs:
   - create
   - delete
-  - get
   - list
-  - patch
   - update
   - watch
 - apiGroups:
@@ -171,7 +162,6 @@ rules:
   - delete
   - get
   - list
-  - patch
   - update
   - watch
 - apiGroups:
@@ -201,22 +191,18 @@ rules:
   verbs:
   - create
   - delete
-  - get
   - list
-  - patch
   - update
   - watch
 - apiGroups:
   - ""
   resources:
-  - serviceaccounts
   - services
   verbs:
   - create
   - delete
   - get
   - list
-  - patch
   - update
   - watch
 - apiGroups:
@@ -226,9 +212,7 @@ rules:
   verbs:
   - create
   - delete
-  - get
   - list
-  - patch
   - update
   - watch
 - apiGroups:
@@ -238,9 +222,7 @@ rules:
   verbs:
   - create
   - delete
-  - get
   - list
-  - patch
   - update
   - watch
 - apiGroups:
@@ -282,13 +264,9 @@ rules:
   resources:
   - prometheusrules
   - servicemonitors
-  - services
   verbs:
   - create
-  - delete
-  - get
   - list
-  - patch
   - update
   - watch
 - apiGroups:
@@ -299,9 +277,7 @@ rules:
   verbs:
   - create
   - delete
-  - get
   - list
-  - patch
   - update
   - watch
 - apiGroups:
@@ -312,9 +288,7 @@ rules:
   verbs:
   - create
   - delete
-  - get
   - list
-  - patch
   - update
   - watch
 - apiGroups:
@@ -326,9 +300,7 @@ rules:
   verbs:
   - create
   - delete
-  - get
   - list
-  - patch
   - update
   - watch
 - apiGroups:
@@ -338,23 +310,18 @@ rules:
   verbs:
   - create
   - delete
-  - get
   - list
-  - patch
   - update
   - watch
 - apiGroups:
-  - rbac.authorization.k8s.io/v1
+  - rbac.authorization.k8s.io
   resources:
-  - role
-  - rolebinding
-  - serviceaccount
+  - rolebindings
+  - roles
   verbs:
   - create
   - delete
-  - get
   - list
-  - patch
   - update
   - watch
 - apiGroups:
@@ -364,45 +331,7 @@ rules:
   verbs:
   - create
   - delete
-  - get
   - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ssp.kubevirt.io
-  resources:
-  - kubevirtcommontemplatesbundles
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ssp.kubevirt.io
-  resources:
-  - kubevirtmetricsaggregations
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ssp.kubevirt.io
-  resources:
-  - kubevirttemplatevalidators
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
   - update
   - watch
 - apiGroups:
@@ -410,11 +339,7 @@ rules:
   resources:
   - ssps
   verbs:
-  - create
-  - delete
-  - get
   - list
-  - patch
   - update
   - watch
 - apiGroups:
@@ -428,8 +353,6 @@ rules:
   resources:
   - ssps/status
   verbs:
-  - get
-  - patch
   - update
 - apiGroups:
   - subresources.kubevirt.io
@@ -442,24 +365,11 @@ rules:
 - apiGroups:
   - tekton.dev
   resources:
-  - clustertasks
-  - tasks
-  verbs:
-  - delete
-  - get
-  - list
-  - patch
-  - update
-- apiGroups:
-  - tekton.dev
-  resources:
   - pipelines
   verbs:
   - create
   - delete
-  - get
   - list
-  - patch
   - update
   - watch
 - apiGroups:
@@ -469,9 +379,7 @@ rules:
   verbs:
   - create
   - delete
-  - get
   - list
-  - patch
   - update
   - watch
 - apiGroups:

--- a/controllers/setup.go
+++ b/controllers/setup.go
@@ -26,7 +26,7 @@ import (
 )
 
 // Need to watch CRDs
-// +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch
+// +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=list;watch
 
 func CreateAndStartReconciler(ctx context.Context, mgr controllerruntime.Manager) error {
 	mgrCtx, cancel := context.WithCancel(ctx)

--- a/controllers/ssp_controller.go
+++ b/controllers/ssp_controller.go
@@ -94,14 +94,11 @@ func NewSspReconciler(client client.Client, uncachedReader client.Reader, infras
 
 var _ reconcile.Reconciler = &sspReconciler{}
 
-// +kubebuilder:rbac:groups=ssp.kubevirt.io,resources=ssps,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=ssp.kubevirt.io,resources=ssps/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=ssp.kubevirt.io,resources=ssps,verbs=list;watch;update
+// +kubebuilder:rbac:groups=ssp.kubevirt.io,resources=ssps/status,verbs=update
 // +kubebuilder:rbac:groups=ssp.kubevirt.io,resources=ssps/finalizers,verbs=update
-// +kubebuilder:rbac:groups=config.openshift.io,resources=infrastructures;clusterversions,verbs=get;list;watch
+// +kubebuilder:rbac:groups=config.openshift.io,resources=infrastructures;clusterversions,verbs=get
 // +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=list
-// +kubebuilder:rbac:groups=ssp.kubevirt.io,resources=kubevirtcommontemplatesbundles,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=ssp.kubevirt.io,resources=kubevirtmetricsaggregations,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=ssp.kubevirt.io,resources=kubevirttemplatevalidators,verbs=get;list;watch;create;update;patch;delete
 
 func (r *sspReconciler) setupController(mgr ctrl.Manager) error {
 	eventHandlerHook := func(request ctrl.Request, obj client.Object) {

--- a/data/olm-catalog/ssp-operator.clusterserviceversion.yaml
+++ b/data/olm-catalog/ssp-operator.clusterserviceversion.yaml
@@ -120,9 +120,7 @@ spec:
           verbs:
           - create
           - delete
-          - get
           - list
-          - patch
           - update
           - watch
         - apiGroups:
@@ -130,7 +128,6 @@ spec:
           resources:
           - customresourcedefinitions
           verbs:
-          - get
           - list
           - watch
         - apiGroups:
@@ -142,7 +139,6 @@ spec:
           - delete
           - get
           - list
-          - patch
           - update
           - watch
         - apiGroups:
@@ -207,20 +203,15 @@ spec:
           - infrastructures
           verbs:
           - get
-          - list
-          - watch
         - apiGroups:
           - ""
           resources:
           - configmaps
           - serviceaccounts
-          - services
           verbs:
           - create
           - delete
-          - get
           - list
-          - patch
           - update
           - watch
         - apiGroups:
@@ -232,7 +223,6 @@ spec:
           - delete
           - get
           - list
-          - patch
           - update
           - watch
         - apiGroups:
@@ -262,22 +252,18 @@ spec:
           verbs:
           - create
           - delete
-          - get
           - list
-          - patch
           - update
           - watch
         - apiGroups:
           - ""
           resources:
-          - serviceaccounts
           - services
           verbs:
           - create
           - delete
           - get
           - list
-          - patch
           - update
           - watch
         - apiGroups:
@@ -287,9 +273,7 @@ spec:
           verbs:
           - create
           - delete
-          - get
           - list
-          - patch
           - update
           - watch
         - apiGroups:
@@ -299,9 +283,7 @@ spec:
           verbs:
           - create
           - delete
-          - get
           - list
-          - patch
           - update
           - watch
         - apiGroups:
@@ -343,13 +325,9 @@ spec:
           resources:
           - prometheusrules
           - servicemonitors
-          - services
           verbs:
           - create
-          - delete
-          - get
           - list
-          - patch
           - update
           - watch
         - apiGroups:
@@ -360,9 +338,7 @@ spec:
           verbs:
           - create
           - delete
-          - get
           - list
-          - patch
           - update
           - watch
         - apiGroups:
@@ -373,9 +349,7 @@ spec:
           verbs:
           - create
           - delete
-          - get
           - list
-          - patch
           - update
           - watch
         - apiGroups:
@@ -387,9 +361,7 @@ spec:
           verbs:
           - create
           - delete
-          - get
           - list
-          - patch
           - update
           - watch
         - apiGroups:
@@ -399,23 +371,18 @@ spec:
           verbs:
           - create
           - delete
-          - get
           - list
-          - patch
           - update
           - watch
         - apiGroups:
-          - rbac.authorization.k8s.io/v1
+          - rbac.authorization.k8s.io
           resources:
-          - role
-          - rolebinding
-          - serviceaccount
+          - rolebindings
+          - roles
           verbs:
           - create
           - delete
-          - get
           - list
-          - patch
           - update
           - watch
         - apiGroups:
@@ -425,45 +392,7 @@ spec:
           verbs:
           - create
           - delete
-          - get
           - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - ssp.kubevirt.io
-          resources:
-          - kubevirtcommontemplatesbundles
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - ssp.kubevirt.io
-          resources:
-          - kubevirtmetricsaggregations
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - ssp.kubevirt.io
-          resources:
-          - kubevirttemplatevalidators
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
           - update
           - watch
         - apiGroups:
@@ -471,11 +400,7 @@ spec:
           resources:
           - ssps
           verbs:
-          - create
-          - delete
-          - get
           - list
-          - patch
           - update
           - watch
         - apiGroups:
@@ -489,8 +414,6 @@ spec:
           resources:
           - ssps/status
           verbs:
-          - get
-          - patch
           - update
         - apiGroups:
           - subresources.kubevirt.io
@@ -503,24 +426,11 @@ spec:
         - apiGroups:
           - tekton.dev
           resources:
-          - clustertasks
-          - tasks
-          verbs:
-          - delete
-          - get
-          - list
-          - patch
-          - update
-        - apiGroups:
-          - tekton.dev
-          resources:
           - pipelines
           verbs:
           - create
           - delete
-          - get
           - list
-          - patch
           - update
           - watch
         - apiGroups:
@@ -530,9 +440,7 @@ spec:
           verbs:
           - create
           - delete
-          - get
           - list
-          - patch
           - update
           - watch
         - apiGroups:

--- a/internal/operands/common-instancetypes/reconcile.go
+++ b/internal/operands/common-instancetypes/reconcile.go
@@ -22,8 +22,8 @@ import (
 )
 
 // Define RBAC rules needed by this operand:
-// +kubebuilder:rbac:groups=instancetype.kubevirt.io,resources=virtualmachineclusterinstancetypes,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=instancetype.kubevirt.io,resources=virtualmachineclusterpreferences,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=instancetype.kubevirt.io,resources=virtualmachineclusterinstancetypes,verbs=list;watch;create;update;delete
+// +kubebuilder:rbac:groups=instancetype.kubevirt.io,resources=virtualmachineclusterpreferences,verbs=list;watch;create;update;delete
 
 const (
 	operandName                          = "common-instancetypes"

--- a/internal/operands/data-sources/reconcile.go
+++ b/internal/operands/data-sources/reconcile.go
@@ -17,8 +17,9 @@ import (
 )
 
 // Define RBAC rules needed by this operand:
-// +kubebuilder:rbac:groups=core,resources=namespaces,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;roles;rolebindings,verbs=get;list;watch;create;update;patch;delete
+// Define RBAC rules needed by this operand:
+// +kubebuilder:rbac:groups=core,resources=namespaces,verbs=get;list;watch;create;update;delete
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;roles;rolebindings,verbs=list;watch;create;update;delete
 // +kubebuilder:rbac:groups=cdi.kubevirt.io,resources=datasources,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=cdi.kubevirt.io,resources=dataimportcrons,verbs=get;list;watch;create;update;patch;delete
 

--- a/internal/operands/metrics/reconcile.go
+++ b/internal/operands/metrics/reconcile.go
@@ -9,8 +9,8 @@ import (
 )
 
 // Define RBAC rules needed by this operand:
-// +kubebuilder:rbac:groups=monitoring.coreos.com,resources=prometheusrules;servicemonitors;services,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=rbac.authorization.k8s.io/v1,resources=role;rolebinding;serviceaccount,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=monitoring.coreos.com,resources=prometheusrules;servicemonitors,verbs=list;watch;create;update
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings,verbs=list;watch;create;update;delete
 // +kubebuilder:rbac:groups="",resources=pods;endpoints,verbs=get;list;watch
 
 const prometheusRulesCrd = "prometheusrules.monitoring.coreos.com"

--- a/internal/operands/tekton-pipelines/reconcile.go
+++ b/internal/operands/tekton-pipelines/reconcile.go
@@ -16,9 +16,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// +kubebuilder:rbac:groups=tekton.dev,resources=pipelines,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=tekton.dev,resources=pipelines,verbs=list;watch;create;update;delete
 // +kubebuilder:rbac:groups=*,resources=configmaps,verbs=list;watch;create;delete
-// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=list;watch;create;update;delete
 
 const (
 	namespacePattern           = "^(openshift|kube)-"

--- a/internal/operands/tekton-tasks/reconcile.go
+++ b/internal/operands/tekton-tasks/reconcile.go
@@ -14,10 +14,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// +kubebuilder:rbac:groups=tekton.dev,resources=clustertasks;tasks,verbs=get;list;update;patch;delete
-// +kubebuilder:rbac:groups=tekton.dev,resources=tasks,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;rolebindings,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=tekton.dev,resources=tasks,verbs=list;watch;create;update;delete
+// +kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=list;watch;create;update;delete
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;rolebindings,verbs=list;watch;create;update;delete
 // +kubebuilder:rbac:groups=kubevirt.io,resources=virtualmachineinstances;virtualmachines,verbs=create;update;get;list;watch;delete
 // +kubebuilder:rbac:groups=subresources.kubevirt.io,resources=virtualmachines/restart;virtualmachines/start;virtualmachines/stop,verbs=update
 // +kubebuilder:rbac:groups=template.openshift.io,resources=templates,verbs=get;list;watch;create;patch;update;delete

--- a/internal/operands/template-validator/reconcile.go
+++ b/internal/operands/template-validator/reconcile.go
@@ -13,10 +13,11 @@ import (
 )
 
 // Define RBAC rules needed by this operand:
-// +kubebuilder:rbac:groups=core,resources=services;serviceaccounts,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;clusterrolebindings,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=validatingwebhookconfigurations,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=list;watch;create;update;delete
+// +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;delete
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;delete
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;clusterrolebindings,verbs=list;watch;create;update;delete
+// +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=validatingwebhookconfigurations,verbs=list;watch;create;update;delete
 
 // RBAC for created roles
 // +kubebuilder:rbac:groups=template.openshift.io,resources=templates,verbs=get;list;watch

--- a/internal/operands/vm-console-proxy/reconcile.go
+++ b/internal/operands/vm-console-proxy/reconcile.go
@@ -29,10 +29,11 @@ const (
 )
 
 // Define RBAC rules needed by this operand:
-// +kubebuilder:rbac:groups=core,resources=services;serviceaccounts;configmaps,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;clusterrolebindings,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;delete
+// +kubebuilder:rbac:groups=core,resources=configmaps;serviceaccounts,verbs=list;watch;create;update;delete
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;delete
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;clusterrolebindings,verbs=list;watch;create;update;delete
+// +kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=list;watch;create;update;delete
 
 // RBAC for created roles
 // +kubebuilder:rbac:groups=kubevirt.io,resources=virtualmachineinstances,verbs=get;list;watch


### PR DESCRIPTION
**What this PR does / why we need it**:
As it is now, some of the RBAC rules and/or verbs are not required for the operator to be able to perform all intended operations.
This PR audits all RBAC rules. The auditory has been carried out following a black box approach, i.e., remove all rules, deploy the operator, run functest, collect forbidden operations, add the missing rules/verbs and repeat. The auditing process has been split in the next action items:

- Deploying the operator in KubevirtCI.
- Deploying the operator in a CRC cluster and running the functest.
- Deploying the operator in a 3 masters and 3 workers nodes and running the functest.
- Deploying a custom downstream build and running the Tier 2 test.

Just in case changes are not clear enough, this is a simplified and normalized diff of the `ClusterRole` file before and after: [https://www.textcompare.org/?id=64a2c9d599377eb6104d8ae3](https://www.textcompare.org/?id=64a2c9d599377eb6104d8ae3) 

The simplified version has been obtained using this [script](https://github.com/jcanocan/rbacSimplifier).

jira-ticket: https://issues.redhat.com/browse/CNV-24031

**Which issue(s) this PR fixes**: 
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Reduce the `ClusterRole` rules used
```
