### PR TITLE
Add Podman to ci-builder

### DIFF
--- a/ci-builder/Dockerfile
+++ b/ci-builder/Dockerfile
@@ -5,7 +5,7 @@ RUN curl -L https://go.dev/dl/go1.19.2.linux-amd64.tar.gz | tar -C /usr/local -x
 ENV PATH=$PATH:/usr/local/go/bin
 
 # Install dependencies and tools
-RUN dnf install -y jq git make findutils which gcc gettext && dnf clean all
+RUN dnf install -y jq git make findutils which podman gcc gettext && dnf clean all
 
 # Download latest stable oc client binary
 RUN curl -L https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/openshift-client-linux.tar.gz | tar -C /usr/local/bin -xzf - oc && \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Add Podman installation to `ci-builder/Dockerfile`, in order to be able to execute the metrics name linter within `make unittest`.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
