### PR TITLE
Update common-instancetypes to v0.3.4

### DIFF
--- a/data/common-instancetypes-bundle/common-clusterinstancetypes-bundle.yaml
+++ b/data/common-instancetypes-bundle/common-clusterinstancetypes-bundle.yaml
@@ -25,7 +25,7 @@ metadata:
     instancetype.kubevirt.io/memory: 16Gi
     instancetype.kubevirt.io/numa: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.3
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.4
   name: cx1.2xlarge
 spec:
   cpu:
@@ -66,7 +66,7 @@ metadata:
     instancetype.kubevirt.io/memory: 32Gi
     instancetype.kubevirt.io/numa: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.3
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.4
   name: cx1.4xlarge
 spec:
   cpu:
@@ -107,7 +107,7 @@ metadata:
     instancetype.kubevirt.io/memory: 64Gi
     instancetype.kubevirt.io/numa: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.3
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.4
   name: cx1.8xlarge
 spec:
   cpu:
@@ -148,7 +148,7 @@ metadata:
     instancetype.kubevirt.io/memory: 4Gi
     instancetype.kubevirt.io/numa: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.3
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.4
   name: cx1.large
 spec:
   cpu:
@@ -189,7 +189,7 @@ metadata:
     instancetype.kubevirt.io/memory: 2Gi
     instancetype.kubevirt.io/numa: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.3
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.4
   name: cx1.medium
 spec:
   cpu:
@@ -230,7 +230,7 @@ metadata:
     instancetype.kubevirt.io/memory: 8Gi
     instancetype.kubevirt.io/numa: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.3
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.4
   name: cx1.xlarge
 spec:
   cpu:
@@ -266,7 +266,7 @@ metadata:
     instancetype.kubevirt.io/gpus: "true"
     instancetype.kubevirt.io/memory: 32Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.3
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.4
   name: gn1.2xlarge
 spec:
   cpu:
@@ -298,7 +298,7 @@ metadata:
     instancetype.kubevirt.io/gpus: "true"
     instancetype.kubevirt.io/memory: 64Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.3
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.4
   name: gn1.4xlarge
 spec:
   cpu:
@@ -330,7 +330,7 @@ metadata:
     instancetype.kubevirt.io/gpus: "true"
     instancetype.kubevirt.io/memory: 128Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.3
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.4
   name: gn1.8xlarge
 spec:
   cpu:
@@ -362,7 +362,7 @@ metadata:
     instancetype.kubevirt.io/gpus: "true"
     instancetype.kubevirt.io/memory: 16Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.3
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.4
   name: gn1.xlarge
 spec:
   cpu:
@@ -380,7 +380,7 @@ metadata:
     instancetype.kubevirt.io/deprecated: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
     kubevirt.io/size: large
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.3
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.4
   name: highperformance.large
 spec:
   cpu:
@@ -398,7 +398,7 @@ metadata:
     instancetype.kubevirt.io/deprecated: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
     kubevirt.io/size: medium
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.3
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.4
   name: highperformance.medium
 spec:
   cpu:
@@ -416,7 +416,7 @@ metadata:
     instancetype.kubevirt.io/deprecated: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
     kubevirt.io/size: small
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.3
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.4
   name: highperformance.small
 spec:
   cpu:
@@ -443,7 +443,7 @@ metadata:
     instancetype.kubevirt.io/hugepages: "true"
     instancetype.kubevirt.io/memory: 64Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.3
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.4
   name: m1.2xlarge
 spec:
   cpu:
@@ -469,7 +469,7 @@ metadata:
     instancetype.kubevirt.io/hugepages: "true"
     instancetype.kubevirt.io/memory: 128Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.3
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.4
   name: m1.4xlarge
 spec:
   cpu:
@@ -495,7 +495,7 @@ metadata:
     instancetype.kubevirt.io/hugepages: "true"
     instancetype.kubevirt.io/memory: 256Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.3
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.4
   name: m1.8xlarge
 spec:
   cpu:
