### PR TITLE
fix: Use Route Status to get Prometheus host

### DIFF
--- a/tests/monitoring_test.go
+++ b/tests/monitoring_test.go
@@ -417,7 +417,8 @@ func getPrometheusUrl() string {
 
 	err := apiClient.Get(ctx, routeKey, &route)
 	Expect(err).ShouldNot(HaveOccurred())
-	return fmt.Sprintf("https://%s", route.Spec.Host)
+	Expect(route.Status.Ingress).ToNot(BeEmpty())
+	return fmt.Sprintf("https://%s", route.Status.Ingress[0].Host)
 }
 
 func getAuthorizationTokenForPrometheus() string {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Use the Route Status instead of the Route Spec to get the Prometheus host in monitoring tests. This avoids cases where the Route controller chose to expose the Route under a different Host than given in the Spec.

**Which issue(s) this PR fixes**: 
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
