### PR TITLE
rbac: Audit `*` verbs of kubevirt-tekton-tasks

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -105,7 +105,6 @@ rules:
   resources:
   - datavolumes
   verbs:
-  - '*'
   - create
   - delete
   - get
@@ -162,7 +161,6 @@ rules:
   resources:
   - persistentvolumeclaims
   verbs:
-  - '*'
   - create
   - delete
   - get
@@ -200,7 +198,11 @@ rules:
   resources:
   - secrets
   verbs:
-  - '*'
+  - create
+  - delete
+  - get
+  - list
+  - patch
 - apiGroups:
   - ""
   resources:
@@ -275,7 +277,7 @@ rules:
   resources:
   - virtualmachines/finalizers
   verbs:
-  - '*'
+  - get
 - apiGroups:
   - monitoring.coreos.com
   resources:

--- a/data/olm-catalog/ssp-operator.clusterserviceversion.yaml
+++ b/data/olm-catalog/ssp-operator.clusterserviceversion.yaml
@@ -163,7 +163,6 @@ spec:
           resources:
           - datavolumes
           verbs:
-          - '*'
           - create
           - delete
           - get
@@ -220,7 +219,6 @@ spec:
           resources:
           - persistentvolumeclaims
           verbs:
-          - '*'
           - create
           - delete
           - get
@@ -258,7 +256,11 @@ spec:
           resources:
           - secrets
           verbs:
-          - '*'
+          - create
+          - delete
+          - get
+          - list
+          - patch
         - apiGroups:
           - ""
           resources:
@@ -333,7 +335,7 @@ spec:
           resources:
           - virtualmachines/finalizers
           verbs:
-          - '*'
+          - get
         - apiGroups:
           - monitoring.coreos.com
           resources:

--- a/internal/operands/tekton-tasks/reconcile.go
+++ b/internal/operands/tekton-tasks/reconcile.go
@@ -22,12 +22,12 @@ import (
 // +kubebuilder:rbac:groups=subresources.kubevirt.io,resources=virtualmachines/restart;virtualmachines/start;virtualmachines/stop,verbs=update
 // +kubebuilder:rbac:groups=template.openshift.io,resources=templates,verbs=get;list;watch;create;patch;update;delete
 // +kubebuilder:rbac:groups=template.openshift.io,resources=processedtemplates,verbs=create
-// +kubebuilder:rbac:groups=cdi.kubevirt.io,resources=datavolumes,verbs=*
+// +kubebuilder:rbac:groups=cdi.kubevirt.io,resources=datavolumes,verbs=get;create;delete
 // +kubebuilder:rbac:groups=cdi.kubevirt.io,resources=datasources,verbs=get;create;delete
-// +kubebuilder:rbac:groups=kubevirt.io,resources=virtualmachines/finalizers,verbs=*
-// +kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=*
+// +kubebuilder:rbac:groups=kubevirt.io,resources=virtualmachines/finalizers,verbs=get
+// +kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=get;update;delete
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=create
-// +kubebuilder:rbac:groups=core,resources=secrets,verbs=*
+// +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;create;patch;delete
 
 const (
 	operandName      = "tekton-tasks"


### PR DESCRIPTION
**What this PR does / why we need it**:
It drops `*` verbs of tekton tasks. For this purpose, the process followed is:

* Drop all tekton tasks permissions using `*` verbs.
* Run unit tests.
* Add required permissions.
* Run functional tests.
* Add required permissions.

The auditing process has been split in the next action items:

* Deploying the operator in a CRC cluster and running the unit and function test.
* Deploying the operator in a 3 masters and 3 workers nodes and running the unit and functional tests.


This process ensures that only strictly required permissions are added. 

jira-ticket: [CNV-24031](https://issues.redhat.com/browse/CNV-24031)

**Which issue(s) this PR fixes**: 
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

Fixes # [https://bugzilla.redhat.com/show_bug.cgi?id=2223775](https://bugzilla.redhat.com/show_bug.cgi?id=2223775)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Replace `*`  tekton tasks verbs by individual verbs
```