@@ -521,7 +521,7 @@ metadata:
     instancetype.kubevirt.io/hugepages: "true"
     instancetype.kubevirt.io/memory: 16Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.3
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.4
   name: m1.large
 spec:
   cpu:
@@ -547,7 +547,7 @@ metadata:
     instancetype.kubevirt.io/hugepages: "true"
     instancetype.kubevirt.io/memory: 32Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.3
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.4
   name: m1.xlarge
 spec:
   cpu:
@@ -572,7 +572,7 @@ metadata:
     instancetype.kubevirt.io/cpu: "8"
     instancetype.kubevirt.io/memory: 32Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.3
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.4
   name: o1.2xlarge
 spec:
   cpu:
@@ -596,7 +596,7 @@ metadata:
     instancetype.kubevirt.io/cpu: "16"
     instancetype.kubevirt.io/memory: 64Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.3
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.4
   name: o1.4xlarge
 spec:
   cpu:
@@ -620,7 +620,7 @@ metadata:
     instancetype.kubevirt.io/cpu: "32"
     instancetype.kubevirt.io/memory: 128Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.3
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.4
   name: o1.8xlarge
 spec:
   cpu:
@@ -644,7 +644,7 @@ metadata:
     instancetype.kubevirt.io/cpu: "2"
     instancetype.kubevirt.io/memory: 8Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.3
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.4
   name: o1.large
 spec:
   cpu:
@@ -668,7 +668,7 @@ metadata:
     instancetype.kubevirt.io/cpu: "1"
     instancetype.kubevirt.io/memory: 4Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.3
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.4
   name: o1.medium
 spec:
   cpu:
@@ -692,7 +692,7 @@ metadata:
     instancetype.kubevirt.io/cpu: "4"
     instancetype.kubevirt.io/memory: 16Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.3
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.4
   name: o1.xlarge
 spec:
   cpu:
@@ -708,7 +708,7 @@ metadata:
     instancetype.kubevirt.io/deprecated: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
     kubevirt.io/size: large
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.3
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.4
   name: server.large
 spec:
   cpu:
@@ -723,7 +723,7 @@ metadata:
     instancetype.kubevirt.io/deprecated: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
     kubevirt.io/size: medium
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.3
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.4
   name: server.medium
 spec:
   cpu:
@@ -738,7 +738,7 @@ metadata:
     instancetype.kubevirt.io/deprecated: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
     kubevirt.io/size: micro
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.3
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.4
   name: server.micro
 spec:
   cpu:
@@ -753,7 +753,7 @@ metadata:
     instancetype.kubevirt.io/deprecated: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
     kubevirt.io/size: small
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.3
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.4
   name: server.small
 spec:
   cpu:
@@ -768,7 +768,7 @@ metadata:
     instancetype.kubevirt.io/deprecated: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
     kubevirt.io/size: tiny
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.3
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.4
   name: server.tiny
 spec:
   cpu:
@@ -795,7 +795,7 @@ metadata:
     instancetype.kubevirt.io/cpu: "8"
     instancetype.kubevirt.io/memory: 32Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.3
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.4
   name: u1.2xlarge
 spec:
   cpu:
@@ -822,7 +822,7 @@ metadata:
     instancetype.kubevirt.io/cpu: "16"
     instancetype.kubevirt.io/memory: 64Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.3
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.4
   name: u1.4xlarge
 spec:
   cpu:
@@ -849,7 +849,7 @@ metadata:
     instancetype.kubevirt.io/cpu: "32"
     instancetype.kubevirt.io/memory: 128Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.3
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.4
   name: u1.8xlarge
 spec:
   cpu:
@@ -876,7 +876,7 @@ metadata:
     instancetype.kubevirt.io/cpu: "2"
     instancetype.kubevirt.io/memory: 8Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.3
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.4
   name: u1.large
 spec:
   cpu:
@@ -903,7 +903,7 @@ metadata:
     instancetype.kubevirt.io/cpu: "1"
     instancetype.kubevirt.io/memory: 4Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.3
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.4
   name: u1.medium
 spec:
   cpu:
@@ -930,7 +930,7 @@ metadata:
     instancetype.kubevirt.io/cpu: "1"
     instancetype.kubevirt.io/memory: 1Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.3
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.4
   name: u1.micro
 spec:
   cpu:
