### PR TITLE
feat: introduce dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,40 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-type: "all"
+  - package-ecosystem: "gomod"
+    directory: "/"
+    target-branch: "release-v0.18"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-type: "all"
+  - package-ecosystem: "gomod"
+    directory: "/"
+    target-branch: "release-v0.17"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-type: "all"
+  - package-ecosystem: "gomod"
+    directory: "/"
+    target-branch: "release-v0.16"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-type: "all"
+  - package-ecosystem: "gomod"
+    directory: "/"
+    target-branch: "release-v0.15"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-type: "all"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"  


### PR DESCRIPTION
**What this PR does / why we need it**:
feat: introduce dependabot config

this PR introduces dependabot config for main and other release branches.

**Release note**:
```
NONE
```
