### PR TITLE
fix: CI uses the latest released Kubevirt

### DIFF
--- a/automation/common/versions.sh
+++ b/automation/common/versions.sh
@@ -54,9 +54,7 @@ function latest_version() {
 }
 
 # Latest released Kubevirt version
-# KUBEVIRT_VERSION=$(latest_version "kubevirt" "kubevirt")
-# FIXME(lyarwood) Replace with above once v1.0.0 is released
-KUBEVIRT_VERSION=v1.0.0-rc.0
+KUBEVIRT_VERSION=$(latest_version "kubevirt" "kubevirt")
 
 # Latest released CDI version
 CDI_VERSION=$(latest_version "kubevirt" "containerized-data-importer")


### PR DESCRIPTION

**What this PR does / why we need it**:
Version was pinned before Kubevirt `1.0.0` release. Now it can be unpinned.

**Release note**:
```release-note
None
```
