### PR TITLE
fix: Use the latest image of vm-console-proxy

### DIFF
--- a/.github/workflows/release-vm-console-proxy.yaml
+++ b/.github/workflows/release-vm-console-proxy.yaml
@@ -17,6 +17,7 @@ jobs:
           OUTPUT_FILE=./data/vm-console-proxy-bundle/vm-console-proxy.yaml
           mkdir -p ./data/vm-console-proxy-bundle
           curl -L https://github.com/kubevirt/vm-console-proxy/releases/download/${RELEASE_VERSION}/vm-console-proxy.yaml > ${OUTPUT_FILE}
+          sed -i "s/defaultVmConsoleProxyImageTag = .*$/defaultVmConsoleProxyImageTag = \"${RELEASE_VERSION}\"/" ./internal/operands/vm-console-proxy/defaults.go 
 
       - name: Create pull request
         if: ${{ github.event.client_payload.release_version }} != ''

--- a/config/manager/manager.template.yaml
+++ b/config/manager/manager.template.yaml
@@ -37,6 +37,7 @@ spec:
           - name: OPERATOR_VERSION
           - name: TEKTON_TASKS_IMAGE
           - name: TEKTON_TASKS_DISK_VIRT_IMAGE
+          - name: VM_CONSOLE_PROXY_IMAGE
         image: controller:latest
         name: manager
         resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -70,6 +70,17 @@ rules:
   - list
   - watch
 - apiGroups:
+  - apiregistration.k8s.io
+  resources:
+  - apiservices
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
   - apps
   resources:
   - deployments
@@ -187,13 +198,29 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - serviceaccounts
   verbs:
   - create
   - delete
+  - get
   - list
+  - patch
   - update
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts/token
+  verbs:
+  - create
 - apiGroups:
   - ""
   resources:
@@ -224,14 +251,6 @@ rules:
   - delete
   - list
   - update
-  - watch
-- apiGroups:
-  - kubevirt.io
-  resources:
-  - virtualmachineinstances
-  verbs:
-  - get
-  - list
   - watch
 - apiGroups:
   - kubevirt.io
@@ -282,6 +301,18 @@ rules:
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
+  - clusterrolebindings
+  - clusterroles
+  - rolebindings
+  verbs:
+  - create
+  - delete
+  - list
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
   - clusterroles
   - rolebindings
   verbs:
@@ -320,7 +351,9 @@ rules:
   verbs:
   - create
   - delete
+  - get
   - list
+  - patch
   - update
   - watch
 - apiGroups:
@@ -328,10 +361,8 @@ rules:
   resources:
   - routes
   verbs:
-  - create
   - delete
   - list
-  - update
   - watch
 - apiGroups:
   - ssp.kubevirt.io
@@ -353,6 +384,12 @@ rules:
   - ssps/status
   verbs:
   - update
+- apiGroups:
+  - subresources.kubevirt.io
+  resources:
+  - virtualmachineinstances/vnc
+  verbs:
+  - get
 - apiGroups:
   - subresources.kubevirt.io
   resources:

--- a/data/olm-catalog/ssp-operator.clusterserviceversion.yaml
+++ b/data/olm-catalog/ssp-operator.clusterserviceversion.yaml
@@ -131,6 +131,17 @@ spec:
           - list
           - watch
         - apiGroups:
+          - apiregistration.k8s.io
+          resources:
+          - apiservices
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
           - apps
           resources:
           - deployments
@@ -248,13 +259,29 @@ spec:
         - apiGroups:
           - ""
           resources:
+          - pods
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
           - serviceaccounts
           verbs:
           - create
           - delete
+          - get
           - list
+          - patch
           - update
           - watch
+        - apiGroups:
+          - ""
+          resources:
+          - serviceaccounts/token
+          verbs:
+          - create
         - apiGroups:
           - ""
           resources:
@@ -285,14 +312,6 @@ spec:
           - delete
           - list
           - update
-          - watch
-        - apiGroups:
-          - kubevirt.io
-          resources:
-          - virtualmachineinstances
-          verbs:
-          - get
-          - list
           - watch
         - apiGroups:
           - kubevirt.io
@@ -343,6 +362,18 @@ spec:
         - apiGroups:
           - rbac.authorization.k8s.io
           resources:
