### PR TITLE
Re-add cnv:vmi_status_running:count recording rule

### DIFF
--- a/pkg/monitoring/rules/recordingrules/recordingrules.go
+++ b/pkg/monitoring/rules/recordingrules/recordingrules.go
@@ -5,5 +5,6 @@ import "github.com/machadovilaca/operator-observability/pkg/operatorrules"
 func Register() error {
 	return operatorrules.RegisterRecordingRules(
 		operatorRecordingRules(),
+		vmiRecordingRules,
 	)
 }

--- a/pkg/monitoring/rules/recordingrules/vmi.go
+++ b/pkg/monitoring/rules/recordingrules/vmi.go
@@ -1,0 +1,18 @@
+package recordingrules
+
+import (
+	"github.com/machadovilaca/operator-observability/pkg/operatormetrics"
+	"github.com/machadovilaca/operator-observability/pkg/operatorrules"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+var vmiRecordingRules = []operatorrules.RecordingRule{
+	{
+		MetricsOpts: operatormetrics.MetricOpts{
+			Name: "cnv:vmi_status_running:count",
+			Help: "The total number of running VMIs by status",
+		},
+		MetricType: operatormetrics.GaugeType,
+		Expr:       intstr.FromString("sum(kubevirt_vmi_phase_count{phase=\"running\"}) by (node,os,workload,flavor,instance_type,preference)"),
+	},
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Re-add `cnv:vmi_status_running:count,` incorrectly removed in https://github.com/kubevirt/ssp-operator/pull/870

**Which issue(s) this PR fixes**: 
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Re-add cnv:vmi_status_running:count recording rule
```
