### PR TITLE
[release-v0.18] fix: Keep Ginkgo version in Makefile and go.mod in sync

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ unittest: generate lint fmt vet manifests
 build-functests:
 	go test -c ./tests
 
-GINKGO_VERSION ?= v2.9.1
+GINKGO_VERSION ?= v2.9.2
 GINKGO_TIMEOUT ?= 2h
 
 .PHONY: ginkgo


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This helps avoiding issues during CI runs, where vendoring fails after inadvertently changing the go.mod file.

**Which issue(s) this PR fixes**: 
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
