### PR TITLE
feat: add snyk file to exclude vendor folders

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,5 @@
+# Snyk (https://snyk.io) policy file
+exclude:
+  global:
+    - vendor/**
+    - api/vendor/**


### PR DESCRIPTION
**What this PR does / why we need it**:
feat: add snyk file to exclude vendor folders

this file is used for snyk integration to config snyk scan.


**Release note**:
```
NONE
```
