### PR TITLE
[release-v0.17] chore: Update version of vm-console-proxy container.

### DIFF
--- a/data/vm-console-proxy-bundle/vm-console-proxy.yaml
+++ b/data/vm-console-proxy-bundle/vm-console-proxy.yaml
@@ -100,7 +100,7 @@ spec:
       - args: []
         command:
         - /console
-        image: quay.io/kubevirt/vm-console-proxy:v0.1.0
+        image: quay.io/kubevirt/vm-console-proxy:v0.1.1
         imagePullPolicy: Always
         name: console
         ports:

--- a/internal/operands/vm-console-proxy/reconcile.go
+++ b/internal/operands/vm-console-proxy/reconcile.go
@@ -341,7 +341,7 @@ func getVmConsoleProxyNamespace(request *common.Request) string {
 }
 
 func getVmConsoleProxyImage() string {
-	return common.EnvOrDefault("VM_CONSOLE_PROXY_IMAGE", "quay.io/kubevirt/vm-console-proxy:v0.1.0")
+	return common.EnvOrDefault("VM_CONSOLE_PROXY_IMAGE", "quay.io/kubevirt/vm-console-proxy:v0.1.1")
 }
 
 func findResourcesUsingLabels[PtrL interface {


### PR DESCRIPTION
**What this PR does / why we need it**:
Use the latest patch version of `vm-console-proxy`.

**Release note**:
```release-note
None
```
