### PR TITLE
fix: increase partition1 size in windows efi configmaps

### DIFF
--- a/data/tekton-pipelines/windows-efi-installer-configmaps.yaml
+++ b/data/tekton-pipelines/windows-efi-installer-configmaps.yaml
@@ -34,7 +34,7 @@ data:
                   <CreatePartition wcm:action="add">
                       <Order>1</Order>
                       <Type>Primary</Type>
-                      <Size>300</Size>
+                      <Size>700</Size>
                   </CreatePartition>
                   <CreatePartition wcm:action="add">
                       <Order>2</Order>
@@ -191,7 +191,7 @@ data:
                             <CreatePartition wcm:action="add">
                                 <Order>1</Order>
                                 <Type>Primary</Type>
-                                <Size>300</Size>
+                                <Size>700</Size>
                             </CreatePartition>
                             <CreatePartition wcm:action="add">
                                 <Order>2</Order>


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: increase partition1 size in windows efi configmaps
The windows11-autounattend configMap set the partition1 to 300MB, which is the minimum according to documentation. In practice, however, this causes the installer to create an extra partition at the end of the C: partition, blocking it from expanding. Then during windows update the disk fills up. This commit updates it to 700MB.

**Which issue(s) this PR fixes**: 
Fixes https://issues.redhat.com/browse/CNV-36289

**Special notes for your reviewer**:

**Release note**:
```
fix: increase partition1 size in windows efi configmaps
```
