### PR TITLE
feat: Rework add reviewer workflow

### DIFF
--- a/.github/workflows/add-reviewer-monitoring.yaml
+++ b/.github/workflows/add-reviewer-monitoring.yaml
@@ -1,0 +1,25 @@
+name: Add reviewer from sig-monitoring to PR
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    paths:
+      - internal/operands/metrics/*
+      - internal/common/resource.go
+      - docs/metrics.md
+      - tests/metrics_test_utils.go
+      - tools/metricsdocs/*
+
+jobs:
+  add_reviewer:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Add Reviewer
+        id: add_reviewer
+        run: gh pr comment ${{ github.event.pull_request.number }} --body "/cc sradco"
+        env:
+          GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR reworks the add reviewer workflow to simply add a '/cc user' comment and let Prow handle the rest.

**Special notes for your reviewer**:

**Release note**:
```
None
```
