### PR TITLE
fix: Failing github action

### DIFF
--- a/.github/workflows/add-reviewer-monitoring.yaml
+++ b/.github/workflows/add-reviewer-monitoring.yaml
@@ -22,4 +22,4 @@ jobs:
         id: add_reviewer
         run: gh pr edit ${{ github.event.pull_request.number }} --add-reviewer sradco
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.ACTIONS_TOKEN }}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR changes the token used in GitHub Actions to one with more permissions.

**Release note**:
```
None
```
