### PR TITLE
[release-v0.18] refactor(CNV-31248): remove namespace annotation

### DIFF
--- a/automation/e2e-upgrade-functests/run.sh
+++ b/automation/e2e-upgrade-functests/run.sh
@@ -70,6 +70,5 @@ export SKIP_CLEANUP_AFTER_TESTS="true"
 export TEST_EXISTING_CR_NAME="${SSP_NAME}"
 export TEST_EXISTING_CR_NAMESPACE="${SSP_NAMESPACE}"
 export IS_UPGRADE_LANE="true"
-export VM_CONSOLE_PROXY_NAMESPACE="kubevirt"
 
 make deploy functest

--- a/config/samples/ssp_v1beta2_ssp.yaml
+++ b/config/samples/ssp_v1beta2_ssp.yaml
@@ -1,8 +1,6 @@
 apiVersion: ssp.kubevirt.io/v1beta2
 kind: SSP
 metadata:
-  annotations:
-    ssp.kubevirt.io/vm-console-proxy-namespace: "kubevirt"
   name: ssp-sample
   namespace: kubevirt
 spec:

--- a/data/olm-catalog/ssp-operator.clusterserviceversion.yaml
+++ b/data/olm-catalog/ssp-operator.clusterserviceversion.yaml
@@ -9,9 +9,6 @@ metadata:
           "apiVersion": "ssp.kubevirt.io/v1beta2",
           "kind": "SSP",
           "metadata": {
-            "annotations": {
-              "ssp.kubevirt.io/vm-console-proxy-namespace": "kubevirt"
-            },
             "name": "ssp-sample",
             "namespace": "kubevirt"
           },
@@ -268,13 +265,13 @@ spec:
           - list
           - watch
         - apiGroups:
-            - ""
+          - ""
           resources:
-            - persistentvolumes
+          - persistentvolumes
           verbs:
-            - get
-            - list
-            - watch
+          - get
+          - list
+          - watch
         - apiGroups:
           - ""
           resources:

