### PR TITLE
Fix metrics linter script

### DIFF
--- a/hack/prom_metric_linter.sh
+++ b/hack/prom_metric_linter.sh
@@ -48,9 +48,6 @@ done
 go build -o _out/prom-metrics-collector "$METRICS_COLLECTOR_PATH/..."
 json_output=$(_out/prom-metrics-collector 2>/dev/null)
 
-# Select container runtime
-source "${PROJECT_ROOT}"/hack/config.sh
-
 # Check if runs as part of Openshift-ci. If so, run directly
 if [[ "${OPENSHIFT_CI}" == "true" ]]; then
   errors=$(/usr/bin/prom-metrics-linter \
@@ -59,6 +56,9 @@ if [[ "${OPENSHIFT_CI}" == "true" ]]; then
       --sub-operator-name="$sub_operator_name" 2>/dev/null)
 # Else, run in a container, using the linter image
 else
+  # Select container runtime
+  source "${PROJECT_ROOT}"/hack/config.sh
+
   errors=$($KUBEVIRT_CRI run -i "quay.io/kubevirt/prom-metrics-linter:$linter_image_tag" \
       --metric-families="$json_output" \
       --operator-name="$operator_name" \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Currently, the linter [PR](https://github.com/openshift/release/pull/41234) in CI is failing, since `make lint-metrics` gets to https://github.com/kubevirt/ssp-operator/blob/main/hack/config.sh#L8. This PR moves `source "${PROJECT_ROOT}"/hack/config.sh`, in the metrics linter script, so it will be executed only if the linter runs locally.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
