### PR TITLE
common-instancetypes: Ignore attempts to reconcile virt-operator owned objects from bundle

### DIFF
--- a/tests/common_instancetypes_test.go
+++ b/tests/common_instancetypes_test.go
@@ -4,6 +4,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/utils/pointer"
+	virtv1 "kubevirt.io/api/core/v1"
 	instancetypev1beta1 "kubevirt.io/api/instancetype/v1beta1"
 	ssp "kubevirt.io/ssp-operator/api/v1beta2"
 	common_instancetypes "kubevirt.io/ssp-operator/internal/operands/common-instancetypes"
@@ -59,6 +60,46 @@ var _ = Describe("Common Instance Types", func() {
 			for _, preference := range virtualMachineClusterPreferences {
 				Expect(apiClient.Get(ctx, client.ObjectKey{Name: preference.Name}, &instancetypev1beta1.VirtualMachineClusterPreference{})).To(Succeed())
 			}
+		})
+		It("should ignore resources owned by virt-operator", func() {
+			virtualMachineClusterInstancetypes, err := common_instancetypes.FetchBundleResource[instancetypev1beta1.VirtualMachineClusterInstancetype]("../" + common_instancetypes.BundleDir + common_instancetypes.ClusterInstancetypesBundle)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(virtualMachineClusterInstancetypes).ToNot(BeEmpty())
+
+			virtualMachineClusterPreferences, err := common_instancetypes.FetchBundleResource[instancetypev1beta1.VirtualMachineClusterPreference]("../" + common_instancetypes.BundleDir + common_instancetypes.ClusterPreferencesBundle)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(virtualMachineClusterPreferences).ToNot(BeEmpty())
+
+			// Mutate the preference while also adding the labels for virt-operator
+			instancetypeToUpdate := &virtualMachineClusterInstancetypes[0]
+			Expect(apiClient.Get(ctx, client.ObjectKey{Name: instancetypeToUpdate.Name}, instancetypeToUpdate)).To(Succeed())
+			updatedCPUGuestCount := instancetypeToUpdate.Spec.CPU.Guest + 1
+			instancetypeToUpdate.Spec.CPU.Guest = updatedCPUGuestCount
+			instancetypeToUpdate.Labels = map[string]string{
+				virtv1.ManagedByLabel: virtv1.ManagedByLabelOperatorValue,
+			}
+			Expect(apiClient.Update(ctx, instancetypeToUpdate)).To(Succeed())
+
+			// Mutate the preference while also adding the labels for virt-operator
+			preferenceToUpdate := &virtualMachineClusterPreferences[0]
+			Expect(apiClient.Get(ctx, client.ObjectKey{Name: preferenceToUpdate.Name}, preferenceToUpdate)).To(Succeed())
+			updatedPreferredCPUTopology := instancetypev1beta1.PreferCores
+			updatedPreferenceCPU := &instancetypev1beta1.CPUPreferences{
+				PreferredCPUTopology: &updatedPreferredCPUTopology,
+			}
+			preferenceToUpdate.Spec.CPU = updatedPreferenceCPU
+			preferenceToUpdate.Labels = map[string]string{
+				virtv1.ManagedByLabel: virtv1.ManagedByLabelOperatorValue,
+			}
+			Expect(apiClient.Update(ctx, preferenceToUpdate)).To(Succeed())
+
+			triggerReconciliation()
+
+			// Assert that the mutations made above persist as the reconcile is being ignored
+			Expect(apiClient.Get(ctx, client.ObjectKey{Name: instancetypeToUpdate.Name}, instancetypeToUpdate)).To(Succeed())
+			Expect(instancetypeToUpdate.Spec.CPU.Guest).To(Equal(updatedCPUGuestCount))
+			Expect(apiClient.Get(ctx, client.ObjectKey{Name: preferenceToUpdate.Name}, preferenceToUpdate)).To(Succeed())
+			Expect(preferenceToUpdate.Spec.CPU).To(Equal(updatedPreferenceCPU))
 		})
 	})
 	Context("webhook", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR introduces `IgnoreObjectOwnedByVirtOperator` to `reconcileBuilder` that as the name suggests ignores attempts to reconcile resources that are labelled as being owned by KubeVirt's `virt-operator`.

This is then used by the `common-instancetypes` operand ahead of deployment of these resources being enabled through `virt-operator` by https://github.com/kubevirt/kubevirt/pull/10309.

Future changes will also introduce a configurable to disable `common-instancetypes` deployment within SSP and ultimately deprecate the functionality ahead of removal in a future release of SSP.

**Which issue(s) this PR fixes**: 
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
