### PR TITLE
Update common-instancetypes to v0.3.5

### DIFF
--- a/data/common-instancetypes-bundle/common-clusterinstancetypes-bundle.yaml
+++ b/data/common-instancetypes-bundle/common-clusterinstancetypes-bundle.yaml
@@ -3,6 +3,7 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
+    instancetype.kubevirt.io/class: Compute Exclusive
     instancetype.kubevirt.io/description: |-
       The CX Series provides exclusive compute resources for compute
       intensive applications.
@@ -15,19 +16,16 @@ metadata:
       the IO threading from cores dedicated to the workload.
       In addition, in this series, the NUMA topology of the used
       cores is provided to the VM.
-    instancetype.kubevirt.io/displayName: Compute Exclusive
+    instancetype.kubevirt.io/version: "1"
   labels:
-    instancetype.kubevirt.io/class: compute.exclusive
     instancetype.kubevirt.io/cpu: "8"
     instancetype.kubevirt.io/dedicatedCPUPlacement: "true"
     instancetype.kubevirt.io/hugepages: "true"
-    instancetype.kubevirt.io/icon-pf: pficon-registry
     instancetype.kubevirt.io/isolateEmulatorThread: "true"
     instancetype.kubevirt.io/memory: 16Gi
     instancetype.kubevirt.io/numa: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/version: "1"
-    instancetype.kubevirt.io/common-instancetypes-version: v0.4.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.5
   name: cx1.2xlarge
 spec:
   cpu:
@@ -46,6 +44,7 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
+    instancetype.kubevirt.io/class: Compute Exclusive
     instancetype.kubevirt.io/description: |-
       The CX Series provides exclusive compute resources for compute
       intensive applications.
@@ -58,19 +57,16 @@ metadata:
       the IO threading from cores dedicated to the workload.
       In addition, in this series, the NUMA topology of the used
       cores is provided to the VM.
-    instancetype.kubevirt.io/displayName: Compute Exclusive
+    instancetype.kubevirt.io/version: "1"
   labels:
-    instancetype.kubevirt.io/class: compute.exclusive
     instancetype.kubevirt.io/cpu: "16"
     instancetype.kubevirt.io/dedicatedCPUPlacement: "true"
     instancetype.kubevirt.io/hugepages: "true"
-    instancetype.kubevirt.io/icon-pf: pficon-registry
     instancetype.kubevirt.io/isolateEmulatorThread: "true"
     instancetype.kubevirt.io/memory: 32Gi
     instancetype.kubevirt.io/numa: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/version: "1"
-    instancetype.kubevirt.io/common-instancetypes-version: v0.4.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.5
   name: cx1.4xlarge
 spec:
   cpu:
@@ -89,6 +85,7 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
+    instancetype.kubevirt.io/class: Compute Exclusive
     instancetype.kubevirt.io/description: |-
       The CX Series provides exclusive compute resources for compute
       intensive applications.
@@ -101,19 +98,16 @@ metadata:
       the IO threading from cores dedicated to the workload.
       In addition, in this series, the NUMA topology of the used
       cores is provided to the VM.
-    instancetype.kubevirt.io/displayName: Compute Exclusive
+    instancetype.kubevirt.io/version: "1"
   labels:
-    instancetype.kubevirt.io/class: compute.exclusive
     instancetype.kubevirt.io/cpu: "32"
     instancetype.kubevirt.io/dedicatedCPUPlacement: "true"
     instancetype.kubevirt.io/hugepages: "true"
-    instancetype.kubevirt.io/icon-pf: pficon-registry
     instancetype.kubevirt.io/isolateEmulatorThread: "true"
     instancetype.kubevirt.io/memory: 64Gi
     instancetype.kubevirt.io/numa: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/version: "1"
-    instancetype.kubevirt.io/common-instancetypes-version: v0.4.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.5
   name: cx1.8xlarge
 spec:
   cpu:
@@ -132,6 +126,7 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
+    instancetype.kubevirt.io/class: Compute Exclusive
     instancetype.kubevirt.io/description: |-
       The CX Series provides exclusive compute resources for compute
       intensive applications.
@@ -144,19 +139,16 @@ metadata:
       the IO threading from cores dedicated to the workload.
       In addition, in this series, the NUMA topology of the used
       cores is provided to the VM.
-    instancetype.kubevirt.io/displayName: Compute Exclusive
+    instancetype.kubevirt.io/version: "1"
   labels:
-    instancetype.kubevirt.io/class: compute.exclusive
     instancetype.kubevirt.io/cpu: "2"
     instancetype.kubevirt.io/dedicatedCPUPlacement: "true"
     instancetype.kubevirt.io/hugepages: "true"
-    instancetype.kubevirt.io/icon-pf: pficon-registry
     instancetype.kubevirt.io/isolateEmulatorThread: "true"
     instancetype.kubevirt.io/memory: 4Gi
     instancetype.kubevirt.io/numa: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/version: "1"
-    instancetype.kubevirt.io/common-instancetypes-version: v0.4.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.5
   name: cx1.large
 spec:
   cpu:
@@ -175,6 +167,7 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
+    instancetype.kubevirt.io/class: Compute Exclusive
     instancetype.kubevirt.io/description: |-
       The CX Series provides exclusive compute resources for compute
       intensive applications.
@@ -187,19 +180,16 @@ metadata:
       the IO threading from cores dedicated to the workload.
       In addition, in this series, the NUMA topology of the used
       cores is provided to the VM.
-    instancetype.kubevirt.io/displayName: Compute Exclusive
+    instancetype.kubevirt.io/version: "1"
   labels:
-    instancetype.kubevirt.io/class: compute.exclusive
     instancetype.kubevirt.io/cpu: "1"
     instancetype.kubevirt.io/dedicatedCPUPlacement: "true"
     instancetype.kubevirt.io/hugepages: "true"
-    instancetype.kubevirt.io/icon-pf: pficon-registry
     instancetype.kubevirt.io/isolateEmulatorThread: "true"
     instancetype.kubevirt.io/memory: 2Gi
     instancetype.kubevirt.io/numa: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/version: "1"
-    instancetype.kubevirt.io/common-instancetypes-version: v0.4.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.5
   name: cx1.medium
 spec:
   cpu:
@@ -218,6 +208,7 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
+    instancetype.kubevirt.io/class: Compute Exclusive
     instancetype.kubevirt.io/description: |-
       The CX Series provides exclusive compute resources for compute
       intensive applications.
@@ -230,19 +221,16 @@ metadata:
       the IO threading from cores dedicated to the workload.
       In addition, in this series, the NUMA topology of the used
       cores is provided to the VM.
