### PR TITLE
chore: Update Ginkgo version in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ unittest: generate lint fmt vet manifests metrics-rules-test
 build-functests:
 	go test -c ./tests
 
-GINKGO_VERSION ?= v2.13.1
+GINKGO_VERSION ?= v2.15.0
 GINKGO_TIMEOUT ?= 2h
 
 .PHONY: ginkgo


### PR DESCRIPTION
**What this PR does / why we need it**:
The version in `Makefile` was not updated by dependabot.

**Release note**:
```release-note
None
```