+          - clusterrolebindings
+          - clusterroles
+          - rolebindings
+          verbs:
+          - create
+          - delete
+          - list
+          - update
+          - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
           - clusterroles
           - rolebindings
           verbs:
@@ -381,7 +412,9 @@ spec:
           verbs:
           - create
           - delete
+          - get
           - list
+          - patch
           - update
           - watch
         - apiGroups:
@@ -389,10 +422,8 @@ spec:
           resources:
           - routes
           verbs:
-          - create
           - delete
           - list
-          - update
           - watch
         - apiGroups:
           - ssp.kubevirt.io
@@ -414,6 +445,12 @@ spec:
           - ssps/status
           verbs:
           - update
+        - apiGroups:
+          - subresources.kubevirt.io
+          resources:
+          - virtualmachineinstances/vnc
+          verbs:
+          - get
         - apiGroups:
           - subresources.kubevirt.io
           resources:
@@ -494,6 +531,7 @@ spec:
                   value: 0.14.0
                 - name: TEKTON_TASKS_IMAGE
                 - name: TEKTON_TASKS_DISK_VIRT_IMAGE
+                - name: VM_CONSOLE_PROXY_IMAGE
                 image: quay.io/kubevirt/ssp-operator:latest
                 livenessProbe:
                   httpGet:

--- a/data/vm-console-proxy-bundle/vm-console-proxy.yaml
+++ b/data/vm-console-proxy-bundle/vm-console-proxy.yaml
@@ -23,10 +23,48 @@ rules:
   - kubevirt.io
   resources:
   - virtualmachineinstances
+  - virtualmachines
   verbs:
   - get
   - list
   - watch
+- apiGroups:
+  - subresources.kubevirt.io
+  resources:
+  - virtualmachineinstances/vnc
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts/token
+  verbs:
+  - create
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+  - patch
 - apiGroups:
   - authentication.k8s.io
   resources:
@@ -39,6 +77,20 @@ rules:
   - subjectaccessreviews
   verbs:
   - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: vm-console-proxy
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- kind: ServiceAccount
+  name: vm-console-proxy
+  namespace: kubevirt
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -100,7 +152,7 @@ spec:
       - args: []
         command:
         - /console
-        image: quay.io/kubevirt/vm-console-proxy:v0.2.0
+        image: quay.io/kubevirt/vm-console-proxy:v0.3.1
         imagePullPolicy: Always
         name: console
         ports:
@@ -119,9 +171,6 @@ spec:
         - mountPath: /tmp/vm-console-proxy-cert
           name: vm-console-proxy-cert
           readOnly: true
-        - mountPath: /etc/virt-handler/clientcertificates
-          name: kubevirt-virt-handler-certs
-          readOnly: true
       securityContext:
         runAsNonRoot: true
         seccompProfile:
@@ -135,6 +184,19 @@ spec:
       - name: vm-console-proxy-cert
         secret:
           secretName: vm-console-proxy-cert
-      - name: kubevirt-virt-handler-certs
-        secret:
-          secretName: kubevirt-virt-handler-certs
+---
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"
+  name: v1alpha1.token.kubevirt.io
+spec:
+  group: token.kubevirt.io
+  groupPriorityMinimum: 2000
+  service:
+    name: vm-console-proxy
+    namespace: kubevirt
+    port: 443
+  version: v1alpha1
+  versionPriority: 10

