### PR TITLE
fix: enable arm64 operator build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal as builder
 
 RUN microdnf install -y make tar gzip which && microdnf clean all
 
-RUN curl -L https://go.dev/dl/go1.20.11.linux-amd64.tar.gz | tar -C /usr/local -xzf -
+RUN curl -L https://go.dev/dl/go1.20.11.linux-arm64.tar.gz | tar -C /usr/local -xzf -
 ENV PATH=$PATH:/usr/local/go/bin
 
 # Consume required variables so we can work with make
@@ -36,8 +36,8 @@ COPY hack/csv-generator.go hack/csv-generator.go
 COPY .golangci.yaml .golangci.yaml
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on make manager
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on make csv-generator
+RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on make manager
+RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on make csv-generator
 
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal

--- a/Makefile
+++ b/Makefile
@@ -251,7 +251,9 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 
 # Download operator-sdk locally if necessary
 $(OPERATOR_SDK): $(LOCALBIN)
-	curl --create-dirs -JL https://github.com/operator-framework/operator-sdk/releases/download/$(OPERATOR_SDK_VERSION)/operator-sdk_linux_amd64 -o $(OPERATOR_SDK)
+	ARCH=$(case $(uname -m) in x86_64) echo -n amd64 ;; aarch64) echo -n arm64 ;; *) echo -n $(uname -m) ;; esac)
+	OS=$(uname | awk '{print tolower($0)}')
+	curl --create-dirs -JL https://github.com/operator-framework/operator-sdk/releases/download/$(OPERATOR_SDK_VERSION)/operator-sdk_${OS}_${ARCH} -o $(OPERATOR_SDK)
 	chmod 0755 $(OPERATOR_SDK)
 
 .PHONY: operator-sdk

--- a/validator.Dockerfile
+++ b/validator.Dockerfile
@@ -1,7 +1,7 @@
 FROM registry.access.redhat.com/ubi9/ubi-minimal as builder
 
 RUN microdnf install -y make tar gzip which && microdnf clean all
-RUN curl -L https://go.dev/dl/go1.20.11.linux-amd64.tar.gz | tar -C /usr/local -xzf -
+RUN curl -L https://go.dev/dl/go1.20.11.linux-arm64.tar.gz | tar -C /usr/local -xzf -
 ENV PATH=$PATH:/usr/local/go/bin
 
 ARG VERSION=latest
@@ -22,7 +22,7 @@ COPY api/ api/
 COPY controllers/ controllers/
 COPY internal/ internal/
 
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -ldflags="-X 'kubevirt.io/ssp-operator/internal/template-validator/version.COMPONENT=$COMPONENT'\
+RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build -a -ldflags="-X 'kubevirt.io/ssp-operator/internal/template-validator/version.COMPONENT=$COMPONENT'\
 -X 'kubevirt.io/ssp-operator/internal/template-validator/version.VERSION=$VERSION'\
 -X 'kubevirt.io/ssp-operator/internal/template-validator/version.BRANCH=$BRANCH'\
 -X 'kubevirt.io/ssp-operator/internal/template-validator/version.REVISION=$REVISION'" -o kubevirt-template-validator internal/template-validator/main.go


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Enable developer building operator on an arm64 machine as an additional option.

Jira-Url: https://issues.redhat.com/browse/CNV-36775

**Which issue(s) this PR fixes**: 
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

Fixes #802

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```