### PR TITLE
[release-v0.18] rbac: Audit `*` verbs from kubevirt-tekton-tasks

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -35,24 +35,6 @@ rules:
   - list
   - watch
 - apiGroups:
-  - '*'
-  resources:
-  - persistentvolumeclaims
-  verbs:
-  - '*'
-- apiGroups:
-  - '*'
-  resources:
-  - pods
-  verbs:
-  - create
-- apiGroups:
-  - '*'
-  resources:
-  - secrets
-  verbs:
-  - '*'
-- apiGroups:
   - admissionregistration.k8s.io
   resources:
   - validatingwebhookconfigurations
@@ -137,7 +119,6 @@ rules:
   resources:
   - datavolumes
   verbs:
-  - '*'
   - create
   - delete
   - get
@@ -219,9 +200,20 @@ rules:
   resources:
   - pods
   verbs:
+  - create
   - get
   - list
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
 - apiGroups:
   - ""
   resources:
@@ -302,7 +294,7 @@ rules:
   resources:
   - virtualmachines/finalizers
   verbs:
-  - '*'
+  - get
 - apiGroups:
   - monitoring.coreos.com
   resources:

--- a/data/olm-catalog/ssp-operator.clusterserviceversion.yaml
+++ b/data/olm-catalog/ssp-operator.clusterserviceversion.yaml
@@ -93,24 +93,6 @@ spec:
           - list
           - watch
         - apiGroups:
-          - '*'
-          resources:
-          - persistentvolumeclaims
-          verbs:
-          - '*'
-        - apiGroups:
-          - '*'
-          resources:
-          - pods
-          verbs:
-          - create
-        - apiGroups:
-          - '*'
-          resources:
-          - secrets
-          verbs:
-          - '*'
-        - apiGroups:
           - admissionregistration.k8s.io
           resources:
           - validatingwebhookconfigurations
@@ -195,7 +177,6 @@ spec:
           resources:
           - datavolumes
           verbs:
-          - '*'
           - create
           - delete
           - get
@@ -277,9 +258,20 @@ spec:
           resources:
           - pods
           verbs:
+          - create
           - get
           - list
           - watch
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
         - apiGroups:
           - ""
           resources:
@@ -360,7 +352,7 @@ spec:
           resources:
           - virtualmachines/finalizers
           verbs:
-          - '*'
+          - get
         - apiGroups:
           - monitoring.coreos.com
           resources:

--- a/internal/operands/tekton-tasks/tekton-tasks.go
+++ b/internal/operands/tekton-tasks/tekton-tasks.go
@@ -22,12 +22,12 @@ import (
 // +kubebuilder:rbac:groups=subresources.kubevirt.io,resources=virtualmachines/restart;virtualmachines/start;virtualmachines/stop,verbs=update
 // +kubebuilder:rbac:groups=template.openshift.io,resources=templates,verbs=get;list;watch;create;patch;update;delete
 // +kubebuilder:rbac:groups=template.openshift.io,resources=processedtemplates,verbs=create
-// +kubebuilder:rbac:groups=cdi.kubevirt.io,resources=datavolumes,verbs=*
+// +kubebuilder:rbac:groups=cdi.kubevirt.io,resources=datavolumes,verbs=get;create;delete
 // +kubebuilder:rbac:groups=cdi.kubevirt.io,resources=datasources,verbs=get;create;delete
-// +kubebuilder:rbac:groups=kubevirt.io,resources=virtualmachines/finalizers,verbs=*
-// +kubebuilder:rbac:groups=*,resources=persistentvolumeclaims,verbs=*
-// +kubebuilder:rbac:groups=*,resources=pods,verbs=create
-// +kubebuilder:rbac:groups=*,resources=secrets,verbs=*
+// +kubebuilder:rbac:groups=kubevirt.io,resources=virtualmachines/finalizers,verbs=get
+// +kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=get;update;delete
+// +kubebuilder:rbac:groups=core,resources=pods,verbs=create
+// +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;create;patch;delete
 
 const (
 	operandName      = "tekton-tasks"


### PR DESCRIPTION
This is a manual backport of https://github.com/kubevirt/ssp-operator/pull/684
```release-note
Replace `*`  tekton tasks verbs by individual verbs
```
