### PR TITLE
[release-v0.18] fix: Use the latest image of vm-console-proxy

### DIFF
--- a/.github/workflows/release-vm-console-proxy.yaml
+++ b/.github/workflows/release-vm-console-proxy.yaml
@@ -17,6 +17,7 @@ jobs:
           OUTPUT_FILE=./data/vm-console-proxy-bundle/vm-console-proxy.yaml
           mkdir -p ./data/vm-console-proxy-bundle
           curl -L https://github.com/kubevirt/vm-console-proxy/releases/download/${RELEASE_VERSION}/vm-console-proxy.yaml > ${OUTPUT_FILE}
+          sed -i "s/defaultVmConsoleProxyImageTag = .*$/defaultVmConsoleProxyImageTag = \"${RELEASE_VERSION}\"/" ./internal/operands/vm-console-proxy/defaults.go 
 
       - name: Create pull request
         if: ${{ github.event.client_payload.release_version }} != ''

--- a/config/manager/manager.template.yaml
+++ b/config/manager/manager.template.yaml
@@ -37,6 +37,7 @@ spec:
           - name: OPERATOR_VERSION
           - name: TEKTON_TASKS_IMAGE
           - name: TEKTON_TASKS_DISK_VIRT_IMAGE
+          - name: VM_CONSOLE_PROXY_IMAGE
         image: controller:latest
         name: manager
         resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -73,6 +73,18 @@ rules:
   - list
   - watch
 - apiGroups:
+  - apiregistration.k8s.io
+  resources:
+  - apiservices
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - apps
   resources:
   - deployments
@@ -197,6 +209,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - serviceaccounts
   verbs:
   - create
@@ -220,6 +240,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - serviceaccounts/token
+  verbs:
+  - create
+- apiGroups:
   - instancetype.kubevirt.io
   resources:
   - virtualmachineclusterinstancetypes
@@ -242,14 +268,6 @@ rules:
   - list
   - patch
   - update
-  - watch
-- apiGroups:
-  - kubevirt.io
-  resources:
-  - virtualmachineinstances
-  verbs:
-  - get
-  - list
   - watch
 - apiGroups:
   - kubevirt.io
@@ -306,6 +324,20 @@ rules:
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
+  - clusterrolebindings
+  - clusterroles
+  - rolebindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
   - clusterroles
   - rolebindings
   verbs:
@@ -343,6 +375,19 @@ rules:
   - update
   - watch
 - apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  - roles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - rbac.authorization.k8s.io/v1
   resources:
   - role
@@ -361,12 +406,8 @@ rules:
   resources:
   - routes
   verbs:
-  - create
   - delete
-  - get
   - list
-  - patch
-  - update
   - watch
 - apiGroups:
   - ssp.kubevirt.io
@@ -430,6 +471,12 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - subresources.kubevirt.io
+  resources:
+  - virtualmachineinstances/vnc
+  verbs:
+  - get
 - apiGroups:
   - subresources.kubevirt.io
   resources:

--- a/data/olm-catalog/ssp-operator.clusterserviceversion.yaml
+++ b/data/olm-catalog/ssp-operator.clusterserviceversion.yaml
@@ -134,6 +134,18 @@ spec:
           - list
           - watch
         - apiGroups:
+          - apiregistration.k8s.io
+          resources:
+          - apiservices
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
           - apps
           resources:
           - deployments
@@ -258,6 +270,14 @@ spec:
         - apiGroups:
           - ""
           resources:
+          - pods
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
           - serviceaccounts
           verbs:
           - create
@@ -281,6 +301,12 @@ spec:
           - update
           - watch
         - apiGroups:
+          - ""
+          resources:
+          - serviceaccounts/token
+          verbs:
+          - create
+        - apiGroups:
           - instancetype.kubevirt.io
           resources:
           - virtualmachineclusterinstancetypes
@@ -303,14 +329,6 @@ spec:
           - list
           - patch
           - update
