### PR TITLE
chore: Regenerate CRD in data folder

### DIFF
--- a/data/crd/ssp.kubevirt.io_ssps.yaml
+++ b/data/crd/ssp.kubevirt.io_ssps.yaml
@@ -3915,6 +3915,8 @@ spec:
                 description: FeatureGates for SSP
                 properties:
                   deployCommonInstancetypes:
+                    description: Enables deployment of the common-instancetypes bundles,
+                      defaults to true.
                     type: boolean
                   deployTektonTaskResources:
                     type: boolean


### PR DESCRIPTION
Regenerated CRD `data/crd/ssp.kubevirt.io_ssps.yaml` by running "make container-build"

**Release note**:
```release-note
None
```
