### PR TITLE
Update common-instancetypes to v0.3.1

### DIFF
--- a/data/common-instancetypes-bundle/common-clusterinstancetypes-bundle.yaml
+++ b/data/common-instancetypes-bundle/common-clusterinstancetypes-bundle.yaml
@@ -25,7 +25,7 @@ metadata:
     instancetype.kubevirt.io/memory: 16Gi
     instancetype.kubevirt.io/numa: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.1
   name: cx1.2xlarge
 spec:
   cpu:
@@ -66,7 +66,7 @@ metadata:
     instancetype.kubevirt.io/memory: 32Gi
     instancetype.kubevirt.io/numa: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.1
   name: cx1.4xlarge
 spec:
   cpu:
@@ -107,7 +107,7 @@ metadata:
     instancetype.kubevirt.io/memory: 64Gi
     instancetype.kubevirt.io/numa: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.1
   name: cx1.8xlarge
 spec:
   cpu:
@@ -148,7 +148,7 @@ metadata:
     instancetype.kubevirt.io/memory: 4Gi
     instancetype.kubevirt.io/numa: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.1
   name: cx1.large
 spec:
   cpu:
@@ -189,7 +189,7 @@ metadata:
     instancetype.kubevirt.io/memory: 2Gi
     instancetype.kubevirt.io/numa: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.1
   name: cx1.medium
 spec:
   cpu:
@@ -230,7 +230,7 @@ metadata:
     instancetype.kubevirt.io/memory: 8Gi
     instancetype.kubevirt.io/numa: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.1
   name: cx1.xlarge
 spec:
   cpu:
@@ -266,7 +266,7 @@ metadata:
     instancetype.kubevirt.io/gpus: "true"
     instancetype.kubevirt.io/memory: 32Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.1
   name: gn1.2xlarge
 spec:
   cpu:
@@ -298,7 +298,7 @@ metadata:
     instancetype.kubevirt.io/gpus: "true"
     instancetype.kubevirt.io/memory: 64Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.1
   name: gn1.4xlarge
 spec:
   cpu:
@@ -330,7 +330,7 @@ metadata:
     instancetype.kubevirt.io/gpus: "true"
     instancetype.kubevirt.io/memory: 128Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.1
   name: gn1.8xlarge
 spec:
   cpu:
@@ -362,7 +362,7 @@ metadata:
     instancetype.kubevirt.io/gpus: "true"
     instancetype.kubevirt.io/memory: 16Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.1
   name: gn1.xlarge
 spec:
   cpu:
@@ -380,7 +380,7 @@ metadata:
     instancetype.kubevirt.io/deprecated: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
     kubevirt.io/size: large
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.1
   name: highperformance.large
 spec:
   cpu:
@@ -398,7 +398,7 @@ metadata:
     instancetype.kubevirt.io/deprecated: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
     kubevirt.io/size: medium
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.1
   name: highperformance.medium
 spec:
   cpu:
@@ -416,7 +416,7 @@ metadata:
     instancetype.kubevirt.io/deprecated: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
     kubevirt.io/size: small
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.1
   name: highperformance.small
 spec:
   cpu:
@@ -443,7 +443,7 @@ metadata:
     instancetype.kubevirt.io/hugepages: "true"
     instancetype.kubevirt.io/memory: 64Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.1
   name: m1.2xlarge
 spec:
   cpu:
@@ -469,7 +469,7 @@ metadata:
     instancetype.kubevirt.io/hugepages: "true"
     instancetype.kubevirt.io/memory: 128Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.1
   name: m1.4xlarge
 spec:
   cpu:
@@ -495,7 +495,7 @@ metadata:
     instancetype.kubevirt.io/hugepages: "true"
     instancetype.kubevirt.io/memory: 256Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.1
   name: m1.8xlarge
 spec:
   cpu:
@@ -521,7 +521,7 @@ metadata:
     instancetype.kubevirt.io/hugepages: "true"
     instancetype.kubevirt.io/memory: 16Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.1
   name: m1.large
 spec:
   cpu:
@@ -547,7 +547,7 @@ metadata:
     instancetype.kubevirt.io/hugepages: "true"
     instancetype.kubevirt.io/memory: 32Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.1
   name: m1.xlarge
 spec:
   cpu:
