### PR TITLE
fix: Remove use of kubevirt.io/v1alpha3 in template-validator tests

### DIFF
--- a/internal/template-validator/validation/test-utils/utils.go
+++ b/internal/template-validator/validation/test-utils/utils.go
@@ -11,7 +11,7 @@ import (
 func NewVMCirros() *kubevirt.VirtualMachine {
 	vm := kubevirt.VirtualMachine{}
 	b := bytes.NewBufferString(`
-apiVersion: kubevirt.io/v1alpha3
+apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:
   labels:


### PR DESCRIPTION
**What this PR does / why we need it**:

`kubevirt.io/v1alpha3` is now deprecated in favour of `kubevirt.io/v1`.

Related to but not a fix for #716

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
