### PR TITLE
feat: set special labels to dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,8 +12,12 @@ updates:
       development-dependencies:
         dependency-type: "development"
     open-pull-requests-limit: 3
+    labels:
+      - "release-note-none"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"  
     open-pull-requests-limit: 3
+    labels:
+      - "release-note-none"


### PR DESCRIPTION
**What this PR does / why we need it**:
feat: set special labels to dependabot PRs

Set release-note-none and ok-to-test labels to
prs which were created by dependabot

**Release note**:
```
NONE
```