@@ -563,14 +563,16 @@ metadata:
   annotations:
     instancetype.kubevirt.io/class: Overcommitted
     instancetype.kubevirt.io/description: |-
-      The O Series is based on the N Series, with the only difference
+      The O Series is based on the U Series, with the only difference
       being that memory is overcommitted.
 
       *O* is the abbreviation for "Overcommitted".
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "8"
+    instancetype.kubevirt.io/memory: 32Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.1
   name: o1.2xlarge
 spec:
   cpu:
@@ -585,14 +587,16 @@ metadata:
   annotations:
     instancetype.kubevirt.io/class: Overcommitted
     instancetype.kubevirt.io/description: |-
-      The O Series is based on the N Series, with the only difference
+      The O Series is based on the U Series, with the only difference
       being that memory is overcommitted.
 
       *O* is the abbreviation for "Overcommitted".
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "16"
+    instancetype.kubevirt.io/memory: 64Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.1
   name: o1.4xlarge
 spec:
   cpu:
@@ -607,14 +611,16 @@ metadata:
   annotations:
     instancetype.kubevirt.io/class: Overcommitted
     instancetype.kubevirt.io/description: |-
-      The O Series is based on the N Series, with the only difference
+      The O Series is based on the U Series, with the only difference
       being that memory is overcommitted.
 
       *O* is the abbreviation for "Overcommitted".
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "32"
+    instancetype.kubevirt.io/memory: 128Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.1
   name: o1.8xlarge
 spec:
   cpu:
@@ -629,14 +635,16 @@ metadata:
   annotations:
     instancetype.kubevirt.io/class: Overcommitted
     instancetype.kubevirt.io/description: |-
-      The O Series is based on the N Series, with the only difference
+      The O Series is based on the U Series, with the only difference
       being that memory is overcommitted.
 
       *O* is the abbreviation for "Overcommitted".
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "2"
+    instancetype.kubevirt.io/memory: 8Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.1
   name: o1.large
 spec:
   cpu:
@@ -651,14 +659,16 @@ metadata:
   annotations:
     instancetype.kubevirt.io/class: Overcommitted
     instancetype.kubevirt.io/description: |-
-      The O Series is based on the N Series, with the only difference
+      The O Series is based on the U Series, with the only difference
       being that memory is overcommitted.
 
       *O* is the abbreviation for "Overcommitted".
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "1"
+    instancetype.kubevirt.io/memory: 4Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.1
   name: o1.medium
 spec:
   cpu:
@@ -673,14 +683,16 @@ metadata:
   annotations:
     instancetype.kubevirt.io/class: Overcommitted
     instancetype.kubevirt.io/description: |-
-      The O Series is based on the N Series, with the only difference
+      The O Series is based on the U Series, with the only difference
       being that memory is overcommitted.
 
       *O* is the abbreviation for "Overcommitted".
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "4"
+    instancetype.kubevirt.io/memory: 16Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.1
   name: o1.xlarge
 spec:
   cpu:
@@ -696,7 +708,7 @@ metadata:
     instancetype.kubevirt.io/deprecated: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
     kubevirt.io/size: large
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.1
   name: server.large
 spec:
   cpu:
@@ -711,7 +723,7 @@ metadata:
     instancetype.kubevirt.io/deprecated: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
     kubevirt.io/size: medium
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.1
   name: server.medium
 spec:
   cpu:
@@ -726,7 +738,7 @@ metadata:
     instancetype.kubevirt.io/deprecated: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
     kubevirt.io/size: micro
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.1
   name: server.micro
 spec:
   cpu:
@@ -741,7 +753,7 @@ metadata:
     instancetype.kubevirt.io/deprecated: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
     kubevirt.io/size: small
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.1
   name: server.small
 spec:
   cpu:
@@ -756,7 +768,7 @@ metadata:
     instancetype.kubevirt.io/deprecated: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
     kubevirt.io/size: tiny
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.1
   name: server.tiny
 spec:
   cpu:
@@ -783,7 +795,7 @@ metadata:
     instancetype.kubevirt.io/cpu: "8"
     instancetype.kubevirt.io/memory: 32Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.1
   name: u1.2xlarge
 spec:
   cpu:
