### PR TITLE
fix: custom configuration of crio in testing cluster

### DIFF
--- a/automation/e2e-tekton/example-pipelines-test.sh
+++ b/automation/e2e-tekton/example-pipelines-test.sh
@@ -4,6 +4,8 @@ cp -L $KUBECONFIG /tmp/kubeconfig && export KUBECONFIG=/tmp/kubeconfig
 export IMG=${CI_OPERATOR_IMG}
 export VALIDATOR_IMG=${CI_VALIDATOR_IMG}
 
+./hack/set-crio-permissions-command.sh
+
 # switch to faster storage class for example pipelines tests (slower storage class is causing timeouts due 
 # to not able to copy whole windows disk)
 if ! oc get storageclass | grep -q 'ssd-csi (default)' > /dev/null; then

--- a/automation/e2e-tekton/test-files/windows10-dv.yaml
+++ b/automation/e2e-tekton/test-files/windows10-dv.yaml
@@ -8,7 +8,7 @@ spec:
   source:
       registry:
         url: 'docker://quay.io/openshift-cnv/containerdisks:Win10_21H2_English_x64'
-        secretRef: "tekton-operator-container-disk-puller" 
+        pullMethod: node
   storage:
     volumeMode: Filesystem
     accessModes:

--- a/automation/e2e-tekton/test-files/windows11-dv.yaml
+++ b/automation/e2e-tekton/test-files/windows11-dv.yaml
@@ -8,7 +8,7 @@ spec:
   source:
       registry:
         url: 'docker://quay.io/openshift-cnv/containerdisks:Win11_22H2_English_x64'
-        secretRef: "tekton-operator-container-disk-puller" 
+        pullMethod: node
   storage:
     volumeMode: Filesystem
     accessModes:

--- a/automation/e2e-tekton/test-files/windows2k22-dv.yaml
+++ b/automation/e2e-tekton/test-files/windows2k22-dv.yaml
@@ -8,7 +8,7 @@ spec:
   source:
       registry:
         url: 'docker://quay.io/openshift-cnv/containerdisks:Win2022_English_x64'
-        secretRef: "tekton-operator-container-disk-puller" 
+        pullMethod: node
   storage:
     volumeMode: Filesystem
     accessModes:

--- a/hack/set-crio-permissions-command.sh
+++ b/hack/set-crio-permissions-command.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -ex
+
+DEBUG_NS=debug-ns
+oc create ns ${DEBUG_NS}
+oc label ns ${DEBUG_NS} security.openshift.io/scc.podSecurityLabelSync=false --overwrite
+oc label ns ${DEBUG_NS} pod-security.kubernetes.io/enforce=privileged --overwrite
+
+NODES=$(oc get nodes -o json | jq -r .items[].metadata.name)
+
+while IFS= read -r node
+do
+	echo "setting device_ownership_from_security_context for ${node}.."
+	oc debug node/${node} --to-namespace ${DEBUG_NS} -- chroot /host sed -i '/^\[crio\.runtime\]/a device_ownership_from_security_context = true' /etc/crio/crio.conf
+	echo "restarting crio service on ${node}"
+	oc debug node/${node} --to-namespace ${DEBUG_NS} -- chroot /host systemctl restart crio
+done <<< "${NODES}"


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: custom configuration of crio in testing cluster

our e2e are not working due to permission issue in crio. cri-o/cri-o#7192 should revert the change.
Until that revert PR is released and available in ci envs, we have to set special configuration on crio on all nodes

**Special notes for your reviewer**:

**Release note**:
```
NONE
```
