### PR TITLE
Remove 'codingben' from OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -6,7 +6,6 @@ approvers:
 reviewers:
   - 0xFelix
   - akrejcir
-  - codingben
   - jcanocan
   - ksimon1
   - lyarwood


### PR DESCRIPTION
**What this PR does / why we need it**:
Removed `codingben` from OWNERS.

**Release note**:
```release-note
None
```