@@ -810,7 +822,7 @@ metadata:
     instancetype.kubevirt.io/cpu: "16"
     instancetype.kubevirt.io/memory: 64Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.1
   name: u1.4xlarge
 spec:
   cpu:
@@ -837,7 +849,7 @@ metadata:
     instancetype.kubevirt.io/cpu: "32"
     instancetype.kubevirt.io/memory: 128Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.1
   name: u1.8xlarge
 spec:
   cpu:
@@ -864,7 +876,7 @@ metadata:
     instancetype.kubevirt.io/cpu: "2"
     instancetype.kubevirt.io/memory: 8Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.1
   name: u1.large
 spec:
   cpu:
@@ -891,7 +903,7 @@ metadata:
     instancetype.kubevirt.io/cpu: "1"
     instancetype.kubevirt.io/memory: 4Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.1
   name: u1.medium
 spec:
   cpu:
@@ -918,7 +930,7 @@ metadata:
     instancetype.kubevirt.io/cpu: "4"
     instancetype.kubevirt.io/memory: 16Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.1
   name: u1.xlarge
 spec:
   cpu:

--- a/data/common-instancetypes-bundle/common-clusterpreferences-bundle.yaml
+++ b/data/common-instancetypes-bundle/common-clusterpreferences-bundle.yaml
@@ -12,7 +12,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.1
   name: alpine
 spec:
   devices:
@@ -37,7 +37,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.1
   name: centos.7
 spec:
   devices:
@@ -62,7 +62,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.1
   name: centos.7.desktop
 spec:
   devices:
@@ -90,7 +90,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.1
   name: centos.8.stream
 spec:
   devices:
@@ -115,7 +115,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.1
   name: centos.8.stream.desktop
 spec:
   devices:
@@ -143,7 +143,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.1
   name: centos.9.stream
 spec:
   devices:
@@ -175,7 +175,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.1
   name: centos.9.stream.desktop
 spec:
   devices:
@@ -210,7 +210,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.1
   name: cirros
 spec:
   devices:
@@ -235,7 +235,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.1
   name: fedora
 spec:
   devices:
@@ -267,7 +267,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.1
   name: rhel.7
 spec:
   devices:
@@ -292,7 +292,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.1
   name: rhel.7.desktop
 spec:
   devices:
@@ -320,7 +320,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.1
   name: rhel.8
 spec:
   devices:
@@ -345,7 +345,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.1
   name: rhel.8.desktop
 spec:
   devices:
@@ -373,7 +373,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.1
   name: rhel.9
 spec:
   devices:
@@ -405,7 +405,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.1
   name: rhel.9.desktop
 spec:
   devices:
@@ -440,7 +440,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.1
   name: ubuntu
 spec:
   devices:
@@ -466,7 +466,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.1
   name: windows.10
 spec:
   clock:
@@ -524,7 +524,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.1
   name: windows.10.virtio
 spec:
   clock:
@@ -584,7 +584,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.1
   name: windows.11
 spec:
   clock:
@@ -642,7 +642,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.1
   name: windows.11.virtio
 spec:
   clock:
@@ -702,7 +702,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.1
   name: windows.2k12
 spec:
   clock:
@@ -760,7 +760,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.1
   name: windows.2k12.virtio
 spec:
   clock:
@@ -820,7 +820,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.1
   name: windows.2k16
 spec:
   clock:
@@ -873,7 +873,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.1
   name: windows.2k16.virtio
 spec:
   clock:
@@ -928,7 +928,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.1
   name: windows.2k19
 spec:
   clock:
@@ -986,7 +986,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.1
   name: windows.2k19.virtio
 spec:
   clock:
@@ -1046,7 +1046,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.1
   name: windows.2k22
 spec:
   clock:
@@ -1109,7 +1109,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.1
   name: windows.2k22.virtio
 spec:
   clock:


### PR DESCRIPTION
common-instancetypes: Update bundle to v0.3.1

https://github.com/kubevirt/common-instancetypes/releases/tag/v0.3.1

**Release note**:
```release-note
Update common-instancetypes bundle to v0.3.1
```
