### PR TITLE
fix: fix wrong parsing of vm.spec.template.spec.domain.memory.guest in validator

### DIFF
--- a/internal/template-validator/validation/path/path.go
+++ b/internal/template-validator/validation/path/path.go
@@ -171,7 +171,14 @@ func (r *Results) AsInt64() ([]int64, error) {
 					continue
 				}
 			}
-			return nil, fmt.Errorf("mismatching type: %v, not int or resource.Quantity", res[j].Type().Name())
+			if quantityObj, ok := obj.(*resource.Quantity); ok {
+				v, ok := quantityObj.AsInt64()
+				if ok {
+					ret = append(ret, v)
+					continue
+				}
+			}
+			return nil, fmt.Errorf("mismatching type: %v, not int or resource.Quantity", res[j].Type())
 		}
 	}
 	return ret, nil

--- a/internal/template-validator/validation/path/path_test.go
+++ b/internal/template-validator/validation/path/path_test.go
@@ -101,6 +101,22 @@ var _ = Describe("Path", func() {
 			Expect(vals[0]).To(BeNumerically(">", 1024))
 		})
 
+		It("Should provide integer result for quantity pointer object", func() {
+			s := "jsonpath::.spec.domain.memory.guest"
+			p, err := New(s)
+			Expect(p).To(Not(BeNil()))
+			Expect(err).ToNot(HaveOccurred())
+
+			results, err := p.Find(vmCirros)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(results.Len()).To(BeNumerically(">=", 1))
+
+			vals, err := results.AsInt64()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(vals).To(HaveLen(1))
+			Expect(vals[0]).To(BeNumerically(">", 2147483647), "value is lower than 2Gi")
+		})
+
 		It("Should provide some string results", func() {
 			s := "jsonpath::.spec.domain.machine.type"
 			p, err := New(s)

--- a/internal/template-validator/validation/test-utils/utils.go
+++ b/internal/template-validator/validation/test-utils/utils.go
@@ -2,6 +2,7 @@ package test_utils
 
 import (
 	"bytes"
+
 	"k8s.io/apimachinery/pkg/util/yaml"
 
 	kubevirt "kubevirt.io/api/core/v1"
@@ -34,6 +35,8 @@ spec:
             name: cloudinitdisk
         machine:
           type: "q35"
+        memory:
+          guest: 2Gi
         resources:
           requests:
             memory: 128M


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: fix wrong parsing of vm.spec.template.spec.domain.memory.guest in validator

template validator could not parse pointer to resource.Quantity struct. This PR adds support for it

**Which issue(s) this PR fixes**: 
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2236545

**Release note**:
```
NONE
```
