### PR TITLE
Rename VirtualMachineCRCErrors to VMStorageClassWarning

### DIFF
--- a/pkg/monitoring/rules/rules-tests.yaml
+++ b/pkg/monitoring/rules/rules-tests.yaml
@@ -163,7 +163,7 @@ tests:
         alertname: "SSPCommonTemplatesModificationReverted"
         exp_alerts: []
 
-  # VirtualMachineCRCErrors alert tests
+  # VMStorageClassWarning alert tests
   - interval: "1m"
     input_series:
       - series: 'kubevirt_ssp_vm_rbd_block_volume_without_rxbounce'
@@ -171,16 +171,16 @@ tests:
 
     alert_rule_test:
       - eval_time: "1m"
-        alertname: "VirtualMachineCRCErrors"
+        alertname: "VMStorageClassWarning"
         exp_alerts: []
 
       - eval_time: "2m"
-        alertname: "VirtualMachineCRCErrors"
+        alertname: "VMStorageClassWarning"
         exp_alerts:
           - exp_annotations:
-              description: "1 Virtual Machines are in risk of causing CRC errors and major service outages"
-              summary: "When running VMs using ODF storage with 'rbd' mounter or 'rbd.csi.ceph.com provisioner', it will report bad crc/signature errors and cluster performance will be severely degraded if krbd:rxbounce is not set."
-              runbook_url: "test-runbook:VirtualMachineCRCErrors"
+              summary: "1 Virtual Machines may cause reports of bad crc/signature errors due to certain I/O patterns"
+              description: "When running VMs using ODF storage with 'rbd' mounter or 'rbd.csi.ceph.com provisioner', VMs may cause reports of bad crc/signature errors due to certain I/O patterns. Cluster performance can be severely degraded if the number of re-transmissions due to crc errors causes network saturation."
+              runbook_url: "test-runbook:VMStorageClassWarning"
             exp_labels:
               severity: "warning"
               operator_health_impact: "none"
@@ -188,5 +188,5 @@ tests:
               kubernetes_operator_component: "ssp-operator"
 
       - eval_time: "3m"
-        alertname: "VirtualMachineCRCErrors"
+        alertname: "VMStorageClassWarning"
         exp_alerts: []

--- a/pkg/monitoring/rules/rules.go
+++ b/pkg/monitoring/rules/rules.go
@@ -162,12 +162,12 @@ func AlertRules(runbookURLTemplate string) []promv1.Rule {
 			},
 		},
 		{
-			Alert: "VirtualMachineCRCErrors",
+			Alert: "VMStorageClassWarning",
 			Expr:  intstr.FromString("(count(kubevirt_ssp_vm_rbd_block_volume_without_rxbounce > 0) or vector(0)) > 0"),
 			Annotations: map[string]string{
-				"description": "{{ $value }} Virtual Machines are in risk of causing CRC errors and major service outages",
-				"summary":     "When running VMs using ODF storage with 'rbd' mounter or 'rbd.csi.ceph.com provisioner', it will report bad crc/signature errors and cluster performance will be severely degraded if krbd:rxbounce is not set.",
-				"runbook_url": fmt.Sprintf(runbookURLTemplate, "VirtualMachineCRCErrors"),
+				"summary":     "{{ $value }} Virtual Machines may cause reports of bad crc/signature errors due to certain I/O patterns",
+				"description": "When running VMs using ODF storage with 'rbd' mounter or 'rbd.csi.ceph.com provisioner', VMs may cause reports of bad crc/signature errors due to certain I/O patterns. Cluster performance can be severely degraded if the number of re-transmissions due to crc errors causes network saturation.",
+				"runbook_url": fmt.Sprintf(runbookURLTemplate, "VMStorageClassWarning"),
 			},
 			Labels: map[string]string{
 				severityAlertLabelKey:     "warning",

--- a/tests/monitoring_test.go
+++ b/tests/monitoring_test.go
@@ -163,7 +163,7 @@ var _ = Describe("Prometheus Alerts", func() {
 		})
 	})
 
-	Context("VirtualMachineCRCErrors", func() {
+	Context("VMStorageClassWarning", func() {
 		var vm *kubevirtv1.VirtualMachine
 		var pvc *core.PersistentVolumeClaim
 		var pv *core.PersistentVolume
@@ -272,16 +272,16 @@ var _ = Describe("Prometheus Alerts", func() {
 			return vmName
 		}
 
-		It("[test_id:TODO] Should not fire VirtualMachineCRCErrors when rxbounce is enabled", func() {
+		It("[test_id:TODO] Should not fire VMStorageClassWarning when rxbounce is enabled", func() {
 			vmName := createResources(true, true)
 			waitForSeriesToBeDetected(fmt.Sprintf("kubevirt_ssp_vm_rbd_block_volume_without_rxbounce{name='%s'} == 0", vmName))
-			alertShouldNotBeActive("VirtualMachineCRCErrors")
+			alertShouldNotBeActive("VMStorageClassWarning")
 		})
 
-		It("[test_id:10549] Should fire VirtualMachineCRCErrors when rxbounce is disabled", func() {
+		It("[test_id:10549] Should fire VMStorageClassWarning when rxbounce is disabled", func() {
 			vmName := createResources(true, false)
 			waitForSeriesToBeDetected(fmt.Sprintf("kubevirt_ssp_vm_rbd_block_volume_without_rxbounce{name='%s'} == 1", vmName))
-			waitForAlertToActivate("VirtualMachineCRCErrors")
+			waitForAlertToActivate("VMStorageClassWarning")
 
 			err := apiClient.Delete(ctx, vm)
 			Expect(err).ToNot(HaveOccurred())
@@ -291,7 +291,7 @@ var _ = Describe("Prometheus Alerts", func() {
 			}).Should(MatchError(k8serrors.IsNotFound, "IsNotFound"))
 
 			waitForSeriesToBeDetected(fmt.Sprintf("kubevirt_ssp_vm_rbd_block_volume_without_rxbounce{name='%s'} == 0", vmName))
-			alertShouldNotBeActive("VirtualMachineCRCErrors")
+			alertShouldNotBeActive("VMStorageClassWarning")
 		})
 	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

The concerns are that this alert will fire once any VM is running without the new "-virtualization" storage class (or a custom-defined SC with the "rxbounce" option). We believe that means most upgrade scenarios will start to fire this alert (and it's not easy to transition VMs to the new storage class). We think the wording should be softened and clarified.

jira-ticket: https://issues.redhat.com/browse/CNV-35099

**Which issue(s) this PR fixes**: 
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Rename VirtualMachineCRCErrors to VMStorageClassWarning
```
