### PR TITLE
refactor(CNV-31248): remove namespace annotation

### DIFF
--- a/automation/e2e-upgrade-functests/run.sh
+++ b/automation/e2e-upgrade-functests/run.sh
@@ -70,6 +70,5 @@ export SKIP_CLEANUP_AFTER_TESTS="true"
 export TEST_EXISTING_CR_NAME="${SSP_NAME}"
 export TEST_EXISTING_CR_NAMESPACE="${SSP_NAMESPACE}"
 export IS_UPGRADE_LANE="true"
-export VM_CONSOLE_PROXY_NAMESPACE="kubevirt"
 
 make deploy functest

--- a/config/samples/ssp_v1beta2_ssp.yaml
+++ b/config/samples/ssp_v1beta2_ssp.yaml
@@ -1,8 +1,6 @@
 apiVersion: ssp.kubevirt.io/v1beta2
 kind: SSP
 metadata:
-  annotations:
-    ssp.kubevirt.io/vm-console-proxy-namespace: "kubevirt"
   name: ssp-sample
   namespace: kubevirt
 spec:

--- a/data/olm-catalog/ssp-operator.clusterserviceversion.yaml
+++ b/data/olm-catalog/ssp-operator.clusterserviceversion.yaml
@@ -9,9 +9,6 @@ metadata:
           "apiVersion": "ssp.kubevirt.io/v1beta2",
           "kind": "SSP",
           "metadata": {
-            "annotations": {
-              "ssp.kubevirt.io/vm-console-proxy-namespace": "kubevirt"
-            },
             "name": "ssp-sample",
             "namespace": "kubevirt"
           },
@@ -259,19 +256,19 @@ spec:
         - apiGroups:
           - ""
           resources:
-          - pods
+          - persistentvolumes
           verbs:
           - get
           - list
           - watch
         - apiGroups:
-            - ""
+          - ""
           resources:
-            - persistentvolumes
+          - pods
           verbs:
-            - get
-            - list
-            - watch
+          - get
+          - list
+          - watch
         - apiGroups:
           - ""
           resources:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,8 +21,6 @@ To activate the operator, create the SSP Custom Resource (CR):
 apiVersion: ssp.kubevirt.io/v1beta2
 kind: SSP
 metadata:
-  annotations:
-    ssp.kubevirt.io/vm-console-proxy-namespace: "kubevirt"
   name: ssp-sample
   namespace: kubevirt
 spec:
@@ -49,8 +47,6 @@ This annotation is used by VM console proxy operand.
 apiVersion: ssp.kubevirt.io/v1beta1
 kind: SSP
 metadata:
-  annotations:
-    ssp.kubevirt.io/vm-console-proxy-namespace: "kubevirt" # If not set, then default namespace is "kubevirt"
   name: ssp-sample
   namespace: kubevirt
 spec: {}

