### PR TITLE
[release-v0.18] fix: Use TokenRequest API to get prometheus token

### DIFF
--- a/tests/monitoring_test.go
+++ b/tests/monitoring_test.go
@@ -3,11 +3,9 @@ package tests
 import (
 	"context"
 	"crypto/tls"
-	"errors"
 	"fmt"
 	"net"
 	"net/http"
-	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -19,6 +17,7 @@ import (
 	promApiv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	promConfig "github.com/prometheus/common/config"
 	apps "k8s.io/api/apps/v1"
+	authnv1 "k8s.io/api/authentication/v1"
 	core "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -26,7 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/utils/pointer"
 	kubevirtv1 "kubevirt.io/api/core/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	ssp "kubevirt.io/ssp-operator/api/v1beta2"
 	"kubevirt.io/ssp-operator/internal/operands/metrics"
@@ -421,28 +419,11 @@ func getPrometheusUrl() string {
 }
 
 func getAuthorizationTokenForPrometheus() string {
-	var token string
-	Eventually(func() error {
-		secretList := &core.SecretList{}
-		namespace := client.InNamespace(metrics.MonitorNamespace)
-		err := apiClient.List(ctx, secretList, namespace)
-		if err != nil {
-			return fmt.Errorf("error getting secret: %w", err)
-		}
-		var tokenBytes []byte
-		var ok bool
-		for _, secret := range secretList.Items {
-			if strings.HasPrefix(secret.Name, "prometheus-k8s-token") {
-				tokenBytes, ok = secret.Data["token"]
-				if !ok {
-					return errors.New("token not found in secret data")
-				}
-				break
-			}
-		}
+	const serviceAccountName = "prometheus-k8s"
+	tokenReview, err := coreClient.CoreV1().ServiceAccounts(metrics.MonitorNamespace).
+		CreateToken(ctx, serviceAccountName, &authnv1.TokenRequest{}, metav1.CreateOptions{})
 
-		token = string(tokenBytes)
-		return nil
-	}, 10*time.Second, time.Second).Should(Succeed())
-	return token
+	Expect(err).ToNot(HaveOccurred())
+
+	return tokenReview.Status.Token
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Getting the token using TokenRequest API is more stable than listing all secrets and looking for the right one.

**Special notes for your reviewer**:
Cherry-pick of https://github.com/kubevirt/ssp-operator/pull/858

**Release note**:
```release-note
None
```
