### PR TITLE
feat: add evictionStrategy to VMs in tekton pipelines

### DIFF
--- a/data/tekton-pipelines/windows-bios-installer-pipeline.yaml
+++ b/data/tekton-pipelines/windows-bios-installer-pipeline.yaml
@@ -101,6 +101,7 @@ spec:
                         url: $(params.winImageDownloadURL)
               template:
                 spec:
+                  evictionStrategy: LiveMigrateIfPossible
                   domain:
                     devices:
                       disks:

--- a/data/tekton-pipelines/windows-customize-pipeline.yaml
+++ b/data/tekton-pipelines/windows-customize-pipeline.yaml
@@ -86,6 +86,7 @@ spec:
                 name: $(params.preferenceName)
               template:
                 spec:
+                  evictionStrategy: LiveMigrateIfPossible
                   domain:
                     devices:
                       disks:

--- a/data/tekton-pipelines/windows-efi-installer-pipeline.yaml
+++ b/data/tekton-pipelines/windows-efi-installer-pipeline.yaml
@@ -118,6 +118,7 @@ spec:
                 name: $(params.preferenceName)
               template:
                 spec:
+                  evictionStrategy: LiveMigrateIfPossible
                   domain:
                     devices:
                       disks:


### PR DESCRIPTION
**What this PR does / why we need it**:
feat: add evictionStrategy to VMs in tekton pipelines

Sometimes when node crashes, VM is not migrated. This commit adds eviction strategy to VMs.

**Which issue(s) this PR fixes**: 
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2221665

**Release note**:
```
Add evictionStrategy to VMs in tekton pipelines

```