--- a/tests/env/env.go
+++ b/tests/env/env.go
@@ -9,18 +9,17 @@ import (
 )
 
 const (
-	envExistingCrName          = "TEST_EXISTING_CR_NAME"
-	envExistingCrNamespace     = "TEST_EXISTING_CR_NAMESPACE"
-	envSkipUpdateSspTests      = "SKIP_UPDATE_SSP_TESTS"
-	envSkipCleanupAfterTests   = "SKIP_CLEANUP_AFTER_TESTS"
-	envTimeout                 = "TIMEOUT_MINUTES"
-	envShortTimeout            = "SHORT_TIMEOUT_MINUTES"
-	envTopologyMode            = "TOPOLOGY_MODE"
-	envIsUpgradeLane           = "IS_UPGRADE_LANE"
-	envSspDeploymentName       = "SSP_DEPLOYMENT_NAME"
-	envSspDeploymentNamespace  = "SSP_DEPLOYMENT_NAMESPACE"
-	envSspWebhookServiceName   = "SSP_WEBHOOK_SERVICE_NAME"
-	envVmConsoleProxyNamespace = "VM_CONSOLE_PROXY_NAMESPACE"
+	envExistingCrName         = "TEST_EXISTING_CR_NAME"
+	envExistingCrNamespace    = "TEST_EXISTING_CR_NAMESPACE"
+	envSkipUpdateSspTests     = "SKIP_UPDATE_SSP_TESTS"
+	envSkipCleanupAfterTests  = "SKIP_CLEANUP_AFTER_TESTS"
+	envTimeout                = "TIMEOUT_MINUTES"
+	envShortTimeout           = "SHORT_TIMEOUT_MINUTES"
+	envTopologyMode           = "TOPOLOGY_MODE"
+	envIsUpgradeLane          = "IS_UPGRADE_LANE"
+	envSspDeploymentName      = "SSP_DEPLOYMENT_NAME"
+	envSspDeploymentNamespace = "SSP_DEPLOYMENT_NAMESPACE"
+	envSspWebhookServiceName  = "SSP_WEBHOOK_SERVICE_NAME"
 )
 
 const (
@@ -95,10 +94,6 @@ func SspDeploymentNamespace() string {
 
 func SspWebhookServiceName() string {
 	return os.Getenv(envSspWebhookServiceName)
-}
-
-func VmConsoleProxyNamespace() string {
-	return os.Getenv(envVmConsoleProxyNamespace)
 }
 
 func getBoolEnv(envName string) bool {

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -45,7 +45,6 @@ import (
 	sspv1beta1 "kubevirt.io/ssp-operator/api/v1beta1"
 	sspv1beta2 "kubevirt.io/ssp-operator/api/v1beta2"
 	"kubevirt.io/ssp-operator/internal/common"
-	vm_console_proxy "kubevirt.io/ssp-operator/internal/operands/vm-console-proxy"
 )
 
 var (
@@ -63,7 +62,6 @@ type TestSuiteStrategy interface {
 	GetName() string
 	GetNamespace() string
 	GetTemplatesNamespace() string
-	GetVmConsoleProxyNamespace() string
 	GetValidatorReplicas() int
 	GetSSPDeploymentName() string
 	GetSSPDeploymentNameSpace() string
@@ -114,9 +112,6 @@ func (s *newSspStrategy) Init() {
 				common.AppKubernetesPartOfLabel:    "hyperconverged-cluster",
 				common.AppKubernetesVersionLabel:   "v0.0.0-test",
 				common.AppKubernetesComponentLabel: common.AppComponentSchedule.String(),
-			},
-			Annotations: map[string]string{
-				vm_console_proxy.VmConsoleProxyNamespaceAnnotation: s.GetVmConsoleProxyNamespace(),
 			},
 		},
 		Spec: sspv1beta2.SSPSpec{
@@ -180,11 +175,6 @@ func (s *newSspStrategy) GetNamespace() string {
 func (s *newSspStrategy) GetTemplatesNamespace() string {
 	const commonTemplatesTestNS = "ssp-operator-functests-templates"
 	return commonTemplatesTestNS
-}
-
-func (s *newSspStrategy) GetVmConsoleProxyNamespace() string {
-	const vmConsoleProxyNamespace = "kubevirt"
-	return vmConsoleProxyNamespace
 }
 
 func (s *newSspStrategy) GetValidatorReplicas() int {
@@ -314,21 +304,6 @@ func (s *existingSspStrategy) GetTemplatesNamespace() string {
 		panic("Strategy is not initialized")
 	}
 	return s.ssp.Spec.CommonTemplates.Namespace
-}
-
-func (s *existingSspStrategy) GetVmConsoleProxyNamespace() string {
-	if s.ssp != nil && s.ssp.ObjectMeta.GetAnnotations() != nil {
-		namespace, isFound := s.ssp.ObjectMeta.GetAnnotations()[vm_console_proxy.VmConsoleProxyNamespaceAnnotation]
-		if isFound {
-			return namespace
-		}
-	}
-
-	namespace := env.VmConsoleProxyNamespace()
-	if namespace == "" {
-		panic("VM_CONSOLE_PROXY_NAMESPACE is not set")
-	}
-	return namespace
 }
 
 func (s *existingSspStrategy) GetValidatorReplicas() int {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Remove vm-console-proxy-namespace annotation that
is no longer relevant since a new released VM
console proxy is no longer require namespace
to operate, by default it was kubevirt as it
required an access to virt-handler (and also
virt-handler certificates).

Jira-Url: https://issues.redhat.com/browse/CNV-31248

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Remove vm-console-proxy-namespace annotation
```
