### PR TITLE
test: remove part-of label expected

### DIFF
--- a/tests/service_controller_test.go
+++ b/tests/service_controller_test.go
@@ -46,7 +46,6 @@ var _ = Describe("Service Controller", func() {
 		Expect(service.GetLabels()).To(HaveKeyWithValue(common.AppKubernetesManagedByLabel, controllers.ServiceManagedByLabelValue))
 		Expect(service.GetLabels()).To(HaveKeyWithValue(common.AppKubernetesVersionLabel, common.GetOperatorVersion()))
 		Expect(service.GetLabels()).To(HaveKeyWithValue(common.AppKubernetesComponentLabel, controllers.ServiceControllerName))
-		Expect(service.GetLabels()[common.AppKubernetesPartOfLabel]).To(BeEmpty())
 	})
 
 	It("[test_id: 8808] Should re-create ssp-operator-metrics service if deleted", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Remove the test of expected part-of label from
service tests because in upstream CI we don't
set that label and it's empty.

However, in downstream it's deployed by HCO and
the part-of label is set.

Jira Urls:
1. https://issues.redhat.com/browse/CNV-32226
2. https://issues.redhat.com/browse/CNV-32128

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
