### PR TITLE
fix: replacing of namespace annotation when openshift-cnv namespace is set

### DIFF
--- a/data/tekton-pipelines/pipelines-rbac.yaml
+++ b/data/tekton-pipelines/pipelines-rbac.yaml
@@ -4,7 +4,7 @@ kind: RoleBinding
 metadata:
   name: windows-pipelines-modify-data-object
   annotations:
-    "kubevirt.io/deploy-namespace": "kubevirt-os-images"
+    "kubevirt.io/tekton-piplines-deploy-namespace": "kubevirt-os-images"
 roleRef:
   kind: ClusterRole
   name: modify-data-object-task
@@ -18,7 +18,7 @@ kind: RoleBinding
 metadata:
   name: windows-pipelines-create-vm
   annotations:
-    "kubevirt.io/deploy-namespace": "kubevirt-os-images"
+    "kubevirt.io/tekton-piplines-deploy-namespace": "kubevirt-os-images"
 roleRef:
   kind: ClusterRole
   name: create-vm-from-manifest-task
@@ -32,7 +32,7 @@ kind: RoleBinding
 metadata:
   name: windows-pipelines-wait-for-vmi
   annotations:
-    "kubevirt.io/deploy-namespace": "kubevirt-os-images"
+    "kubevirt.io/tekton-piplines-deploy-namespace": "kubevirt-os-images"
 roleRef:
   kind: ClusterRole
   name: modify-data-object-task
@@ -46,7 +46,7 @@ kind: RoleBinding
 metadata:
   name: windows-pipelines-cleanup-vm
   annotations:
-    "kubevirt.io/deploy-namespace": "kubevirt-os-images"
+    "kubevirt.io/tekton-piplines-deploy-namespace": "kubevirt-os-images"
 roleRef:
   kind: ClusterRole
   name: cleanup-vm-task

--- a/data/tekton-pipelines/windows-bios-installer-configmaps.yaml
+++ b/data/tekton-pipelines/windows-bios-installer-configmaps.yaml
@@ -4,7 +4,7 @@ kind: ConfigMap
 metadata:
   name: windows10-bios-autounattend
   annotations:
-    "kubevirt.io/deploy-namespace": "kubevirt-os-images"
+    "kubevirt.io/tekton-piplines-deploy-namespace": "kubevirt-os-images"
 data:
   autounattend.xml: |
     <?xml version="1.0" encoding="utf-8"?>

--- a/data/tekton-pipelines/windows-customize-configmaps.yaml
+++ b/data/tekton-pipelines/windows-customize-configmaps.yaml
@@ -4,7 +4,7 @@ kind: ConfigMap
 metadata:
   name: windows-sqlserver
   annotations:
-    "kubevirt.io/deploy-namespace": "kubevirt-os-images"
+    "kubevirt.io/tekton-piplines-deploy-namespace": "kubevirt-os-images"
 data:
   unattend.xml: |
     <?xml version="1.0" encoding="utf-8"?>
@@ -63,7 +63,7 @@ kind: ConfigMap
 metadata:
   name: windows-vs-code
   annotations:
-    "kubevirt.io/deploy-namespace": "kubevirt-os-images"
+    "kubevirt.io/tekton-piplines-deploy-namespace": "kubevirt-os-images"
 data:
   unattend.xml: |
     <?xml version="1.0" encoding="utf-8"?>
@@ -122,7 +122,7 @@ kind: ConfigMap
 metadata:
   name: windows10-unattend
   annotations:
-    "kubevirt.io/deploy-namespace": "kubevirt-os-images"
+    "kubevirt.io/tekton-piplines-deploy-namespace": "kubevirt-os-images"
 data:
   unattend.xml: |
     <?xml version="1.0" encoding="utf-8"?>
@@ -195,7 +195,7 @@ kind: ConfigMap
 metadata:
   name: windows11-unattend
   annotations:
-    "kubevirt.io/deploy-namespace": "kubevirt-os-images"
+    "kubevirt.io/tekton-piplines-deploy-namespace": "kubevirt-os-images"
 data:
   unattend.xml: |
     <?xml version="1.0" encoding="utf-8"?>


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: replacing of namespace annotation when kubevirt namespace is set

When ssp CR contains kubevirt namespace as a target namespace
for pipelines, ssp operator recognized this namespace as user defined
and deployed configmaps and roleBindings to a single namespace, instead
of two namespaces. That broke our default pipeline flow. This
change adds a check if the pipeline namespace in the CR is kubevirt,
then it is not used as a user defined namespace and
kubevirt.io/deploy-namespace annotation is used instead.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2237916

**Special notes for your reviewer**:

**Release note**:
```
NONE
```
