### PR TITLE
Force runbooks names to equal alerts names

### DIFF
--- a/tests/metrics_test.go
+++ b/tests/metrics_test.go
@@ -205,9 +205,11 @@ var _ = Describe("Metrics", func() {
 				for _, rule := range group.Rules {
 					if rule.Alert != "" {
 						Expect(rule.Annotations).To(HaveKeyWithValue("summary", Not(BeEmpty())),
-							fmt.Sprintf("%s summary is missing or empty", rule.Alert))
-						Expect(rule.Annotations).To(HaveKeyWithValue("runbook_url", Not(BeEmpty())),
-							fmt.Sprintf("%s runbook_url is missing or empty", rule.Alert))
+							"%s summary is missing or empty", rule.Alert)
+						Expect(rule.Annotations).To(HaveKey("runbook_url"),
+							"%s runbook_url is missing", rule.Alert)
+						Expect(rule.Annotations).To(HaveKeyWithValue("runbook_url", HaveSuffix(rule.Alert)),
+							"%s runbook is not equal to alert name", rule.Alert)
 						resp, err := http.Head(rule.Annotations["runbook_url"])
 						Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("%s runbook is not available", rule.Alert))
 						Expect(resp.StatusCode).Should(Equal(http.StatusOK), fmt.Sprintf("%s runbook is not available", rule.Alert))
@@ -221,13 +223,13 @@ var _ = Describe("Metrics", func() {
 				for _, rule := range group.Rules {
 					if rule.Alert != "" {
 						Expect(rule.Labels).To(HaveKeyWithValue("severity", BeElementOf("info", "warning", "critical")),
-							fmt.Sprintf("%s severity label is missing or not valid", rule.Alert))
+							"%s severity label is missing or not valid", rule.Alert)
 						Expect(rule.Labels).To(HaveKeyWithValue("operator_health_impact", BeElementOf("none", "warning", "critical")),
-							fmt.Sprintf("%s operator_health_impact label is missing or not valid", rule.Alert))
+							"%s operator_health_impact label is missing or not valid", rule.Alert)
 						Expect(rule.Labels).To(HaveKeyWithValue("kubernetes_operator_part_of", "kubevirt"),
-							fmt.Sprintf("%s kubernetes_operator_part_of label is missing or not valid", rule.Alert))
+							"%s kubernetes_operator_part_of label is missing or not valid", rule.Alert)
 						Expect(rule.Labels).To(HaveKeyWithValue("kubernetes_operator_component", "ssp-operator"),
-							fmt.Sprintf("%s kubernetes_operator_component label is missing or not valid", rule.Alert))
+							"%s kubernetes_operator_component label is missing or not valid", rule.Alert)
 					}
 				}
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR adds a check to the alerts rules test, which verifies that the alerts `runbook_url` annotations has the alerts names as a suffix.

**Which issue(s) this PR fixes**: https://issues.redhat.com/browse/CNV-30798


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```