### PR TITLE
fix: change delete object type in clean up section in efi pipeline

### DIFF
--- a/data/tekton-pipelines/windows-efi-installer-pipeline.yaml
+++ b/data/tekton-pipelines/windows-efi-installer-pipeline.yaml
@@ -218,7 +218,7 @@ spec:
         - name: deleteObject
           value: true
         - name: deleteObjectKind
-          value: PersistentVolumeClaim
+          value: DataVolume
         - name: deleteObjectName
           value: $(tasks.import-win-iso.results.name)
         - name: namespace
@@ -231,7 +231,7 @@ spec:
         - name: deleteObject
           value: true
         - name: deleteObjectKind
-          value: PersistentVolumeClaim
+          value: DataVolume
         - name: deleteObjectName
           value: $(tasks.create-vm-root-disk.results.name)
         - name: namespace


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: change delete object type in clean up section in efi pipeline

CDI changed behaviour of dataVolume garbage collector. It is now disabled by default. This is causing issue in finally section of efi pipeline, beause the pipeline is trying to delete PVCs, but because the fact, that datavolume is still present, the PVCs are not deleted.
This commit changes the PVC object kind to DataVolume in deleteObjectKind parameter. 
Revert PR for DV GC - https://github.com/kubevirt/containerized-data-importer/commit/0bc6a8aeca570ce138dd28616d15e8a06ce88c1e
Signed-off-by: Karel Simon <ksimon@redhat.com>

**Which issue(s) this PR fixes**: 
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2227957

**Release note**:
```
fix: change delete object type in clean up section in efi pipeline
```
