### PR TITLE
chore: Update golang in CI to 1.20

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -8,10 +8,10 @@ jobs:
   validate_metrics_docs:
     runs-on: ubuntu-latest
     steps:
-      - name: Install Golang 1.19
+      - name: Install Golang 1.20
         uses: actions/setup-go@v2
         with:
-          go-version: '1.19'
+          go-version: '1.20'
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Generate metrics docs
@@ -22,10 +22,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - name: Install Golang 1.19
+    - name: Install Golang 1.20
       uses: actions/setup-go@v2
       with:
-        go-version: '1.19'
+        go-version: '1.20'
 
     - name: Checkout code
       uses: actions/checkout@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,10 +9,10 @@ jobs:
     name: Upload Release Asset
     runs-on: ubuntu-latest
     steps:
-      - name: Install Golang 1.19
+      - name: Install Golang 1.20
         uses: actions/setup-go@v2
         with:
-          go-version: '1.19'
+          go-version: '1.20'
 
       - name: Checkout code
         uses: actions/checkout@v2
@@ -32,7 +32,7 @@ jobs:
           make release
 
       - name: Upload CRD Asset
-        id: upload-crd-asset 
+        id: upload-crd-asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.ACTIONS_TOKEN }}
@@ -43,7 +43,7 @@ jobs:
           asset_content_type: text/plain
 
       - name: Upload CSV Asset
-        id: upload-csv-asset 
+        id: upload-csv-asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.ACTIONS_TOKEN }}
@@ -54,7 +54,7 @@ jobs:
           asset_content_type: text/plain
 
       - name: Upload Operator Asset
-        id: upload-operator-asset 
+        id: upload-operator-asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.ACTIONS_TOKEN }}

--- a/ci-builder/Dockerfile
+++ b/ci-builder/Dockerfile
@@ -1,7 +1,7 @@
 # This Dockerfile is used in openshift CI
 FROM quay.io/fedora/fedora:37
 
-RUN curl -L https://go.dev/dl/go1.19.2.linux-amd64.tar.gz | tar -C /usr/local -xzf -
+RUN curl -L https://go.dev/dl/go1.20.11.linux-amd64.tar.gz | tar -C /usr/local -xzf -
 ENV PATH=$PATH:/usr/local/go/bin
 
 # Install dependencies and tools


### PR DESCRIPTION
**What this PR does / why we need it**:
Updated `ci-builder` container and GitHub actions to use golang `1.20`.

**Special notes for your reviewer**:
This PR is a prerequisite for: https://github.com/kubevirt/ssp-operator/pull/745
Because the CI uses the `ci-builder` container from the current `HEAD`, not from the PR: https://docs.ci.openshift.org/docs/architecture/ci-operator/#build-root-image

**Release note**:
```release-note
None
```