-          - watch
-        - apiGroups:
-          - kubevirt.io
-          resources:
-          - virtualmachineinstances
-          verbs:
-          - get
-          - list
           - watch
         - apiGroups:
           - kubevirt.io
@@ -367,6 +385,20 @@ spec:
         - apiGroups:
           - rbac.authorization.k8s.io
           resources:
+          - clusterrolebindings
+          - clusterroles
+          - rolebindings
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
           - clusterroles
           - rolebindings
           verbs:
@@ -404,6 +436,19 @@ spec:
           - update
           - watch
         - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - rolebindings
+          - roles
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
           - rbac.authorization.k8s.io/v1
           resources:
           - role
@@ -422,12 +467,8 @@ spec:
           resources:
           - routes
           verbs:
-          - create
           - delete
-          - get
           - list
-          - patch
-          - update
           - watch
         - apiGroups:
           - ssp.kubevirt.io
@@ -491,6 +532,12 @@ spec:
           - get
           - patch
           - update
+        - apiGroups:
+          - subresources.kubevirt.io
+          resources:
+          - virtualmachineinstances/vnc
+          verbs:
+          - get
         - apiGroups:
           - subresources.kubevirt.io
           resources:
@@ -586,6 +633,7 @@ spec:
                   value: 0.14.0
                 - name: TEKTON_TASKS_IMAGE
                 - name: TEKTON_TASKS_DISK_VIRT_IMAGE
+                - name: VM_CONSOLE_PROXY_IMAGE
                 image: quay.io/kubevirt/ssp-operator:latest
                 livenessProbe:
                   httpGet:

--- a/data/vm-console-proxy-bundle/vm-console-proxy.yaml
+++ b/data/vm-console-proxy-bundle/vm-console-proxy.yaml
@@ -23,10 +23,48 @@ rules:
   - kubevirt.io
   resources:
   - virtualmachineinstances
+  - virtualmachines
   verbs:
   - get
   - list
   - watch
+- apiGroups:
+  - subresources.kubevirt.io
+  resources:
+  - virtualmachineinstances/vnc
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts/token
+  verbs:
+  - create
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+  - patch
 - apiGroups:
   - authentication.k8s.io
   resources:
@@ -39,6 +77,20 @@ rules:
   - subjectaccessreviews
   verbs:
   - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: vm-console-proxy
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- kind: ServiceAccount
+  name: vm-console-proxy
+  namespace: kubevirt
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -100,7 +152,7 @@ spec:
       - args: []
         command:
         - /console
-        image: quay.io/kubevirt/vm-console-proxy:v0.2.0
+        image: quay.io/kubevirt/vm-console-proxy:v0.3.1
         imagePullPolicy: Always
         name: console
         ports:
@@ -119,9 +171,6 @@ spec:
         - mountPath: /tmp/vm-console-proxy-cert
           name: vm-console-proxy-cert
           readOnly: true
-        - mountPath: /etc/virt-handler/clientcertificates
-          name: kubevirt-virt-handler-certs
-          readOnly: true
       securityContext:
         runAsNonRoot: true
         seccompProfile:
@@ -135,6 +184,19 @@ spec:
       - name: vm-console-proxy-cert
         secret:
           secretName: vm-console-proxy-cert
-      - name: kubevirt-virt-handler-certs
-        secret:
-          secretName: kubevirt-virt-handler-certs
+---
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"
+  name: v1alpha1.token.kubevirt.io
+spec:
+  group: token.kubevirt.io
+  groupPriorityMinimum: 2000
+  service:
+    name: vm-console-proxy
+    namespace: kubevirt
+    port: 443
+  version: v1alpha1
+  versionPriority: 10