-    instancetype.kubevirt.io/displayName: Compute Exclusive
+    instancetype.kubevirt.io/version: "1"
   labels:
-    instancetype.kubevirt.io/class: compute.exclusive
     instancetype.kubevirt.io/cpu: "4"
     instancetype.kubevirt.io/dedicatedCPUPlacement: "true"
     instancetype.kubevirt.io/hugepages: "true"
-    instancetype.kubevirt.io/icon-pf: pficon-registry
     instancetype.kubevirt.io/isolateEmulatorThread: "true"
     instancetype.kubevirt.io/memory: 8Gi
     instancetype.kubevirt.io/numa: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/version: "1"
-    instancetype.kubevirt.io/common-instancetypes-version: v0.4.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.5
   name: cx1.xlarge
 spec:
   cpu:
@@ -261,6 +249,7 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
+    instancetype.kubevirt.io/class: GPU NVIDIA
     instancetype.kubevirt.io/description: |-
       The GN Series provides instances types intended for VMs with
       NVIDIA GPU resources attached.
@@ -270,18 +259,14 @@ metadata:
       This series is intended to be used with VMs consuming GPUs
       provided by the
       [NVIDIA GPU Operator](https://github.com/NVIDIA/gpu-operator)
-      which can be installed on Kubernetes and also is made available
-      on OpenShift via OperatorHub.
-    instancetype.kubevirt.io/displayName: GPU NVIDIA
+      which is made available on OpenShift via OperatorHub.
+    instancetype.kubevirt.io/version: "1"
   labels:
-    instancetype.kubevirt.io/class: gpu.nvidia
     instancetype.kubevirt.io/cpu: "8"
     instancetype.kubevirt.io/gpus: "true"
-    instancetype.kubevirt.io/icon-pf: fa-microchip
     instancetype.kubevirt.io/memory: 32Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/version: "1"
-    instancetype.kubevirt.io/common-instancetypes-version: v0.4.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.5
   name: gn1.2xlarge
 spec:
   cpu:
@@ -296,6 +281,7 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
+    instancetype.kubevirt.io/class: GPU NVIDIA
     instancetype.kubevirt.io/description: |-
       The GN Series provides instances types intended for VMs with
       NVIDIA GPU resources attached.
@@ -305,18 +291,14 @@ metadata:
       This series is intended to be used with VMs consuming GPUs
       provided by the
       [NVIDIA GPU Operator](https://github.com/NVIDIA/gpu-operator)
-      which can be installed on Kubernetes and also is made available
-      on OpenShift via OperatorHub.
-    instancetype.kubevirt.io/displayName: GPU NVIDIA
+      which is made available on OpenShift via OperatorHub.
+    instancetype.kubevirt.io/version: "1"
   labels:
-    instancetype.kubevirt.io/class: gpu.nvidia
     instancetype.kubevirt.io/cpu: "16"
     instancetype.kubevirt.io/gpus: "true"
-    instancetype.kubevirt.io/icon-pf: fa-microchip
     instancetype.kubevirt.io/memory: 64Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/version: "1"
-    instancetype.kubevirt.io/common-instancetypes-version: v0.4.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.5
   name: gn1.4xlarge
 spec:
   cpu:
@@ -331,6 +313,7 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
+    instancetype.kubevirt.io/class: GPU NVIDIA
     instancetype.kubevirt.io/description: |-
       The GN Series provides instances types intended for VMs with
       NVIDIA GPU resources attached.
@@ -340,18 +323,14 @@ metadata:
       This series is intended to be used with VMs consuming GPUs
       provided by the
       [NVIDIA GPU Operator](https://github.com/NVIDIA/gpu-operator)
-      which can be installed on Kubernetes and also is made available
-      on OpenShift via OperatorHub.
-    instancetype.kubevirt.io/displayName: GPU NVIDIA
+      which is made available on OpenShift via OperatorHub.
+    instancetype.kubevirt.io/version: "1"
   labels:
-    instancetype.kubevirt.io/class: gpu.nvidia
     instancetype.kubevirt.io/cpu: "32"
     instancetype.kubevirt.io/gpus: "true"
-    instancetype.kubevirt.io/icon-pf: fa-microchip
     instancetype.kubevirt.io/memory: 128Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/version: "1"
-    instancetype.kubevirt.io/common-instancetypes-version: v0.4.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.5
   name: gn1.8xlarge
 spec:
   cpu:
@@ -366,6 +345,7 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
+    instancetype.kubevirt.io/class: GPU NVIDIA
     instancetype.kubevirt.io/description: |-
       The GN Series provides instances types intended for VMs with
       NVIDIA GPU resources attached.
@@ -375,18 +355,14 @@ metadata:
       This series is intended to be used with VMs consuming GPUs
       provided by the
       [NVIDIA GPU Operator](https://github.com/NVIDIA/gpu-operator)
-      which can be installed on Kubernetes and also is made available
-      on OpenShift via OperatorHub.
-    instancetype.kubevirt.io/displayName: GPU NVIDIA
+      which is made available on OpenShift via OperatorHub.
+    instancetype.kubevirt.io/version: "1"
   labels:
-    instancetype.kubevirt.io/class: gpu.nvidia
     instancetype.kubevirt.io/cpu: "4"
     instancetype.kubevirt.io/gpus: "true"
-    instancetype.kubevirt.io/icon-pf: fa-microchip
     instancetype.kubevirt.io/memory: 16Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/version: "1"
-    instancetype.kubevirt.io/common-instancetypes-version: v0.4.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.5
   name: gn1.xlarge
 spec:
   cpu:
@@ -400,22 +376,74 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
+  labels:
+    instancetype.kubevirt.io/deprecated: "true"
+    instancetype.kubevirt.io/vendor: kubevirt.io
+    kubevirt.io/size: large
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.5
+  name: highperformance.large
+spec:
+  cpu:
+    dedicatedCPUPlacement: true
+    guest: 2
+    isolateEmulatorThread: true
+  ioThreadsPolicy: shared
+  memory:
+    guest: 8Gi
+---
+apiVersion: instancetype.kubevirt.io/v1beta1
+kind: VirtualMachineClusterInstancetype
+metadata:
+  labels:
+    instancetype.kubevirt.io/deprecated: "true"
+    instancetype.kubevirt.io/vendor: kubevirt.io
+    kubevirt.io/size: medium
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.5
+  name: highperformance.medium
+spec:
+  cpu:
+    dedicatedCPUPlacement: true
+    guest: 1
+    isolateEmulatorThread: true
+  ioThreadsPolicy: shared
+  memory:
+    guest: 4Gi
+---
+apiVersion: instancetype.kubevirt.io/v1beta1
+kind: VirtualMachineClusterInstancetype
+metadata:
+  labels:
+    instancetype.kubevirt.io/deprecated: "true"
+    instancetype.kubevirt.io/vendor: kubevirt.io
+    kubevirt.io/size: small
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.5
+  name: highperformance.small
+spec:
+  cpu:
+    dedicatedCPUPlacement: true
+    guest: 1
+    isolateEmulatorThread: true
+  ioThreadsPolicy: shared
+  memory:
+    guest: 2Gi
+---
+apiVersion: instancetype.kubevirt.io/v1beta1
+kind: VirtualMachineClusterInstancetype
+metadata:
   annotations:
+    instancetype.kubevirt.io/class: Memory Intensive
     instancetype.kubevirt.io/description: |-
       The M Series provides resources for memory intensive
       applications.
 
       *M* is the abbreviation of "Memory".
-    instancetype.kubevirt.io/displayName: Memory Intensive
+    instancetype.kubevirt.io/version: "1"
   labels:
-    instancetype.kubevirt.io/class: memory.intensive
     instancetype.kubevirt.io/cpu: "8"
     instancetype.kubevirt.io/hugepages: "true"
-    instancetype.kubevirt.io/icon-pf: fa-memory
     instancetype.kubevirt.io/memory: 64Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/version: "1"
-    instancetype.kubevirt.io/common-instancetypes-version: v0.4.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.5
   name: m1.2xlarge
 spec:
   cpu:
@@ -429,21 +457,19 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
+    instancetype.kubevirt.io/class: Memory Intensive
     instancetype.kubevirt.io/description: |-
       The M Series provides resources for memory intensive
       applications.
 
       *M* is the abbreviation of "Memory".
-    instancetype.kubevirt.io/displayName: Memory Intensive
+    instancetype.kubevirt.io/version: "1"
   labels:
-    instancetype.kubevirt.io/class: memory.intensive
     instancetype.kubevirt.io/cpu: "16"
     instancetype.kubevirt.io/hugepages: "true"
-    instancetype.kubevirt.io/icon-pf: fa-memory
     instancetype.kubevirt.io/memory: 128Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/version: "1"
-    instancetype.kubevirt.io/common-instancetypes-version: v0.4.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.5
   name: m1.4xlarge
 spec:
   cpu:
@@ -457,21 +483,19 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
+    instancetype.kubevirt.io/class: Memory Intensive
     instancetype.kubevirt.io/description: |-
       The M Series provides resources for memory intensive
       applications.
 
       *M* is the abbreviation of "Memory".
-    instancetype.kubevirt.io/displayName: Memory Intensive
+    instancetype.kubevirt.io/version: "1"
   labels:
-    instancetype.kubevirt.io/class: memory.intensive
     instancetype.kubevirt.io/cpu: "32"
     instancetype.kubevirt.io/hugepages: "true"
-    instancetype.kubevirt.io/icon-pf: fa-memory
     instancetype.kubevirt.io/memory: 256Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/version: "1"
-    instancetype.kubevirt.io/common-instancetypes-version: v0.4.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.5
   name: m1.8xlarge
 spec:
   cpu:
@@ -485,21 +509,19 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
+    instancetype.kubevirt.io/class: Memory Intensive
     instancetype.kubevirt.io/description: |-
       The M Series provides resources for memory intensive
       applications.
 
       *M* is the abbreviation of "Memory".
-    instancetype.kubevirt.io/displayName: Memory Intensive
+    instancetype.kubevirt.io/version: "1"
   labels:
-    instancetype.kubevirt.io/class: memory.intensive
     instancetype.kubevirt.io/cpu: "2"
     instancetype.kubevirt.io/hugepages: "true"
-    instancetype.kubevirt.io/icon-pf: fa-memory
     instancetype.kubevirt.io/memory: 16Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/version: "1"
-    instancetype.kubevirt.io/common-instancetypes-version: v0.4.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.5
   name: m1.large
 spec:
   cpu:
@@ -513,21 +535,19 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
+    instancetype.kubevirt.io/class: Memory Intensive
     instancetype.kubevirt.io/description: |-
       The M Series provides resources for memory intensive
       applications.
 
       *M* is the abbreviation of "Memory".
-    instancetype.kubevirt.io/displayName: Memory Intensive
+    instancetype.kubevirt.io/version: "1"
   labels:
-    instancetype.kubevirt.io/class: memory.intensive
     instancetype.kubevirt.io/cpu: "4"
     instancetype.kubevirt.io/hugepages: "true"
-    instancetype.kubevirt.io/icon-pf: fa-memory
     instancetype.kubevirt.io/memory: 32Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/version: "1"
-    instancetype.kubevirt.io/common-instancetypes-version: v0.4.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.5
   name: m1.xlarge
 spec:
   cpu:
@@ -541,230 +561,18 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/description: |-
-      The N Series provides resources for network intensive DPDK
-      applications, like VNFs.
-
-      *N* is the abbreviation for "Network".
-
-      This series of instancetypes requires nodes capable
-      of running DPDK workloads and being marked with the respective
-      node-role.kubevirt.io/worker-dpdk label as such.
-    instancetype.kubevirt.io/displayName: Network
-  labels:
-    instancetype.kubevirt.io/class: network
-    instancetype.kubevirt.io/cpu: "16"
-    instancetype.kubevirt.io/dedicatedCPUPlacement: "true"
-    instancetype.kubevirt.io/hugepages: "true"
-    instancetype.kubevirt.io/icon-pf: pficon-network
-    instancetype.kubevirt.io/isolateEmulatorThread: "true"
-    instancetype.kubevirt.io/memory: 32Gi
-    instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/version: "1"
-    instancetype.kubevirt.io/common-instancetypes-version: v0.4.0
-  name: n1.2xlarge
-spec:
-  annotations:
-    cpu-load-balancing.crio.io: disable
-    cpu-quota.crio.io: disable
-    irq-load-balancing.crio.io: disable
-  cpu:
-    dedicatedCPUPlacement: true
-    guest: 16
-    isolateEmulatorThread: true
-  memory:
-    guest: 32Gi
-    hugepages:
-      pageSize: 1Gi
-  nodeSelector:
-    node-role.kubernetes.io/worker-dpdk: ""
----
-apiVersion: instancetype.kubevirt.io/v1beta1
-kind: VirtualMachineClusterInstancetype
-metadata:
-  annotations:
-    instancetype.kubevirt.io/description: |-
-      The N Series provides resources for network intensive DPDK
-      applications, like VNFs.
-
-      *N* is the abbreviation for "Network".
-
-      This series of instancetypes requires nodes capable
-      of running DPDK workloads and being marked with the respective
-      node-role.kubevirt.io/worker-dpdk label as such.
-    instancetype.kubevirt.io/displayName: Network
-  labels:
-    instancetype.kubevirt.io/class: network
-    instancetype.kubevirt.io/cpu: "32"
-    instancetype.kubevirt.io/dedicatedCPUPlacement: "true"
-    instancetype.kubevirt.io/hugepages: "true"
-    instancetype.kubevirt.io/icon-pf: pficon-network
-    instancetype.kubevirt.io/isolateEmulatorThread: "true"
-    instancetype.kubevirt.io/memory: 64Gi
-    instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/version: "1"
-    instancetype.kubevirt.io/common-instancetypes-version: v0.4.0
-  name: n1.4xlarge
-spec:
-  annotations:
-    cpu-load-balancing.crio.io: disable
-    cpu-quota.crio.io: disable
-    irq-load-balancing.crio.io: disable
-  cpu:
-    dedicatedCPUPlacement: true
-    guest: 32
-    isolateEmulatorThread: true
-  memory:
-    guest: 64Gi
-    hugepages:
-      pageSize: 1Gi
-  nodeSelector:
-    node-role.kubernetes.io/worker-dpdk: ""
----
-apiVersion: instancetype.kubevirt.io/v1beta1
-kind: VirtualMachineClusterInstancetype
-metadata:
-  annotations:
-    instancetype.kubevirt.io/description: |-
-      The N Series provides resources for network intensive DPDK
-      applications, like VNFs.
-
-      *N* is the abbreviation for "Network".
-
-      This series of instancetypes requires nodes capable
-      of running DPDK workloads and being marked with the respective
-      node-role.kubevirt.io/worker-dpdk label as such.
-    instancetype.kubevirt.io/displayName: Network
-  labels:
-    instancetype.kubevirt.io/class: network
-    instancetype.kubevirt.io/cpu: "64"
-    instancetype.kubevirt.io/dedicatedCPUPlacement: "true"
-    instancetype.kubevirt.io/hugepages: "true"
-    instancetype.kubevirt.io/icon-pf: pficon-network
-    instancetype.kubevirt.io/isolateEmulatorThread: "true"
-    instancetype.kubevirt.io/memory: 128Gi
-    instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/version: "1"
-    instancetype.kubevirt.io/common-instancetypes-version: v0.4.0
-  name: n1.8xlarge
-spec:
-  annotations:
-    cpu-load-balancing.crio.io: disable
-    cpu-quota.crio.io: disable
-    irq-load-balancing.crio.io: disable
-  cpu:
-    dedicatedCPUPlacement: true
-    guest: 64
-    isolateEmulatorThread: true
-  memory:
-    guest: 128Gi
-    hugepages:
-      pageSize: 1Gi
-  nodeSelector:
-    node-role.kubernetes.io/worker-dpdk: ""
----
-apiVersion: instancetype.kubevirt.io/v1beta1
-kind: VirtualMachineClusterInstancetype
-metadata:
-  annotations:
-    instancetype.kubevirt.io/description: |-
-      The N Series provides resources for network intensive DPDK
-      applications, like VNFs.
-
-      *N* is the abbreviation for "Network".
-
-      This series of instancetypes requires nodes capable
-      of running DPDK workloads and being marked with the respective
-      node-role.kubevirt.io/worker-dpdk label as such.
-    instancetype.kubevirt.io/displayName: Network
-  labels:
-    instancetype.kubevirt.io/class: network
-    instancetype.kubevirt.io/cpu: "4"
-    instancetype.kubevirt.io/dedicatedCPUPlacement: "true"
-    instancetype.kubevirt.io/hugepages: "true"
-    instancetype.kubevirt.io/icon-pf: pficon-network
-    instancetype.kubevirt.io/isolateEmulatorThread: "true"
-    instancetype.kubevirt.io/memory: 8Gi
-    instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/version: "1"
-    instancetype.kubevirt.io/common-instancetypes-version: v0.4.0
-  name: n1.large
-spec:
-  annotations:
-    cpu-load-balancing.crio.io: disable
-    cpu-quota.crio.io: disable
-    irq-load-balancing.crio.io: disable
-  cpu:
-    dedicatedCPUPlacement: true
-    guest: 4
-    isolateEmulatorThread: true
-  memory:
-    guest: 8Gi
-    hugepages:
-      pageSize: 1Gi
-  nodeSelector:
-    node-role.kubernetes.io/worker-dpdk: ""
----
-apiVersion: instancetype.kubevirt.io/v1beta1
-kind: VirtualMachineClusterInstancetype
-metadata:
-  annotations:
-    instancetype.kubevirt.io/description: |-
-      The N Series provides resources for network intensive DPDK
-      applications, like VNFs.
-
-      *N* is the abbreviation for "Network".
-
-      This series of instancetypes requires nodes capable
-      of running DPDK workloads and being marked with the respective
-      node-role.kubevirt.io/worker-dpdk label as such.
-    instancetype.kubevirt.io/displayName: Network
-  labels:
-    instancetype.kubevirt.io/class: network
-    instancetype.kubevirt.io/cpu: "8"
-    instancetype.kubevirt.io/dedicatedCPUPlacement: "true"
-    instancetype.kubevirt.io/hugepages: "true"
-    instancetype.kubevirt.io/icon-pf: pficon-network
-    instancetype.kubevirt.io/isolateEmulatorThread: "true"
-    instancetype.kubevirt.io/memory: 16Gi
-    instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/version: "1"
-    instancetype.kubevirt.io/common-instancetypes-version: v0.4.0
-  name: n1.xlarge
-spec:
-  annotations:
-    cpu-load-balancing.crio.io: disable
-    cpu-quota.crio.io: disable
-    irq-load-balancing.crio.io: disable
-  cpu:
-    dedicatedCPUPlacement: true
-    guest: 8
-    isolateEmulatorThread: true
-  memory:
-    guest: 16Gi
-    hugepages:
-      pageSize: 1Gi
-  nodeSelector:
-    node-role.kubernetes.io/worker-dpdk: ""
----
-apiVersion: instancetype.kubevirt.io/v1beta1
-kind: VirtualMachineClusterInstancetype
-metadata:
-  annotations:
+    instancetype.kubevirt.io/class: Overcommitted
     instancetype.kubevirt.io/description: |-
       The O Series is based on the U Series, with the only difference
       being that memory is overcommitted.
 
       *O* is the abbreviation for "Overcommitted".
-    instancetype.kubevirt.io/displayName: Overcommitted
+    instancetype.kubevirt.io/version: "1"
   labels:
-    instancetype.kubevirt.io/class: overcommitted
     instancetype.kubevirt.io/cpu: "8"
-    instancetype.kubevirt.io/icon-pf: pficon-virtual-machine
     instancetype.kubevirt.io/memory: 32Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/version: "1"
-    instancetype.kubevirt.io/common-instancetypes-version: v0.4.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.5
   name: o1.2xlarge
 spec:
   cpu:
@@ -777,20 +585,18 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
+    instancetype.kubevirt.io/class: Overcommitted
     instancetype.kubevirt.io/description: |-
       The O Series is based on the U Series, with the only difference
       being that memory is overcommitted.
 
       *O* is the abbreviation for "Overcommitted".
-    instancetype.kubevirt.io/displayName: Overcommitted
+    instancetype.kubevirt.io/version: "1"
   labels:
-    instancetype.kubevirt.io/class: overcommitted
     instancetype.kubevirt.io/cpu: "16"
-    instancetype.kubevirt.io/icon-pf: pficon-virtual-machine
     instancetype.kubevirt.io/memory: 64Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/version: "1"
-    instancetype.kubevirt.io/common-instancetypes-version: v0.4.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.5
   name: o1.4xlarge
 spec:
   cpu:
@@ -803,20 +609,18 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
+    instancetype.kubevirt.io/class: Overcommitted
     instancetype.kubevirt.io/description: |-
       The O Series is based on the U Series, with the only difference
       being that memory is overcommitted.
 
       *O* is the abbreviation for "Overcommitted".
-    instancetype.kubevirt.io/displayName: Overcommitted
+    instancetype.kubevirt.io/version: "1"
   labels:
-    instancetype.kubevirt.io/class: overcommitted
     instancetype.kubevirt.io/cpu: "32"
-    instancetype.kubevirt.io/icon-pf: pficon-virtual-machine
     instancetype.kubevirt.io/memory: 128Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/version: "1"
-    instancetype.kubevirt.io/common-instancetypes-version: v0.4.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.5
   name: o1.8xlarge
 spec:
   cpu:
@@ -829,20 +633,18 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
+    instancetype.kubevirt.io/class: Overcommitted
     instancetype.kubevirt.io/description: |-
       The O Series is based on the U Series, with the only difference
       being that memory is overcommitted.
 
       *O* is the abbreviation for "Overcommitted".
-    instancetype.kubevirt.io/displayName: Overcommitted
+    instancetype.kubevirt.io/version: "1"
   labels:
-    instancetype.kubevirt.io/class: overcommitted
     instancetype.kubevirt.io/cpu: "2"
-    instancetype.kubevirt.io/icon-pf: pficon-virtual-machine
     instancetype.kubevirt.io/memory: 8Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/version: "1"
-    instancetype.kubevirt.io/common-instancetypes-version: v0.4.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.5
   name: o1.large
 spec:
   cpu:
@@ -855,20 +657,18 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
+    instancetype.kubevirt.io/class: Overcommitted
     instancetype.kubevirt.io/description: |-
       The O Series is based on the U Series, with the only difference
       being that memory is overcommitted.
 
       *O* is the abbreviation for "Overcommitted".
-    instancetype.kubevirt.io/displayName: Overcommitted
+    instancetype.kubevirt.io/version: "1"
   labels:
-    instancetype.kubevirt.io/class: overcommitted
     instancetype.kubevirt.io/cpu: "1"
-    instancetype.kubevirt.io/icon-pf: pficon-virtual-machine
     instancetype.kubevirt.io/memory: 4Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/version: "1"
-    instancetype.kubevirt.io/common-instancetypes-version: v0.4.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.5
   name: o1.medium
 spec:
   cpu:
@@ -881,98 +681,18 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
+    instancetype.kubevirt.io/class: Overcommitted
     instancetype.kubevirt.io/description: |-
       The O Series is based on the U Series, with the only difference
       being that memory is overcommitted.
 
       *O* is the abbreviation for "Overcommitted".
-    instancetype.kubevirt.io/displayName: Overcommitted
-  labels:
-    instancetype.kubevirt.io/class: overcommitted
-    instancetype.kubevirt.io/cpu: "1"
-    instancetype.kubevirt.io/icon-pf: pficon-virtual-machine
-    instancetype.kubevirt.io/memory: 1Gi
-    instancetype.kubevirt.io/vendor: kubevirt.io
     instancetype.kubevirt.io/version: "1"
-    instancetype.kubevirt.io/common-instancetypes-version: v0.4.0
-  name: o1.micro
-spec:
-  cpu:
-    guest: 1
-  memory:
-    guest: 1Gi
-    overcommitPercent: 50
----
-apiVersion: instancetype.kubevirt.io/v1beta1
-kind: VirtualMachineClusterInstancetype
-metadata:
-  annotations:
-    instancetype.kubevirt.io/description: |-
-      The O Series is based on the U Series, with the only difference
-      being that memory is overcommitted.
-
-      *O* is the abbreviation for "Overcommitted".
-    instancetype.kubevirt.io/displayName: Overcommitted
   labels:
-    instancetype.kubevirt.io/class: overcommitted
-    instancetype.kubevirt.io/cpu: "1"
-    instancetype.kubevirt.io/icon-pf: pficon-virtual-machine
-    instancetype.kubevirt.io/memory: 512Mi
-    instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/version: "1"
-    instancetype.kubevirt.io/common-instancetypes-version: v0.4.0
-  name: o1.nano
-spec:
-  cpu:
-    guest: 1
-  memory:
-    guest: 512Mi
-    overcommitPercent: 50
----
-apiVersion: instancetype.kubevirt.io/v1beta1
-kind: VirtualMachineClusterInstancetype
-metadata:
-  annotations:
-    instancetype.kubevirt.io/description: |-
-      The O Series is based on the U Series, with the only difference
-      being that memory is overcommitted.
-
-      *O* is the abbreviation for "Overcommitted".
-    instancetype.kubevirt.io/displayName: Overcommitted
-  labels:
-    instancetype.kubevirt.io/class: overcommitted
-    instancetype.kubevirt.io/cpu: "1"
-    instancetype.kubevirt.io/icon-pf: pficon-virtual-machine
-    instancetype.kubevirt.io/memory: 2Gi
-    instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/version: "1"
-    instancetype.kubevirt.io/common-instancetypes-version: v0.4.0
-  name: o1.small
-spec:
-  cpu:
-    guest: 1
-  memory:
-    guest: 2Gi
-    overcommitPercent: 50
----
-apiVersion: instancetype.kubevirt.io/v1beta1
-kind: VirtualMachineClusterInstancetype
-metadata:
-  annotations:
-    instancetype.kubevirt.io/description: |-
-      The O Series is based on the U Series, with the only difference
-      being that memory is overcommitted.
-
-      *O* is the abbreviation for "Overcommitted".
-    instancetype.kubevirt.io/displayName: Overcommitted
-  labels:
-    instancetype.kubevirt.io/class: overcommitted
     instancetype.kubevirt.io/cpu: "4"
-    instancetype.kubevirt.io/icon-pf: pficon-virtual-machine
     instancetype.kubevirt.io/memory: 16Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/version: "1"
-    instancetype.kubevirt.io/common-instancetypes-version: v0.4.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.5
   name: o1.xlarge
 spec:
   cpu:
@@ -984,7 +704,83 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
+  labels:
+    instancetype.kubevirt.io/deprecated: "true"
+    instancetype.kubevirt.io/vendor: kubevirt.io
+    kubevirt.io/size: large
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.5
+  name: server.large
+spec:
+  cpu:
+    guest: 2
+  memory:
+    guest: 8Gi
+---
+apiVersion: instancetype.kubevirt.io/v1beta1
+kind: VirtualMachineClusterInstancetype
+metadata:
+  labels:
+    instancetype.kubevirt.io/deprecated: "true"
+    instancetype.kubevirt.io/vendor: kubevirt.io
+    kubevirt.io/size: medium
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.5
+  name: server.medium
+spec:
+  cpu:
+    guest: 1
+  memory:
+    guest: 4Gi
+---
+apiVersion: instancetype.kubevirt.io/v1beta1
+kind: VirtualMachineClusterInstancetype
+metadata:
+  labels:
+    instancetype.kubevirt.io/deprecated: "true"
+    instancetype.kubevirt.io/vendor: kubevirt.io
+    kubevirt.io/size: micro
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.5
+  name: server.micro
+spec:
+  cpu:
+    guest: 1
+  memory:
+    guest: 256Mi
+---
+apiVersion: instancetype.kubevirt.io/v1beta1
+kind: VirtualMachineClusterInstancetype
+metadata:
+  labels:
+    instancetype.kubevirt.io/deprecated: "true"
+    instancetype.kubevirt.io/vendor: kubevirt.io
+    kubevirt.io/size: small
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.5
+  name: server.small
+spec:
+  cpu:
+    guest: 1
+  memory:
+    guest: 2Gi
+---
+apiVersion: instancetype.kubevirt.io/v1beta1
+kind: VirtualMachineClusterInstancetype
+metadata:
+  labels:
+    instancetype.kubevirt.io/deprecated: "true"
+    instancetype.kubevirt.io/vendor: kubevirt.io
+    kubevirt.io/size: tiny
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.5
+  name: server.tiny
+spec:
+  cpu:
+    guest: 1
+  memory:
+    guest: 1.5Gi
+---
+apiVersion: instancetype.kubevirt.io/v1beta1
+kind: VirtualMachineClusterInstancetype
+metadata:
   annotations:
+    instancetype.kubevirt.io/class: General Purpose
     instancetype.kubevirt.io/description: |-
       The U Series is quite neutral and provides resources for
       general purpose applications.
@@ -994,15 +790,12 @@ metadata:
 
       VMs of instance types will share physical CPU cores on a
       time-slice basis with other VMs.
-    instancetype.kubevirt.io/displayName: General Purpose
+    instancetype.kubevirt.io/version: "1"
   labels:
-    instancetype.kubevirt.io/class: general.purpose
     instancetype.kubevirt.io/cpu: "8"
-    instancetype.kubevirt.io/icon-pf: pficon-server-group
     instancetype.kubevirt.io/memory: 32Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/version: "1"
-    instancetype.kubevirt.io/common-instancetypes-version: v0.4.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.5
   name: u1.2xlarge
 spec:
   cpu:
@@ -1014,6 +807,7 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
+    instancetype.kubevirt.io/class: General Purpose
     instancetype.kubevirt.io/description: |-
       The U Series is quite neutral and provides resources for
       general purpose applications.
@@ -1023,15 +817,12 @@ metadata:
 
       VMs of instance types will share physical CPU cores on a
       time-slice basis with other VMs.
-    instancetype.kubevirt.io/displayName: General Purpose
+    instancetype.kubevirt.io/version: "1"
   labels:
-    instancetype.kubevirt.io/class: general.purpose
     instancetype.kubevirt.io/cpu: "16"
-    instancetype.kubevirt.io/icon-pf: pficon-server-group
     instancetype.kubevirt.io/memory: 64Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/version: "1"
-    instancetype.kubevirt.io/common-instancetypes-version: v0.4.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.5
   name: u1.4xlarge
 spec:
   cpu:
@@ -1043,6 +834,7 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
+    instancetype.kubevirt.io/class: General Purpose
     instancetype.kubevirt.io/description: |-
       The U Series is quite neutral and provides resources for
       general purpose applications.
@@ -1052,15 +844,12 @@ metadata:
 
       VMs of instance types will share physical CPU cores on a
       time-slice basis with other VMs.
-    instancetype.kubevirt.io/displayName: General Purpose
+    instancetype.kubevirt.io/version: "1"
   labels:
-    instancetype.kubevirt.io/class: general.purpose
     instancetype.kubevirt.io/cpu: "32"
-    instancetype.kubevirt.io/icon-pf: pficon-server-group
     instancetype.kubevirt.io/memory: 128Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/version: "1"
-    instancetype.kubevirt.io/common-instancetypes-version: v0.4.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.5
   name: u1.8xlarge
 spec:
   cpu:
@@ -1072,6 +861,7 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
+    instancetype.kubevirt.io/class: General Purpose
     instancetype.kubevirt.io/description: |-
       The U Series is quite neutral and provides resources for
       general purpose applications.
@@ -1081,15 +871,12 @@ metadata:
 
       VMs of instance types will share physical CPU cores on a
       time-slice basis with other VMs.
-    instancetype.kubevirt.io/displayName: General Purpose
+    instancetype.kubevirt.io/version: "1"
   labels:
-    instancetype.kubevirt.io/class: general.purpose
     instancetype.kubevirt.io/cpu: "2"
-    instancetype.kubevirt.io/icon-pf: pficon-server-group
     instancetype.kubevirt.io/memory: 8Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/version: "1"
-    instancetype.kubevirt.io/common-instancetypes-version: v0.4.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.5
   name: u1.large
 spec:
   cpu:
@@ -1101,6 +888,7 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
+    instancetype.kubevirt.io/class: General Purpose
     instancetype.kubevirt.io/description: |-
       The U Series is quite neutral and provides resources for
       general purpose applications.
@@ -1110,15 +898,12 @@ metadata:
 
       VMs of instance types will share physical CPU cores on a
       time-slice basis with other VMs.
-    instancetype.kubevirt.io/displayName: General Purpose
+    instancetype.kubevirt.io/version: "1"
   labels:
-    instancetype.kubevirt.io/class: general.purpose
     instancetype.kubevirt.io/cpu: "1"
-    instancetype.kubevirt.io/icon-pf: pficon-server-group
     instancetype.kubevirt.io/memory: 4Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/version: "1"
-    instancetype.kubevirt.io/common-instancetypes-version: v0.4.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.5
   name: u1.medium
 spec:
   cpu:
@@ -1130,6 +915,7 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
+    instancetype.kubevirt.io/class: General Purpose
     instancetype.kubevirt.io/description: |-
       The U Series is quite neutral and provides resources for
       general purpose applications.
@@ -1139,15 +925,12 @@ metadata:
 
       VMs of instance types will share physical CPU cores on a
       time-slice basis with other VMs.
-    instancetype.kubevirt.io/displayName: General Purpose
+    instancetype.kubevirt.io/version: "1"
   labels:
-    instancetype.kubevirt.io/class: general.purpose
     instancetype.kubevirt.io/cpu: "1"
-    instancetype.kubevirt.io/icon-pf: pficon-server-group
     instancetype.kubevirt.io/memory: 1Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/version: "1"
-    instancetype.kubevirt.io/common-instancetypes-version: v0.4.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.5
   name: u1.micro
 spec:
   cpu:
@@ -1159,6 +942,7 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
+    instancetype.kubevirt.io/class: General Purpose
     instancetype.kubevirt.io/description: |-
       The U Series is quite neutral and provides resources for
       general purpose applications.
@@ -1168,15 +952,12 @@ metadata:
 
       VMs of instance types will share physical CPU cores on a
       time-slice basis with other VMs.
-    instancetype.kubevirt.io/displayName: General Purpose
+    instancetype.kubevirt.io/version: "1"
   labels:
-    instancetype.kubevirt.io/class: general.purpose
     instancetype.kubevirt.io/cpu: "1"
-    instancetype.kubevirt.io/icon-pf: pficon-server-group
     instancetype.kubevirt.io/memory: 512Mi
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/version: "1"
-    instancetype.kubevirt.io/common-instancetypes-version: v0.4.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.5
   name: u1.nano
 spec:
   cpu:
@@ -1188,6 +969,7 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
+    instancetype.kubevirt.io/class: General Purpose
     instancetype.kubevirt.io/description: |-
       The U Series is quite neutral and provides resources for
       general purpose applications.
@@ -1197,15 +979,12 @@ metadata:
 
       VMs of instance types will share physical CPU cores on a
       time-slice basis with other VMs.
-    instancetype.kubevirt.io/displayName: General Purpose
+    instancetype.kubevirt.io/version: "1"
   labels:
-    instancetype.kubevirt.io/class: general.purpose
     instancetype.kubevirt.io/cpu: "1"
-    instancetype.kubevirt.io/icon-pf: pficon-server-group
     instancetype.kubevirt.io/memory: 2Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/version: "1"
-    instancetype.kubevirt.io/common-instancetypes-version: v0.4.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.5
   name: u1.small
 spec:
   cpu:
@@ -1217,6 +996,7 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
+    instancetype.kubevirt.io/class: General Purpose
     instancetype.kubevirt.io/description: |-
       The U Series is quite neutral and provides resources for
       general purpose applications.
@@ -1226,15 +1006,12 @@ metadata:
 
       VMs of instance types will share physical CPU cores on a
       time-slice basis with other VMs.
-    instancetype.kubevirt.io/displayName: General Purpose
+    instancetype.kubevirt.io/version: "1"
   labels:
-    instancetype.kubevirt.io/class: general.purpose
     instancetype.kubevirt.io/cpu: "4"
-    instancetype.kubevirt.io/icon-pf: pficon-server-group
     instancetype.kubevirt.io/memory: 16Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/version: "1"
-    instancetype.kubevirt.io/common-instancetypes-version: v0.4.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.5
   name: u1.xlarge
 spec:
   cpu:

--- a/data/common-instancetypes-bundle/common-clusterpreferences-bundle.yaml
+++ b/data/common-instancetypes-bundle/common-clusterpreferences-bundle.yaml
@@ -12,7 +12,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.4.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.5
   name: alpine
 spec:
   devices:
@@ -37,7 +37,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.4.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.5
   name: centos.7
 spec:
   devices:
@@ -62,7 +62,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.4.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.5
   name: centos.7.desktop
 spec:
   devices:
@@ -90,7 +90,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.4.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.5
   name: centos.stream8
 spec:
   devices:
@@ -115,7 +115,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.4.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.5
   name: centos.stream8.desktop
 spec:
   devices:
@@ -135,34 +135,6 @@ kind: VirtualMachineClusterPreference
 metadata:
   annotations:
     iconClass: icon-centos
-    openshift.io/display-name: CentOS Stream 8
-    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
-    openshift.io/provider-display-name: KubeVirt
-    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
-    tags: hidden,kubevirt,linux,centos-stream,dpdk
-  labels:
-    instancetype.kubevirt.io/os-type: linux
-    instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.4.0
-  name: centos.stream8.dpdk
-spec:
-  cpu:
-    preferredCPUTopology: preferSpread
-  devices:
-    preferredDiskBus: virtio
-    preferredInterfaceModel: virtio
-    preferredNetworkInterfaceMultiQueue: true
-  requirements:
-    cpu:
-      guest: 1
-    memory:
-      guest: 1.5Gi
----
-apiVersion: instancetype.kubevirt.io/v1beta1
-kind: VirtualMachineClusterPreference
-metadata:
-  annotations:
-    iconClass: icon-centos
     openshift.io/display-name: CentOS Stream 9
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
@@ -171,7 +143,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.4.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.5
   name: centos.stream9
 spec:
   devices:
@@ -198,7 +170,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.4.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.5
   name: centos.stream9.desktop
 spec:
   devices:
@@ -219,36 +191,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterPreference
 metadata:
   annotations:
-    iconClass: icon-centos
-    openshift.io/display-name: CentOS Stream 9
-    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
-    openshift.io/provider-display-name: KubeVirt
-    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
-    tags: hidden,kubevirt,linux,centos-stream,dpdk
-  labels:
-    instancetype.kubevirt.io/os-type: linux
-    instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.4.0
-  name: centos.stream9.dpdk
-spec:
-  cpu:
-    preferredCPUTopology: preferSpread
-  devices:
-    preferredDiskBus: virtio
-    preferredDiskDedicatedIoThread: true
-    preferredInterfaceModel: virtio
-    preferredNetworkInterfaceMultiQueue: true
-    preferredRng: {}
-  requirements:
-    cpu:
-      guest: 1
-    memory:
-      guest: 1.5Gi
----
-apiVersion: instancetype.kubevirt.io/v1beta1
-kind: VirtualMachineClusterPreference
-metadata:
-  annotations:
     iconClass: icon-cirros
     openshift.io/display-name: Cirros
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
@@ -258,7 +200,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.4.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.5
   name: cirros
 spec:
   devices:
@@ -283,7 +225,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.4.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.5
   name: fedora
 spec:
   devices:
@@ -315,7 +257,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.4.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.5
   name: rhel.7
 spec:
   devices:
@@ -340,7 +282,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.4.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.5
   name: rhel.7.desktop
 spec:
   devices:
@@ -368,7 +310,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.4.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.5
   name: rhel.8
 spec:
   devices:
@@ -393,7 +335,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.4.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.5
   name: rhel.8.desktop
 spec:
   devices:
@@ -413,34 +355,6 @@ kind: VirtualMachineClusterPreference
 metadata:
   annotations:
     iconClass: icon-rhel
-    openshift.io/display-name: Red Hat Enterprise Linux 8
-    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
-    openshift.io/provider-display-name: KubeVirt
-    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
-    tags: hidden,kubevirt,linux,rhel,dpdk
-  labels:
-    instancetype.kubevirt.io/os-type: linux
-    instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.4.0
-  name: rhel.8.dpdk
-spec:
-  cpu:
-    preferredCPUTopology: preferSpread
-  devices:
-    preferredDiskBus: virtio
-    preferredInterfaceModel: virtio
-    preferredNetworkInterfaceMultiQueue: true
-  requirements:
-    cpu:
-      guest: 1
-    memory:
-      guest: 1.5Gi
----
-apiVersion: instancetype.kubevirt.io/v1beta1
-kind: VirtualMachineClusterPreference
-metadata:
-  annotations:
-    iconClass: icon-rhel
     openshift.io/display-name: Red Hat Enterprise Linux 9
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
@@ -449,7 +363,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.4.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.5
   name: rhel.9
 spec:
   devices:
@@ -481,7 +395,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.4.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.5
   name: rhel.9.desktop
 spec:
   devices:
@@ -507,41 +421,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterPreference
 metadata:
   annotations:
-    iconClass: icon-rhel
-    openshift.io/display-name: Red Hat Enterprise Linux 9
-    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
-    openshift.io/provider-display-name: KubeVirt
-    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
-    tags: hidden,kubevirt,linux,rhel,dpdk
-  labels:
-    instancetype.kubevirt.io/os-type: linux
-    instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.4.0
-  name: rhel.9.dpdk
-spec:
-  cpu:
-    preferredCPUTopology: preferSpread
-  devices:
-    preferredDiskBus: virtio
-    preferredDiskDedicatedIoThread: true
-    preferredInterfaceModel: virtio
-    preferredNetworkInterfaceMultiQueue: true
-    preferredRng: {}
-  features:
-    preferredSmm: {}
-  firmware:
-    preferredUseEfi: true
-    preferredUseSecureBoot: true
-  requirements:
-    cpu:
-      guest: 1
-    memory:
-      guest: 1.5Gi
----
-apiVersion: instancetype.kubevirt.io/v1beta1
-kind: VirtualMachineClusterPreference
-metadata:
-  annotations:
     iconClass: icon-ubuntu
     openshift.io/display-name: Ubuntu
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
@@ -551,7 +430,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.4.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.5
   name: ubuntu
 spec:
   devices:
@@ -577,7 +456,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.4.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.5
   name: windows.10
 spec:
   clock:
@@ -635,7 +514,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.4.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.5
   name: windows.10.virtio
 spec:
   clock:
@@ -687,7 +566,7 @@ kind: VirtualMachineClusterPreference
 metadata:
   annotations:
     iconClass: icon-windows
-    openshift.io/display-name: Microsoft Windows 11
+    openshift.io/display-name: Microsoft Windows 11 (virtio)
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
@@ -695,7 +574,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.4.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.5
   name: windows.11
 spec:
   clock:
@@ -750,7 +629,7 @@ kind: VirtualMachineClusterPreference
 metadata:
   annotations:
     iconClass: icon-windows
-    openshift.io/display-name: Microsoft Windows 11 (virtio)
+    openshift.io/display-name: Microsoft Windows 11
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
@@ -758,7 +637,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.4.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.5
   name: windows.11.virtio
 spec:
   clock:
@@ -821,10 +700,9 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,windows
   labels:
-    instancetype.kubevirt.io/deprecated: "true"
     instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.4.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.5
   name: windows.2k12
 spec:
   clock:
@@ -880,10 +758,9 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,windows
   labels:
-    instancetype.kubevirt.io/deprecated: "true"
     instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.4.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.5
   name: windows.2k12.virtio
 spec:
   clock:
@@ -943,7 +820,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.4.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.5
   name: windows.2k16
 spec:
   clock:
@@ -1001,7 +878,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.4.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.5
   name: windows.2k16.virtio
 spec:
   clock:
@@ -1053,7 +930,7 @@ kind: VirtualMachineClusterPreference
 metadata:
   annotations:
     iconClass: icon-windows
-    openshift.io/display-name: Microsoft Windows Server 2019
+    openshift.io/display-name: Microsoft Windows Server 2019 (virtio)
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
@@ -1061,7 +938,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.4.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.5
   name: windows.2k19
 spec:
   clock:
@@ -1111,7 +988,7 @@ kind: VirtualMachineClusterPreference
 metadata:
   annotations:
     iconClass: icon-windows
-    openshift.io/display-name: Microsoft Windows Server 2019 (virtio)
+    openshift.io/display-name: Microsoft Windows Server 2019
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
@@ -1119,7 +996,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.4.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.5
   name: windows.2k19.virtio
 spec:
   clock:
@@ -1179,7 +1056,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.4.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.5
   name: windows.2k22
 spec:
   clock:
@@ -1242,7 +1119,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
-    instancetype.kubevirt.io/common-instancetypes-version: v0.4.0
+    instancetype.kubevirt.io/common-instancetypes-version: v0.3.5
   name: windows.2k22.virtio
 spec:
   clock:


### PR DESCRIPTION
common-instancetypes: Update bundle to v0.3.5

https://github.com/kubevirt/common-instancetypes/releases/tag/v0.3.5

**Release note**:
```release-note
Update common-instancetypes bundle to v0.3.5
```
