### PR TITLE
fix: set boot source labels for DVs created by windows pipelines

### DIFF
--- a/data/tekton-pipelines/windows-bios-installer-pipeline.yaml
+++ b/data/tekton-pipelines/windows-bios-installer-pipeline.yaml
@@ -55,6 +55,11 @@ spec:
             apiVersion: cdi.kubevirt.io/v1beta1
             kind: DataVolume
             metadata:
+              labels:
+                "instancetype.kubevirt.io/default-instancetype-kind": $(params.instanceTypeKind)
+                "instancetype.kubevirt.io/default-instancetype": $(params.instanceTypeName)
+                "instancetype.kubevirt.io/default-preference-kind": $(params.virtualMachinePreferenceKind)
+                "instancetype.kubevirt.io/default-preference": $(params.preferenceName)
               name: $(params.baseDvName)
               namespace: $(params.baseDvNamespace)
             spec:

--- a/data/tekton-pipelines/windows-efi-installer-pipeline.yaml
+++ b/data/tekton-pipelines/windows-efi-installer-pipeline.yaml
@@ -180,6 +180,11 @@ spec:
             metadata:
               annotations:
                 "cdi.kubevirt.io/storage.bind.immediate.requested": "true"
+              labels:
+                "instancetype.kubevirt.io/default-instancetype-kind": $(params.instanceTypeKind)
+                "instancetype.kubevirt.io/default-instancetype": $(params.instanceTypeName)
+                "instancetype.kubevirt.io/default-preference-kind": $(params.virtualMachinePreferenceKind)
+                "instancetype.kubevirt.io/default-preference": $(params.preferenceName)
               name: $(params.baseDvName)
               namespace: $(params.baseDvNamespace)
             spec:


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: set boot source labels for DVs created by windows pipelines

Set default instanceType and preferences labels to result DVs created by windows pipelines. With this fix, preferences will have default windows boot source when user triggers pipeline.

**Which issue(s) this PR fixes**: 
Fixes https://issues.redhat.com/browse/CNV-34661

**Release note**:
```
fix: set boot source labels for DVs created by windows pipelines
```