--- a/hack/csv-generator.go
+++ b/hack/csv-generator.go
@@ -48,6 +48,7 @@ type generatorFlags struct {
 	tektonTasksImage         string
 	tektonTasksDiskVirtImage string
 	virtioImage              string
+	vmConsoleProxyImage      string
 }
 
 var (
@@ -83,6 +84,7 @@ func init() {
 	rootCmd.Flags().StringVar(&f.tektonTasksImage, "tekton-tasks-image", "", "Link to tekton tasks image")
 	rootCmd.Flags().StringVar(&f.tektonTasksDiskVirtImage, "tekton-tasks-disk-virt-image", "", "Link to tekton tasks disk virt image")
 	rootCmd.Flags().StringVar(&f.virtioImage, "virtio-image", "", "Link to virtio image")
+	rootCmd.Flags().StringVar(&f.vmConsoleProxyImage, "vm-console-proxy-image", "", "Link to VM console proxy image")
 	rootCmd.Flags().Int32Var(&f.webhookPort, "webhook-port", 0, "Container port for the admission webhook")
 	rootCmd.Flags().BoolVar(&f.removeCerts, "webhook-remove-certs", false, "Remove the webhook certificate volume and mount")
 	rootCmd.Flags().BoolVar(&f.dumpCRDs, "dump-crds", false, "Dump crds to stdout")
@@ -216,6 +218,14 @@ func buildRelatedImages(flags generatorFlags) ([]interface{}, error) {
 		relatedImages = append(relatedImages, relatedImage)
 	}
 
+	if flags.vmConsoleProxyImage != "" {
+		relatedImage, err := buildRelatedImage(flags.vmConsoleProxyImage, "vm-console-proxy")
+		if err != nil {
+			return nil, err
+		}
+		relatedImages = append(relatedImages, relatedImage)
+	}
+
 	return relatedImages, nil
 }
 
@@ -270,6 +280,10 @@ func updateContainerEnvVars(flags generatorFlags, container v1.Container) []v1.E
 		case common.VirtioImageKey:
 			if flags.virtioImage != "" {
 				envVariable.Value = flags.virtioImage
+			}
+		case common.VmConsoleProxyImageKey:
+			if flags.vmConsoleProxyImage != "" {
+				envVariable.Value = flags.vmConsoleProxyImage
 			}
 		}
 