--- a/hack/csv-generator.go
+++ b/hack/csv-generator.go
@@ -48,6 +48,7 @@ type generatorFlags struct {
 	tektonTasksImage         string
 	tektonTasksDiskVirtImage string
 	virtioImage              string
+	vmConsoleProxyImage      string
 }
 
 var (
@@ -83,6 +84,7 @@ func init() {
 	rootCmd.Flags().StringVar(&f.tektonTasksImage, "tekton-tasks-image", "", "Link to tekton tasks image")
 	rootCmd.Flags().StringVar(&f.tektonTasksDiskVirtImage, "tekton-tasks-disk-virt-image", "", "Link to tekton tasks disk virt image")
 	rootCmd.Flags().StringVar(&f.virtioImage, "virtio-image", "", "Link to virtio image")
+	rootCmd.Flags().StringVar(&f.vmConsoleProxyImage, "vm-console-proxy-image", "", "Link to VM console proxy image")
 	rootCmd.Flags().Int32Var(&f.webhookPort, "webhook-port", 0, "Container port for the admission webhook")
 	rootCmd.Flags().BoolVar(&f.removeCerts, "webhook-remove-certs", false, "Remove the webhook certificate volume and mount")
 	rootCmd.Flags().BoolVar(&f.dumpCRDs, "dump-crds", false, "Dump crds to stdout")
@@ -216,6 +218,14 @@ func buildRelatedImages(flags generatorFlags) ([]interface{}, error) {
 		relatedImages = append(relatedImages, relatedImage)
 	}
 
+	if flags.vmConsoleProxyImage != "" {
+		relatedImage, err := buildRelatedImage(flags.vmConsoleProxyImage, "vm-console-proxy")
+		if err != nil {
+			return nil, err
+		}
+		relatedImages = append(relatedImages, relatedImage)
+	}
+
 	return relatedImages, nil
 }
 
@@ -270,6 +280,10 @@ func updateContainerEnvVars(flags generatorFlags, container v1.Container) []v1.E
 		case common.VirtioImageKey:
 			if flags.virtioImage != "" {
 				envVariable.Value = flags.virtioImage
+			}
+		case common.VmConsoleProxyImageKey:
+			if flags.vmConsoleProxyImage != "" {
+				envVariable.Value = flags.vmConsoleProxyImage
 			}
 		}
 

