### PR TITLE
fix: GH actions for bumping virtio version

### DIFF
--- a/.github/workflows/update-virtio-version.yaml
+++ b/.github/workflows/update-virtio-version.yaml
@@ -34,15 +34,18 @@ jobs:
           KUBEVIRT_VERSION=$(curl -s https://api.github.com/repos/kubevirt/kubevirt/releases | \
             jq '.[] | select(.prerelease==false) | .tag_name' | sort -V | tail -n1 | tr -d '"')
 
-          LOCAL_KUBEVIRT_VERSION=$(grep -Po '(?<=virtio-container-disk:)[^"]+' pkg/environment/environment.go)
+          LOCAL_KUBEVIRT_VERSION=$(grep -Po '(?<=virtio-container-disk:)[^"]+' internal/common/environment.go)
 
           if [[ ${LOCAL_KUBEVIRT_VERSION} != ${KUBEVIRT_VERSION} ]]; then
             sed -i "s/${LOCAL_KUBEVIRT_VERSION}/${KUBEVIRT_VERSION}/g" internal/common/environment.go
+            sed -i "s/${LOCAL_KUBEVIRT_VERSION}/${KUBEVIRT_VERSION}/g" data/tekton-pipelines/windows-efi-installer-pipeline.yaml
+            sed -i "s/${LOCAL_KUBEVIRT_VERSION}/${KUBEVIRT_VERSION}/g" data/tekton-pipelines/windows-bios-installer-pipeline.yaml
 
             PATCH_BRANCH="update-virtio-version-${KUBEVIRT_VERSION}"
 
             git checkout -b "${PATCH_BRANCH}"
-            git add pkg/environment/environment.go
+            git add internal/common/environment.go
+            git add data/tekton-pipelines
             git commit -sm "Update virtio image version to ${KUBEVIRT_VERSION}"
             git push --set-upstream --force origin "${PATCH_BRANCH}"
 


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: GH actions for bumping virtio version
script contained wrong paths for files, which need update

**Release note**:
```
NONE

```