--- a/hack/csv-generator_test.go
+++ b/hack/csv-generator_test.go
@@ -27,6 +27,7 @@ var _ = Describe("csv generator", func() {
 		tektonTasksImage:         "testTektonTasksImage",
 		tektonTasksDiskVirtImage: "testTektonTasksDiskVirtImage",
 		virtioImage:              "testVirtioImage",
+		vmConsoleProxyImage:      "testVmConsoleProxyImage",
 	}
 	envValues := []v1.EnvVar{
 		{Name: common.TemplateValidatorImageKey},
@@ -89,6 +90,9 @@ var _ = Describe("csv generator", func() {
 					}
 					if envVariable.Name == common.VirtioImageKey {
 						Expect(envVariable.Value).To(Equal(flags.virtioImage))
+					}
+					if envVariable.Name == common.VmConsoleProxyImageKey {
+						Expect(envVariable.Value).To(Equal(flags.vmConsoleProxyImage))
 					}
 				}
 				break

--- a/internal/common/environment.go
+++ b/internal/common/environment.go
@@ -21,6 +21,7 @@ const (
 	TektonTasksImageKey         = "TEKTON_TASKS_IMAGE"
 	TektonTasksDiskVirtImageKey = "TEKTON_TASKS_DISK_VIRT_IMAGE"
 	VirtioImageKey              = "VIRTIO_IMG"
+	VmConsoleProxyImageKey      = "VM_CONSOLE_PROXY_IMAGE"
 
 	DefaultTektonTasksIMG         = "quay.io/kubevirt/tekton-tasks:" + TektonTasksVersion
 	DeafultTektonTasksDiskVirtIMG = "quay.io/kubevirt/tekton-tasks-disk-virt:" + TektonTasksVersion

--- a/internal/operands/vm-console-proxy/defaults.go
+++ b/internal/operands/vm-console-proxy/defaults.go
@@ -1,0 +1,8 @@
+package vm_console_proxy
+
+// This file is updated by GitHub action defined in .github/workflows/release-vm-console-proxy.yaml
+
+const (
+	defaultVmConsoleProxyImageTag = "v0.3.1"
+	defaultVmConsoleProxyImage    = "quay.io/kubevirt/vm-console-proxy:" + defaultVmConsoleProxyImageTag
+)

--- a/internal/vm-console-proxy-bundle/bundle-test-duplicate.yaml
+++ b/internal/vm-console-proxy-bundle/bundle-test-duplicate.yaml
@@ -32,10 +32,48 @@ rules:
   - kubevirt.io
   resources:
   - virtualmachineinstances
+  - virtualmachines
   verbs:
   - get
   - list
   - watch
+- apiGroups:
+  - subresources.kubevirt.io
+  resources:
+  - virtualmachineinstances/vnc
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts/token
+  verbs:
+  - create
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+  - patch
 - apiGroups:
   - authentication.k8s.io
   resources:
@@ -48,6 +86,20 @@ rules:
   - subjectaccessreviews
   verbs:
   - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: vm-console-proxy
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+  - kind: ServiceAccount
+    name: vm-console-proxy
+    namespace: kubevirt
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -109,7 +161,7 @@ spec:
       - args: []
         command:
         - /console
-        image: quay.io/kubevirt/vm-console-proxy:latest
+        image: quay.io/kubevirt/vm-console-proxy:v0.3.1
         imagePullPolicy: Always
         name: console
         ports:
@@ -128,9 +180,6 @@ spec:
         - mountPath: /tmp/vm-console-proxy-cert
           name: vm-console-proxy-cert
           readOnly: true
-        - mountPath: /etc/virt-handler/clientcertificates
-          name: kubevirt-virt-handler-certs
-          readOnly: true
       securityContext:
         runAsNonRoot: true
         seccompProfile:
@@ -144,6 +193,19 @@ spec:
       - name: vm-console-proxy-cert
         secret:
           secretName: vm-console-proxy-cert
-      - name: kubevirt-virt-handler-certs
-        secret:
-          secretName: kubevirt-virt-handler-certs
+---
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"
+  name: v1alpha1.token.kubevirt.io
+spec:
+  group: token.kubevirt.io
+  groupPriorityMinimum: 2000
+  service:
+    name: vm-console-proxy
+    namespace: kubevirt
+    port: 443
+  version: v1alpha1
+  versionPriority: 10

--- a/internal/vm-console-proxy-bundle/bundle-test-incorrect.yaml
+++ b/internal/vm-console-proxy-bundle/bundle-test-incorrect.yaml
@@ -1,4 +1,4 @@
-# Incorrect because ConfigMap is missing.
+# Incorrect because resources are missing.
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/internal/vm-console-proxy-bundle/bundle-test.yaml
+++ b/internal/vm-console-proxy-bundle/bundle-test.yaml
@@ -23,10 +23,48 @@ rules:
   - kubevirt.io
   resources:
   - virtualmachineinstances
+  - virtualmachines
   verbs:
   - get
   - list
   - watch
+- apiGroups:
+  - subresources.kubevirt.io
+  resources:
+  - virtualmachineinstances/vnc
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts/token
+  verbs:
+  - create
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+  - patch
 - apiGroups:
   - authentication.k8s.io
   resources:
@@ -39,6 +77,20 @@ rules:
   - subjectaccessreviews
   verbs:
   - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: vm-console-proxy
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+  - kind: ServiceAccount
+    name: vm-console-proxy
+    namespace: kubevirt
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -100,7 +152,7 @@ spec:
       - args: []
         command:
         - /console
-        image: quay.io/kubevirt/vm-console-proxy:latest
+        image: quay.io/kubevirt/vm-console-proxy:v0.3.1
         imagePullPolicy: Always
         name: console
         ports:
@@ -119,9 +171,6 @@ spec:
         - mountPath: /tmp/vm-console-proxy-cert
           name: vm-console-proxy-cert
           readOnly: true
-        - mountPath: /etc/virt-handler/clientcertificates
-          name: kubevirt-virt-handler-certs
-          readOnly: true
       securityContext:
         runAsNonRoot: true
         seccompProfile:
@@ -135,6 +184,19 @@ spec:
       - name: vm-console-proxy-cert
         secret:
           secretName: vm-console-proxy-cert
-      - name: kubevirt-virt-handler-certs
-        secret:
-          secretName: kubevirt-virt-handler-certs
+---
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"
+  name: v1alpha1.token.kubevirt.io
+spec:
+  group: token.kubevirt.io
+  groupPriorityMinimum: 2000
+  service:
+    name: vm-console-proxy
+    namespace: kubevirt
+    port: 443
+  version: v1alpha1
+  versionPriority: 10

--- a/internal/vm-console-proxy-bundle/bundle_test.go
+++ b/internal/vm-console-proxy-bundle/bundle_test.go
@@ -19,9 +19,11 @@ var _ = Describe("VM Console Proxy Bundle", func() {
 		Expect(bundle.ServiceAccount).ToNot(BeNil(), "service account should not be nil")
 		Expect(bundle.ClusterRole).ToNot(BeNil(), "cluster role should not be nil")
 		Expect(bundle.ClusterRoleBinding).ToNot(BeNil(), "cluster role binding should not be nil")
+		Expect(bundle.RoleBinding).ToNot(BeNil(), "role binding should not be nil")
 		Expect(bundle.Service).ToNot(BeNil(), "service should not be nil")
 		Expect(bundle.Deployment).ToNot(BeNil(), "deployment should not be nil")
 		Expect(bundle.ConfigMap).ToNot(BeNil(), "config map should not be nil")
+		Expect(bundle.ApiService).ToNot(BeNil(), "api service should not be nil")
 	})
 
 	It("should fail if bundle does not contain needed resources", func() {

--- a/tests/e2e-test-csv-generator.sh
+++ b/tests/e2e-test-csv-generator.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 olm_output=$(podman run --rm --entrypoint=/csv-generator quay.io/kubevirt/ssp-operator:latest \
---csv-version=9.9.9 --namespace=namespace-test --operator-version=8.8.8  --validator-image=validator-test --dump-crds \
+--csv-version=9.9.9 --namespace=namespace-test --operator-version=8.8.8  --validator-image=validator-test --vm-console-proxy-image=proxy-test --dump-crds \
 --operator-image=operator-test)
 
 if [ $(echo $olm_output | grep 'ClusterServiceVersion' | wc -l) -eq 0 ]; then
@@ -16,6 +16,11 @@ fi
 
 if [ $(echo $olm_output | grep 'value: validator-test'| wc -l) -eq 0 ]; then
     echo "output doesn't contain correct validator-image"
+    exit 1
+fi
+
+if [ $(echo $olm_output | grep 'value: proxy-test'| wc -l) -eq 0 ]; then
+    echo "output doesn't contain correct proxy-image"
     exit 1
 fi
 

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -392,6 +392,7 @@ func (s *existingSspStrategy) SkipIfUpgradeLane() {
 var (
 	apiClient          client.Client
 	coreClient         *kubernetes.Clientset
+	apiServerHostname  string
 	ctx                context.Context
 	strategy           TestSuiteStrategy
 	sspListerWatcher   cache.ListerWatcher
@@ -468,6 +469,9 @@ func setupApiClient() {
 
 	cfg, err := config.GetConfig()
 	Expect(err).ToNot(HaveOccurred())
+
+	apiServerHostname = cfg.Host
+
 	apiClient, err = client.New(cfg, client.Options{Scheme: testScheme})
 	Expect(err).ToNot(HaveOccurred())
 	coreClient, err = kubernetes.NewForConfig(cfg)


### PR DESCRIPTION
This is a cherry-pick of: https://github.com/kubevirt/ssp-operator/pull/645

**Release note**:
```release-note
csv-generator can be used to set the image of vm-console-proxy.
```
