### PR TITLE
fix: Incorrect DataSource reconciliation

### DIFF
--- a/internal/operands/data-sources/reconcile.go
+++ b/internal/operands/data-sources/reconcile.go
@@ -388,18 +388,17 @@ func reconcileDataSource(dsInfo dataSourceInfo, request *common.Request) (common
 				if foundRes.GetLabels() == nil {
 					foundRes.SetLabels(make(map[string]string))
 				}
+				// We need to restore this label in case it was removed.
+				// If it is removed, then CDI stops watching the DataSource.
 				foundRes.GetLabels()[dataImportCronLabel] = dsInfo.dataImportCronName
-			} else {
-				// Only set app labels if DIC does not exist
-				common.AddAppLabels(request.Instance, operandName, operandComponent, foundRes)
-				delete(foundRes.GetLabels(), dataImportCronLabel)
+				return
 			}
 
-			foundDs := foundRes.(*cdiv1beta1.DataSource)
-			newDs := newRes.(*cdiv1beta1.DataSource)
-			if !dsInfo.autoUpdateEnabled || (foundDs.Spec.Source.PVC == nil && foundDs.Spec.Source.Snapshot == nil) {
-				foundDs.Spec.Source.PVC = newDs.Spec.Source.PVC
-			}
+			// Only set app labels if DIC does not exist
+			common.AddAppLabels(request.Instance, operandName, operandComponent, foundRes)
+			delete(foundRes.GetLabels(), dataImportCronLabel)
+
+			foundRes.(*cdiv1beta1.DataSource).Spec = newRes.(*cdiv1beta1.DataSource).Spec
 		}).
 		Reconcile()
 }

--- a/internal/operands/data-sources/reconcile_test.go
+++ b/internal/operands/data-sources/reconcile_test.go
@@ -202,7 +202,10 @@ var _ = Describe("Data-Sources operand", func() {
 				// Update DataSource to simulate CDI
 				ds := &cdiv1beta1.DataSource{}
 				Expect(request.Client.Get(request.Context, client.ObjectKeyFromObject(&testDataSources[0]), ds)).To(Succeed())
-				ds.Spec.Source.PVC.Name = "test"
+				ds.Spec.Source.PVC = &cdiv1beta1.DataVolumeSourcePVC{
+					Name:      "test",
+					Namespace: internal.GoldenImagesNamespace,
+				}
 				Expect(request.Client.Update(request.Context, ds)).To(Succeed())
 
 				_, err = operand.Reconcile(&request)
@@ -216,37 +219,6 @@ var _ = Describe("Data-Sources operand", func() {
 				// Test that DataSource was restored
 				Expect(request.Client.Get(request.Context, client.ObjectKeyFromObject(&testDataSources[0]), ds)).To(Succeed())
 				Expect(ds.Spec).To(Equal(testDataSources[0].Spec))
-			})
-
-			It("should not restore DataSource if DataImportCron prefers snapshots sources", func() {
-				_, err := operand.Reconcile(&request)
-				Expect(err).ToNot(HaveOccurred())
-
-				cron := cronTemplate.AsDataImportCron()
-				cron.Namespace = internal.GoldenImagesNamespace
-				ExpectResourceExists(&cron, request)
-
-				// Update DataSource to simulate CDI
-				ds := &cdiv1beta1.DataSource{}
-				Expect(request.Client.Get(request.Context, client.ObjectKeyFromObject(&testDataSources[0]), ds)).To(Succeed())
-				ds.Spec.Source.PVC = nil
-				ds.Spec.Source.Snapshot = &cdiv1beta1.DataVolumeSourceSnapshot{
-					Namespace: "test",
-					Name:      "test",
-				}
-				Expect(request.Client.Update(request.Context, ds)).To(Succeed())
-
-				_, err = operand.Reconcile(&request)
-				Expect(err).ToNot(HaveOccurred())
-
-				// Test that DataSource was not changed
-				Expect(request.Client.Get(request.Context, client.ObjectKeyFromObject(&testDataSources[0]), ds)).To(Succeed())
-				Expect(ds.Spec.Source).To(Equal(cdiv1beta1.DataSourceSource{
-					Snapshot: &cdiv1beta1.DataVolumeSourceSnapshot{
-						Namespace: "test",
-						Name:      "test",
-					},
-				}))
 			})
 		})
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The `DataSource` reconciliation only reverted `PVC` field instead of whole `spec`.

**Release note**:
```release-note
None
```
