### PR TITLE
fix: Fix querying for the latest release of ssp-operator

### DIFF
--- a/automation/e2e-upgrade-functests/run.sh
+++ b/automation/e2e-upgrade-functests/run.sh
@@ -21,15 +21,13 @@ RELEASE_BRANCH=${CI_BRANCH}
 if [[ -z ${RELEASE_BRANCH} ]] || [[ ${RELEASE_BRANCH} == "main" ]]
 then
   # Get the latest release branch
-  RELEASE_BRANCH=$(curl 'https://api.github.com/repos/kubevirt/ssp-operator/branches' |
-    jq '[.[].name | select(startswith("release-v"))] | max_by(ltrimstr("release-v") | split(".") | map(tonumber))' |
-    tr -d '"')
+  RELEASE_BRANCH=$(curl -s 'https://api.github.com/repos/kubevirt/ssp-operator/branches?per_page=100' |
+    jq -r '[.[].name | select(startswith("release-v"))] | max_by(ltrimstr("release-v") | split(".") | map(tonumber))')
 fi
 
 # GitHub API returns releases sorted by creation time. Latest release is the first.
-LATEST_RELEASED_VERSION=$(curl 'https://api.github.com/repos/kubevirt/ssp-operator/releases' |
-  jq --arg BRANCH "${RELEASE_BRANCH}" '[.[] | select(.target_commitish == $BRANCH) | .name] | .[0]' |
-  tr -d '"')
+LATEST_RELEASED_VERSION=$(curl -s 'https://api.github.com/repos/kubevirt/ssp-operator/releases' |
+  jq -r --arg BRANCH "${RELEASE_BRANCH}" '[.[] | select(.target_commitish == $BRANCH) | .name] | .[0]')
 
 oc apply -n $NAMESPACE -f "https://github.com/kubevirt/ssp-operator/releases/download/${LATEST_RELEASED_VERSION}/ssp-operator.yaml"
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Fix querying for the latest release of ssp-operator in e2e-upgrade-functests by increasing the number of branches per page to 100 (maximum).

**Which issue(s) this PR fixes**: 
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

Fixes #

**Special notes for your reviewer**:

This is only a temporary fix, the logic for getting branches needs to be extended to handle paginated results. See https://docs.github.com/en/rest/branches/branches?apiVersion=2022-11-28#list-branches--parameters

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