--- a/hack/csv-generator_test.go
+++ b/hack/csv-generator_test.go
@@ -27,6 +27,7 @@ var _ = Describe("csv generator", func() {
 		tektonTasksImage:         "testTektonTasksImage",
 		tektonTasksDiskVirtImage: "testTektonTasksDiskVirtImage",
 		virtioImage:              "testVirtioImage",
+		vmConsoleProxyImage:      "testVmConsoleProxyImage",
 	}
 	envValues := []v1.EnvVar{
 		{Name: common.TemplateValidatorImageKey},
@@ -89,6 +90,9 @@ var _ = Describe("csv generator", func() {
 					}
 					if envVariable.Name == common.VirtioImageKey {
 						Expect(envVariable.Value).To(Equal(flags.virtioImage))
+					}
+					if envVariable.Name == common.VmConsoleProxyImageKey {
+						Expect(envVariable.Value).To(Equal(flags.vmConsoleProxyImage))
 					}
 				}
 				break

--- a/internal/common/environment.go
+++ b/internal/common/environment.go
@@ -21,6 +21,7 @@ const (
 	TektonTasksImageKey         = "TEKTON_TASKS_IMAGE"
 	TektonTasksDiskVirtImageKey = "TEKTON_TASKS_DISK_VIRT_IMAGE"
 	VirtioImageKey              = "VIRTIO_IMG"
+	VmConsoleProxyImageKey      = "VM_CONSOLE_PROXY_IMAGE"
 
 	DefaultTektonTasksIMG         = "quay.io/kubevirt/tekton-tasks:" + TektonTasksVersion
 	DeafultTektonTasksDiskVirtIMG = "quay.io/kubevirt/tekton-tasks-disk-virt:" + TektonTasksVersion

--- a/internal/operands/vm-console-proxy/defaults.go
+++ b/internal/operands/vm-console-proxy/defaults.go
@@ -1,0 +1,8 @@
+package vm_console_proxy
+
+// This file is updated by GitHub action defined in .github/workflows/release-vm-console-proxy.yaml
+
+const (
+	defaultVmConsoleProxyImageTag = "v0.3.1"
+	defaultVmConsoleProxyImage    = "quay.io/kubevirt/vm-console-proxy:" + defaultVmConsoleProxyImageTag
+)

--- a/internal/operands/vm-console-proxy/reconcile.go
+++ b/internal/operands/vm-console-proxy/reconcile.go
@@ -8,8 +8,8 @@ import (
 	apps "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
 	rbac "k8s.io/api/rbac/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	apiregv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	"kubevirt.io/ssp-operator/internal/common"
 	"kubevirt.io/ssp-operator/internal/operands"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -30,16 +30,25 @@ const (
 // +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups=core,resources=configmaps;serviceaccounts,verbs=list;watch;create;update;delete
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;delete
-// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;clusterrolebindings,verbs=list;watch;create;update;delete
-// +kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=list;watch;create;update;delete
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;clusterrolebindings;rolebindings,verbs=list;watch;create;update;delete
+// +kubebuilder:rbac:groups=apiregistration.k8s.io,resources=apiservices,verbs=get;list;watch;create;update;delete
+
+// Deprecated:
+// +kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=list;watch;delete
 
 // RBAC for created roles
-// +kubebuilder:rbac:groups=kubevirt.io,resources=virtualmachineinstances,verbs=get;list;watch
+// +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
+// +kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=get;list;watch;create;update;delete;patch
+// +kubebuilder:rbac:groups=core,resources=serviceaccounts/token,verbs=create
+// +kubebuilder:rbac:groups=kubevirt.io,resources=virtualmachineinstances;virtualmachines,verbs=get;list;watch
+// +kubebuilder:rbac:groups=subresources.kubevirt.io,resources=virtualmachineinstances/vnc,verbs=get
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings,verbs=get;list;watch;create;update;delete;patch
 // +kubebuilder:rbac:groups=authentication.k8s.io,resources=tokenreviews,verbs=create
 // +kubebuilder:rbac:groups=authorization.k8s.io,resources=subjectaccessreviews,verbs=create
 
 func init() {
 	utilruntime.Must(routev1.Install(common.Scheme))
+	utilruntime.Must(apiregv1.AddToScheme(common.Scheme))
 }
 
 func WatchClusterTypes() []operands.WatchType {
@@ -50,6 +59,7 @@ func WatchClusterTypes() []operands.WatchType {
 		{Object: &core.Service{}},
 		{Object: &apps.Deployment{}, WatchFullObject: true},
 		{Object: &core.ConfigMap{}},
+		{Object: &apiregv1.APIService{}},
 		{Object: &routev1.Route{}},
 	}
 }
@@ -58,9 +68,11 @@ type vmConsoleProxy struct {
 	serviceAccount     *core.ServiceAccount
 	clusterRole        *rbac.ClusterRole
 	clusterRoleBinding *rbac.ClusterRoleBinding
+	roleBinding        *rbac.RoleBinding
 	service            *core.Service
 	deployment         *apps.Deployment
 	configMap          *core.ConfigMap
+	apiService         *apiregv1.APIService
 }
 
 var _ operands.Operand = &vmConsoleProxy{}
@@ -70,9 +82,11 @@ func New(bundle *vm_console_proxy_bundle.Bundle) *vmConsoleProxy {
 		serviceAccount:     bundle.ServiceAccount,
 		clusterRole:        bundle.ClusterRole,
 		clusterRoleBinding: bundle.ClusterRoleBinding,
+		roleBinding:        bundle.RoleBinding,
 		service:            bundle.Service,
 		deployment:         bundle.Deployment,
 		configMap:          bundle.ConfigMap,
+		apiService:         bundle.ApiService,
 	}
 }
 
@@ -103,19 +117,41 @@ func (v *vmConsoleProxy) Reconcile(request *common.Request) ([]common.ReconcileR
 		return results, nil
 	}
 
-	return common.CollectResourceStatus(request,
+	reconcileResults, err := common.CollectResourceStatus(request,
 		reconcileServiceAccount(*v.serviceAccount.DeepCopy()),
 		reconcileClusterRole(*v.clusterRole.DeepCopy()),
 		reconcileClusterRoleBinding(*v.clusterRoleBinding.DeepCopy()),
+		reconcileRoleBinding(v.roleBinding.DeepCopy()),
 		reconcileConfigMap(*v.configMap.DeepCopy()),
 		reconcileService(*v.service.DeepCopy()),
 		reconcileDeployment(*v.deployment.DeepCopy()),
-		reconcileRoute(v.service.GetName()))
+		reconcileApiService(v.apiService.DeepCopy()))
+	if err != nil {
+		return nil, err
+	}
+
+	// Route is no longer needed.
+	routeCleanupResults, err := v.deleteRoute(request)
+	if err != nil {
+		return nil, err
+	}
+	for _, cleanupResult := range routeCleanupResults {
+		if !cleanupResult.Deleted {
+			reconcileResults = append(reconcileResults, common.ResourceDeletedResult(cleanupResult.Resource, common.OperationResultDeleted))
+		}
+	}
+
+	return reconcileResults, nil
 }
 
 func (v *vmConsoleProxy) Cleanup(request *common.Request) ([]common.CleanupResult, error) {
 	// We need to use labels to find resources that were deployed by this operand,
 	// because namespace annotation may not be present.
+
+	routeCleanupResults, err := v.deleteRoute(request)
+	if err != nil {
+		return nil, err
+	}
 
 	var objectsToDelete []client.Object
 
@@ -163,6 +199,21 @@ func (v *vmConsoleProxy) Cleanup(request *common.Request) ([]common.CleanupResul
 	}
 	objectsToDelete = append(objectsToDelete, deployments...)
 
+	objectsToDelete = append(objectsToDelete,
+		v.clusterRole.DeepCopy(),
+		v.clusterRoleBinding.DeepCopy(),
+		v.roleBinding.DeepCopy(),
+		v.apiService.DeepCopy())
+
+	cleanupResults, err := common.DeleteAll(request, objectsToDelete...)
+	if err != nil {
+		return nil, err
+	}
+
+	return append(cleanupResults, routeCleanupResults...), nil
+}
+
+func (v *vmConsoleProxy) deleteRoute(request *common.Request) ([]common.CleanupResult, error) {
 	routes, err := findResourcesUsingLabels(
 		request.Context,
 		routeName,
@@ -172,13 +223,8 @@ func (v *vmConsoleProxy) Cleanup(request *common.Request) ([]common.CleanupResul
 	if err != nil {
 		return nil, err
 	}
-	objectsToDelete = append(objectsToDelete, routes...)
 
-	objectsToDelete = append(objectsToDelete,
-		v.clusterRole.DeepCopy(),
-		v.clusterRoleBinding.DeepCopy())
-
-	return common.DeleteAll(request, objectsToDelete...)
+	return common.DeleteAll(request, routes...)
 }
 
 func reconcileServiceAccount(serviceAccount core.ServiceAccount) common.ReconcileFunc {
@@ -204,6 +250,15 @@ func reconcileClusterRoleBinding(clusterRoleBinding rbac.ClusterRoleBinding) com
 	return func(request *common.Request) (common.ReconcileResult, error) {
 		return common.CreateOrUpdate(request).
 			ClusterResource(&clusterRoleBinding).
+			WithAppLabels(operandName, operandComponent).
+			Reconcile()
+	}
+}
+
+func reconcileRoleBinding(roleBinding *rbac.RoleBinding) common.ReconcileFunc {
+	return func(request *common.Request) (common.ReconcileResult, error) {
+		return common.CreateOrUpdate(request).
+			ClusterResource(roleBinding).
 			WithAppLabels(operandName, operandComponent).
 			Reconcile()
 	}
@@ -240,11 +295,21 @@ func reconcileDeployment(deployment apps.Deployment) common.ReconcileFunc {
 	}
 }
 
-func reconcileRoute(serviceName string) common.ReconcileFunc {
+func reconcileApiService(apiService *apiregv1.APIService) common.ReconcileFunc {
 	return func(request *common.Request) (common.ReconcileResult, error) {
+		apiService.Spec.Service.Namespace = getVmConsoleProxyNamespace(request)
 		return common.CreateOrUpdate(request).
-			ClusterResource(newRoute(getVmConsoleProxyNamespace(request), serviceName)).
+			ClusterResource(apiService).
 			WithAppLabels(operandName, operandComponent).
+			UpdateFunc(func(expected, found client.Object) {
+				foundApiService := found.(*apiregv1.APIService)
+				expectedApiService := expected.(*apiregv1.APIService)
+
+				// Keep CA bundle the same in the found object
+				expectedApiService.Spec.CABundle = foundApiService.Spec.CABundle
+
+				foundApiService.Spec = expectedApiService.Spec
+			}).
 			Reconcile()
 	}
 }
@@ -261,7 +326,7 @@ func getVmConsoleProxyNamespace(request *common.Request) string {
 }
 
 func getVmConsoleProxyImage() string {
-	return common.EnvOrDefault("VM_CONSOLE_PROXY_IMAGE", "quay.io/kubevirt/vm-console-proxy:v0.1.0")
+	return common.EnvOrDefault(common.VmConsoleProxyImageKey, defaultVmConsoleProxyImage)
 }
 
 func findResourcesUsingLabels[PtrL interface {
@@ -295,24 +360,4 @@ func findResourcesUsingLabels[PtrL interface {
 		}
 	}
 	return filteredItems, nil
-}
-
-func newRoute(namespace string, serviceName string) *routev1.Route {
-	return &routev1.Route{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      routeName,
-			Namespace: namespace,
-		},
-		Spec: routev1.RouteSpec{
-			To: routev1.RouteTargetReference{
-				Kind: "Service",
-				Name: serviceName,
-			},
-			TLS: &routev1.TLSConfig{
-				Termination:                   routev1.TLSTerminationReencrypt,
-				InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
-			},
-			WildcardPolicy: routev1.WildcardPolicyNone,
-		},
-	}
 }

--- a/internal/vm-console-proxy-bundle/bundle-test-duplicate.yaml
+++ b/internal/vm-console-proxy-bundle/bundle-test-duplicate.yaml
@@ -32,10 +32,48 @@ rules:
   - kubevirt.io
   resources:
   - virtualmachineinstances
+  - virtualmachines
   verbs:
   - get
   - list
   - watch
+- apiGroups:
+  - subresources.kubevirt.io
+  resources:
+  - virtualmachineinstances/vnc
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts/token
+  verbs:
+  - create
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+  - patch
 - apiGroups:
   - authentication.k8s.io
   resources:
@@ -48,6 +86,20 @@ rules:
   - subjectaccessreviews
   verbs:
   - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: vm-console-proxy
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+  - kind: ServiceAccount
+    name: vm-console-proxy
+    namespace: kubevirt
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -109,7 +161,7 @@ spec:
       - args: []
         command:
         - /console
-        image: quay.io/kubevirt/vm-console-proxy:latest
+        image: quay.io/kubevirt/vm-console-proxy:v0.3.1
         imagePullPolicy: Always
         name: console
         ports:
@@ -128,9 +180,6 @@ spec:
         - mountPath: /tmp/vm-console-proxy-cert
           name: vm-console-proxy-cert
           readOnly: true
-        - mountPath: /etc/virt-handler/clientcertificates
-          name: kubevirt-virt-handler-certs
-          readOnly: true
       securityContext:
         runAsNonRoot: true
         seccompProfile:
@@ -144,6 +193,19 @@ spec:
       - name: vm-console-proxy-cert
         secret:
           secretName: vm-console-proxy-cert
-      - name: kubevirt-virt-handler-certs
-        secret:
-          secretName: kubevirt-virt-handler-certs
+---
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"
+  name: v1alpha1.token.kubevirt.io
+spec:
+  group: token.kubevirt.io
+  groupPriorityMinimum: 2000
+  service:
+    name: vm-console-proxy
+    namespace: kubevirt
+    port: 443
+  version: v1alpha1
+  versionPriority: 10

--- a/internal/vm-console-proxy-bundle/bundle-test-incorrect.yaml
+++ b/internal/vm-console-proxy-bundle/bundle-test-incorrect.yaml
@@ -1,4 +1,4 @@
-# Incorrect because ConfigMap is missing.
+# Incorrect because resources are missing.
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/internal/vm-console-proxy-bundle/bundle-test.yaml
+++ b/internal/vm-console-proxy-bundle/bundle-test.yaml
@@ -23,10 +23,48 @@ rules:
   - kubevirt.io
   resources:
   - virtualmachineinstances
+  - virtualmachines
   verbs:
   - get
   - list
   - watch
+- apiGroups:
+  - subresources.kubevirt.io
+  resources:
+  - virtualmachineinstances/vnc
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts/token
+  verbs:
+  - create
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+  - patch
 - apiGroups:
   - authentication.k8s.io
   resources:
@@ -39,6 +77,20 @@ rules:
   - subjectaccessreviews
   verbs:
   - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: vm-console-proxy
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+  - kind: ServiceAccount
+    name: vm-console-proxy
+    namespace: kubevirt
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -100,7 +152,7 @@ spec:
       - args: []
         command:
         - /console
-        image: quay.io/kubevirt/vm-console-proxy:latest
+        image: quay.io/kubevirt/vm-console-proxy:v0.3.1
         imagePullPolicy: Always
         name: console
         ports:
@@ -119,9 +171,6 @@ spec:
         - mountPath: /tmp/vm-console-proxy-cert
           name: vm-console-proxy-cert
           readOnly: true
-        - mountPath: /etc/virt-handler/clientcertificates
-          name: kubevirt-virt-handler-certs
-          readOnly: true
       securityContext:
         runAsNonRoot: true
         seccompProfile:
@@ -135,6 +184,19 @@ spec:
       - name: vm-console-proxy-cert
         secret:
           secretName: vm-console-proxy-cert
-      - name: kubevirt-virt-handler-certs
-        secret:
-          secretName: kubevirt-virt-handler-certs
+---
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"
+  name: v1alpha1.token.kubevirt.io
+spec:
+  group: token.kubevirt.io
+  groupPriorityMinimum: 2000
+  service:
+    name: vm-console-proxy
+    namespace: kubevirt
+    port: 443
+  version: v1alpha1
+  versionPriority: 10

--- a/internal/vm-console-proxy-bundle/bundle_test.go
+++ b/internal/vm-console-proxy-bundle/bundle_test.go
@@ -19,9 +19,11 @@ var _ = Describe("VM Console Proxy Bundle", func() {
 		Expect(bundle.ServiceAccount).ToNot(BeNil(), "service account should not be nil")
 		Expect(bundle.ClusterRole).ToNot(BeNil(), "cluster role should not be nil")
 		Expect(bundle.ClusterRoleBinding).ToNot(BeNil(), "cluster role binding should not be nil")
+		Expect(bundle.RoleBinding).ToNot(BeNil(), "role binding should not be nil")
 		Expect(bundle.Service).ToNot(BeNil(), "service should not be nil")
 		Expect(bundle.Deployment).ToNot(BeNil(), "deployment should not be nil")
 		Expect(bundle.ConfigMap).ToNot(BeNil(), "config map should not be nil")
+		Expect(bundle.ApiService).ToNot(BeNil(), "api service should not be nil")
 	})
 
 	It("should fail if bundle does not contain needed resources", func() {

--- a/tests/e2e-test-csv-generator.sh
+++ b/tests/e2e-test-csv-generator.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 olm_output=$(podman run --rm --entrypoint=/csv-generator quay.io/kubevirt/ssp-operator:latest \
---csv-version=9.9.9 --namespace=namespace-test --operator-version=8.8.8  --validator-image=validator-test --dump-crds \
+--csv-version=9.9.9 --namespace=namespace-test --operator-version=8.8.8  --validator-image=validator-test --vm-console-proxy-image=proxy-test --dump-crds \
 --operator-image=operator-test)
 
 if [ $(echo $olm_output | grep 'ClusterServiceVersion' | wc -l) -eq 0 ]; then
@@ -16,6 +16,11 @@ fi
 
 if [ $(echo $olm_output | grep 'value: validator-test'| wc -l) -eq 0 ]; then
     echo "output doesn't contain correct validator-image"
+    exit 1
+fi
+
+if [ $(echo $olm_output | grep 'value: proxy-test'| wc -l) -eq 0 ]; then
+    echo "output doesn't contain correct proxy-image"
     exit 1
 fi
 

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -392,6 +392,7 @@ func (s *existingSspStrategy) SkipIfUpgradeLane() {
 var (
 	apiClient          client.Client
 	coreClient         *kubernetes.Clientset
+	apiServerHostname  string
 	ctx                context.Context
 	strategy           TestSuiteStrategy
 	sspListerWatcher   cache.ListerWatcher
@@ -468,6 +469,9 @@ func setupApiClient() {
 
 	cfg, err := config.GetConfig()
 	Expect(err).ToNot(HaveOccurred())
+
+	apiServerHostname = cfg.Host
+
 	apiClient, err = client.New(cfg, client.Options{Scheme: testScheme})
 	Expect(err).ToNot(HaveOccurred())
 	coreClient, err = kubernetes.NewForConfig(cfg)


### PR DESCRIPTION
**What this PR does / why we need it**:
- Updated release script to change `vm-console-proxy` image tag.
- csv-generator uses `VM_CONSOLE_PROXY_IMAGE` environment variable to set the image.

**Release note**:
```release-note
csv-generator can be used to set the image of vm-console-proxy.
```