--- a/internal/operands/vm-console-proxy/reconcile.go
+++ b/internal/operands/vm-console-proxy/reconcile.go
@@ -18,8 +18,6 @@ import (
 )
 
 const (
-	VmConsoleProxyNamespaceAnnotation = "ssp.kubevirt.io/vm-console-proxy-namespace"
-
 	operandName      = "vm-console-proxy"
 	operandComponent = "vm-console-proxy"
 
@@ -54,11 +52,16 @@ func WatchClusterTypes() []operands.WatchType {
 	return []operands.WatchType{
 		{Object: &rbac.ClusterRole{}},
 		{Object: &rbac.ClusterRoleBinding{}},
+		{Object: &apiregv1.APIService{}},
+	}
+}
+
+func WatchTypes() []operands.WatchType {
+	return []operands.WatchType{
 		{Object: &core.ServiceAccount{}},
 		{Object: &core.Service{}},
 		{Object: &apps.Deployment{}, WatchFullObject: true},
 		{Object: &core.ConfigMap{}},
-		{Object: &apiregv1.APIService{}},
 		{Object: &routev1.Route{}},
 	}
 }
@@ -94,7 +97,7 @@ func (v *vmConsoleProxy) Name() string {
 }
 
 func (v *vmConsoleProxy) WatchTypes() []operands.WatchType {
-	return nil
+	return WatchTypes()
 }
 
 func (v *vmConsoleProxy) WatchClusterTypes() []operands.WatchType {
@@ -228,9 +231,9 @@ func (v *vmConsoleProxy) deleteRoute(request *common.Request) ([]common.CleanupR
 
 func reconcileServiceAccount(serviceAccount core.ServiceAccount) common.ReconcileFunc {
 	return func(request *common.Request) (common.ReconcileResult, error) {
-		serviceAccount.Namespace = getVmConsoleProxyNamespace(request)
+		serviceAccount.Namespace = request.Instance.Namespace
 		return common.CreateOrUpdate(request).
-			ClusterResource(&serviceAccount).
+			NamespacedResource(&serviceAccount).
 			WithAppLabels(operandName, operandComponent).
 			Reconcile()
 	}
@@ -247,6 +250,7 @@ func reconcileClusterRole(clusterRole rbac.ClusterRole) common.ReconcileFunc {
 
 func reconcileClusterRoleBinding(clusterRoleBinding rbac.ClusterRoleBinding) common.ReconcileFunc {
 	return func(request *common.Request) (common.ReconcileResult, error) {
+		clusterRoleBinding.Subjects[0].Namespace = request.Instance.Namespace
 		return common.CreateOrUpdate(request).
 			ClusterResource(&clusterRoleBinding).
 			WithAppLabels(operandName, operandComponent).
@@ -256,6 +260,7 @@ func reconcileClusterRoleBinding(clusterRoleBinding rbac.ClusterRoleBinding) com
 
 func reconcileRoleBinding(roleBinding *rbac.RoleBinding) common.ReconcileFunc {
 	return func(request *common.Request) (common.ReconcileResult, error) {
+		roleBinding.Subjects[0].Namespace = request.Instance.Namespace
 		return common.CreateOrUpdate(request).
 			ClusterResource(roleBinding).
 			WithAppLabels(operandName, operandComponent).
@@ -265,9 +270,9 @@ func reconcileRoleBinding(roleBinding *rbac.RoleBinding) common.ReconcileFunc {
 
 func reconcileConfigMap(configMap core.ConfigMap) common.ReconcileFunc {
 	return func(request *common.Request) (common.ReconcileResult, error) {
-		configMap.Namespace = getVmConsoleProxyNamespace(request)
+		configMap.Namespace = request.Instance.Namespace
 		return common.CreateOrUpdate(request).
-			ClusterResource(&configMap).
+			NamespacedResource(&configMap).
 			WithAppLabels(operandName, operandComponent).
 			Reconcile()
 	}
@@ -275,9 +280,9 @@ func reconcileConfigMap(configMap core.ConfigMap) common.ReconcileFunc {
 
 func reconcileService(service core.Service) common.ReconcileFunc {
 	return func(request *common.Request) (common.ReconcileResult, error) {
-		service.Namespace = getVmConsoleProxyNamespace(request)
+		service.Namespace = request.Instance.Namespace
 		return common.CreateOrUpdate(request).
-			ClusterResource(&service).
+			NamespacedResource(&service).
 			WithAppLabels(operandName, operandComponent).
 			Reconcile()
 	}
@@ -285,10 +290,10 @@ func reconcileService(service core.Service) common.ReconcileFunc {
 
 func reconcileDeployment(deployment apps.Deployment) common.ReconcileFunc {
 	return func(request *common.Request) (common.ReconcileResult, error) {
-		deployment.Namespace = getVmConsoleProxyNamespace(request)
+		deployment.Namespace = request.Instance.Namespace
 		deployment.Spec.Template.Spec.Containers[0].Image = getVmConsoleProxyImage()
 		return common.CreateOrUpdate(request).
-			ClusterResource(&deployment).
+			NamespacedResource(&deployment).
 			WithAppLabels(operandName, operandComponent).
 			Reconcile()
 	}
@@ -296,7 +301,7 @@ func reconcileDeployment(deployment apps.Deployment) common.ReconcileFunc {
 
 func reconcileApiService(apiService *apiregv1.APIService) common.ReconcileFunc {
 	return func(request *common.Request) (common.ReconcileResult, error) {
-		apiService.Spec.Service.Namespace = getVmConsoleProxyNamespace(request)
+		apiService.Spec.Service.Namespace = request.Instance.Namespace
 		return common.CreateOrUpdate(request).
 			ClusterResource(apiService).
 			WithAppLabels(operandName, operandComponent).
@@ -311,17 +316,6 @@ func reconcileApiService(apiService *apiregv1.APIService) common.ReconcileFunc {
 			}).
 			Reconcile()
 	}
-}
-
-func getVmConsoleProxyNamespace(request *common.Request) string {
-	const defaultNamespace = "kubevirt"
-	if request.Instance.GetAnnotations() == nil {
-		return defaultNamespace
-	}
-	if namespace, isFound := request.Instance.GetAnnotations()[VmConsoleProxyNamespaceAnnotation]; isFound {
-		return namespace
-	}
-	return defaultNamespace
 }
 
 func getVmConsoleProxyImage() string {

--- a/tests/env/env.go
+++ b/tests/env/env.go
@@ -9,18 +9,17 @@ import (
 )
 
 const (
-	envExistingCrName          = "TEST_EXISTING_CR_NAME"
-	envExistingCrNamespace     = "TEST_EXISTING_CR_NAMESPACE"
-	envSkipUpdateSspTests      = "SKIP_UPDATE_SSP_TESTS"
-	envSkipCleanupAfterTests   = "SKIP_CLEANUP_AFTER_TESTS"
-	envTimeout                 = "TIMEOUT_MINUTES"
-	envShortTimeout            = "SHORT_TIMEOUT_MINUTES"
-	envTopologyMode            = "TOPOLOGY_MODE"
-	envIsUpgradeLane           = "IS_UPGRADE_LANE"
-	envSspDeploymentName       = "SSP_DEPLOYMENT_NAME"
-	envSspDeploymentNamespace  = "SSP_DEPLOYMENT_NAMESPACE"
-	envSspWebhookServiceName   = "SSP_WEBHOOK_SERVICE_NAME"
-	envVmConsoleProxyNamespace = "VM_CONSOLE_PROXY_NAMESPACE"
+	envExistingCrName         = "TEST_EXISTING_CR_NAME"
+	envExistingCrNamespace    = "TEST_EXISTING_CR_NAMESPACE"
+	envSkipUpdateSspTests     = "SKIP_UPDATE_SSP_TESTS"
+	envSkipCleanupAfterTests  = "SKIP_CLEANUP_AFTER_TESTS"
+	envTimeout                = "TIMEOUT_MINUTES"
+	envShortTimeout           = "SHORT_TIMEOUT_MINUTES"
+	envTopologyMode           = "TOPOLOGY_MODE"
+	envIsUpgradeLane          = "IS_UPGRADE_LANE"
+	envSspDeploymentName      = "SSP_DEPLOYMENT_NAME"
+	envSspDeploymentNamespace = "SSP_DEPLOYMENT_NAMESPACE"
+	envSspWebhookServiceName  = "SSP_WEBHOOK_SERVICE_NAME"
 )
 
 const (
@@ -95,10 +94,6 @@ func SspDeploymentNamespace() string {
 
 func SspWebhookServiceName() string {
 	return os.Getenv(envSspWebhookServiceName)
-}
-
-func VmConsoleProxyNamespace() string {
-	return os.Getenv(envVmConsoleProxyNamespace)
 }
 
 func getBoolEnv(envName string) bool {

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -45,7 +45,6 @@ import (
 	sspv1beta1 "kubevirt.io/ssp-operator/api/v1beta1"
 	sspv1beta2 "kubevirt.io/ssp-operator/api/v1beta2"
 	"kubevirt.io/ssp-operator/internal/common"
-	vm_console_proxy "kubevirt.io/ssp-operator/internal/operands/vm-console-proxy"
 )
 
 var (
@@ -63,7 +62,6 @@ type TestSuiteStrategy interface {
 	GetName() string
 	GetNamespace() string
 	GetTemplatesNamespace() string
-	GetVmConsoleProxyNamespace() string
 	GetValidatorReplicas() int
 	GetSSPDeploymentName() string
 	GetSSPDeploymentNameSpace() string
@@ -114,9 +112,6 @@ func (s *newSspStrategy) Init() {
 				common.AppKubernetesPartOfLabel:    "hyperconverged-cluster",
 				common.AppKubernetesVersionLabel:   "v0.0.0-test",
 				common.AppKubernetesComponentLabel: common.AppComponentSchedule.String(),
-			},
-			Annotations: map[string]string{
-				vm_console_proxy.VmConsoleProxyNamespaceAnnotation: s.GetVmConsoleProxyNamespace(),
 			},
 		},
 		Spec: sspv1beta2.SSPSpec{
@@ -180,11 +175,6 @@ func (s *newSspStrategy) GetNamespace() string {
 func (s *newSspStrategy) GetTemplatesNamespace() string {
 	const commonTemplatesTestNS = "ssp-operator-functests-templates"
 	return commonTemplatesTestNS
-}
-
-func (s *newSspStrategy) GetVmConsoleProxyNamespace() string {
-	const vmConsoleProxyNamespace = "kubevirt"
-	return vmConsoleProxyNamespace
 }
 
 func (s *newSspStrategy) GetValidatorReplicas() int {
@@ -314,21 +304,6 @@ func (s *existingSspStrategy) GetTemplatesNamespace() string {
 		panic("Strategy is not initialized")
 	}
 	return s.ssp.Spec.CommonTemplates.Namespace
-}
-
-func (s *existingSspStrategy) GetVmConsoleProxyNamespace() string {
-	if s.ssp != nil && s.ssp.ObjectMeta.GetAnnotations() != nil {
-		namespace, isFound := s.ssp.ObjectMeta.GetAnnotations()[vm_console_proxy.VmConsoleProxyNamespaceAnnotation]
-		if isFound {
-			return namespace
-		}
-	}
-
-	namespace := env.VmConsoleProxyNamespace()
-	if namespace == "" {
-		panic("VM_CONSOLE_PROXY_NAMESPACE is not set")
-	}
-	return namespace
 }
 
 func (s *existingSspStrategy) GetValidatorReplicas() int {


### PR DESCRIPTION
This is a backport of: https://github.com/kubevirt/ssp-operator/pull/634

**Release note**:
```release-note
Remove vm-console-proxy-namespace annotation
```