@@ -957,7 +957,7 @@ metadata:
     instancetype.kubevirt.io/cpu: "1"
     instancetype.kubevirt.io/memory: 512Mi
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.3
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.4
   name: u1.nano
 spec:
   cpu:
@@ -984,7 +984,7 @@ metadata:
     instancetype.kubevirt.io/cpu: "1"
     instancetype.kubevirt.io/memory: 2Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.3
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.4
   name: u1.small
 spec:
   cpu:
@@ -1011,7 +1011,7 @@ metadata:
     instancetype.kubevirt.io/cpu: "4"
     instancetype.kubevirt.io/memory: 16Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.3
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.4
   name: u1.xlarge
 spec:
   cpu:

--- a/data/common-instancetypes-bundle/common-clusterpreferences-bundle.yaml
+++ b/data/common-instancetypes-bundle/common-clusterpreferences-bundle.yaml
@@ -12,7 +12,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.3
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.4
   name: alpine
 spec:
   devices:
@@ -37,7 +37,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.3
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.4
   name: centos.7
 spec:
   devices:
@@ -62,7 +62,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.3
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.4
   name: centos.7.desktop
 spec:
   devices:
@@ -90,7 +90,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.3
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.4
   name: centos.stream8
 spec:
   devices:
@@ -115,7 +115,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.3
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.4
   name: centos.stream8.desktop
 spec:
   devices:
@@ -143,7 +143,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.3
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.4
   name: centos.stream9
 spec:
   devices:
@@ -170,7 +170,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.3
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.4
   name: centos.stream9.desktop
 spec:
   devices:
@@ -200,7 +200,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.3
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.4
   name: cirros
 spec:
   devices:
@@ -225,7 +225,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.3
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.4
   name: fedora
 spec:
   devices:
@@ -257,7 +257,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.3
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.4
   name: rhel.7
 spec:
   devices:
@@ -282,7 +282,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.3
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.4
   name: rhel.7.desktop
 spec:
   devices:
@@ -310,7 +310,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.3
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.4
   name: rhel.8
 spec:
   devices:
@@ -335,7 +335,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.3
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.4
   name: rhel.8.desktop
 spec:
   devices:
@@ -363,7 +363,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.3
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.4
   name: rhel.9
 spec:
   devices:
@@ -395,7 +395,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.3
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.4
   name: rhel.9.desktop
 spec:
   devices:
@@ -430,7 +430,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.3
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.4
   name: ubuntu
 spec:
   devices:
@@ -456,7 +456,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.3
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.4
   name: windows.10
 spec:
   clock:
@@ -514,7 +514,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.3
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.4
   name: windows.10.virtio
 spec:
   clock:
@@ -574,7 +574,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.3
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.4
   name: windows.11
 spec:
   clock:
@@ -632,7 +632,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.3
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.4
   name: windows.11.virtio
 spec:
   clock:
@@ -692,7 +692,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.3
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.4
   name: windows.2k12
 spec:
   clock:
@@ -750,7 +750,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.3
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.4
   name: windows.2k12.virtio
 spec:
   clock:
@@ -810,7 +810,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.3
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.4
   name: windows.2k16
 spec:
   clock:
@@ -863,7 +863,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.3
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.4
   name: windows.2k16.virtio
 spec:
   clock:
@@ -918,7 +918,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.3
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.4
   name: windows.2k19
 spec:
   clock:
@@ -976,7 +976,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.3
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.4
   name: windows.2k19.virtio
 spec:
   clock:
@@ -1036,7 +1036,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.3
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.4
   name: windows.2k22
 spec:
   clock:
@@ -1099,7 +1099,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.3.3
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.4
   name: windows.2k22.virtio
 spec:
   clock:


### PR DESCRIPTION
common-instancetypes: Update bundle to v0.3.4

https://github.com/kubevirt/common-instancetypes/releases/tag/v0.3.4

**Release note**:
```release-note
Update common-instancetypes bundle to v0.3.4
```
