### PR TITLE
chore: Update vm-console-proxy to v0.5.0

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -438,3 +438,9 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - token.kubevirt.io
+  resources:
+  - virtualmachines/vnc
+  verbs:
+  - get

--- a/data/olm-catalog/ssp-operator.clusterserviceversion.yaml
+++ b/data/olm-catalog/ssp-operator.clusterserviceversion.yaml
@@ -496,6 +496,12 @@ spec:
           - patch
           - update
           - watch
+        - apiGroups:
+          - token.kubevirt.io
+          resources:
+          - virtualmachines/vnc
+          verbs:
+          - get
         serviceAccountName: ssp-operator
       deployments:
       - label:

--- a/data/vm-console-proxy-bundle/vm-console-proxy.yaml
+++ b/data/vm-console-proxy-bundle/vm-console-proxy.yaml
@@ -9,16 +9,20 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: vm-console-proxy
+  name: token.kubevirt.io:generate
 rules:
 - apiGroups:
-  - ""
+  - token.kubevirt.io
   resources:
-  - pods
+  - virtualmachines/vnc
   verbs:
   - get
-  - list
-  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: vm-console-proxy
+rules:
 - apiGroups:
   - kubevirt.io
   resources:
@@ -152,7 +156,7 @@ spec:
       - args: []
         command:
         - /console
-        image: quay.io/kubevirt/vm-console-proxy:v0.4.0
+        image: quay.io/kubevirt/vm-console-proxy:v0.5.0
         imagePullPolicy: Always
         name: console
         ports:

--- a/internal/operands/vm-console-proxy/defaults.go
+++ b/internal/operands/vm-console-proxy/defaults.go
@@ -3,6 +3,6 @@ package vm_console_proxy
 // This file is updated by GitHub action defined in .github/workflows/release-vm-console-proxy.yaml
 
 const (
-	defaultVmConsoleProxyImageTag = "v0.4.0"
+	defaultVmConsoleProxyImageTag = "v0.5.0"
 	defaultVmConsoleProxyImage    = "quay.io/kubevirt/vm-console-proxy:" + defaultVmConsoleProxyImageTag
 )

--- a/internal/vm-console-proxy-bundle/bundle-test.yaml
+++ b/internal/vm-console-proxy-bundle/bundle-test.yaml
@@ -9,16 +9,20 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: vm-console-proxy
+  name: token.kubevirt.io:generate
 rules:
 - apiGroups:
-  - ""
+  - token.kubevirt.io
   resources:
-  - pods
+  - virtualmachines/vnc
   verbs:
   - get
-  - list
-  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: vm-console-proxy
+rules:
 - apiGroups:
   - kubevirt.io
   resources:
@@ -152,7 +156,7 @@ spec:
       - args: []
         command:
         - /console
-        image: quay.io/kubevirt/vm-console-proxy:v0.3.1
+        image: quay.io/kubevirt/vm-console-proxy:v0.5.0
         imagePullPolicy: Always
         name: console
         ports:

--- a/internal/vm-console-proxy-bundle/bundle_test.go
+++ b/internal/vm-console-proxy-bundle/bundle_test.go
@@ -17,7 +17,7 @@ var _ = Describe("VM Console Proxy Bundle", func() {
 		bundle, err := ReadBundle("bundle-test.yaml")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(bundle.ServiceAccount).ToNot(BeNil(), "service account should not be nil")
-		Expect(bundle.ClusterRole).ToNot(BeNil(), "cluster role should not be nil")
+		Expect(bundle.ClusterRoles).ToNot(BeEmpty(), "cluster role should not be nil")
 		Expect(bundle.ClusterRoleBinding).ToNot(BeNil(), "cluster role binding should not be nil")
 		Expect(bundle.RoleBinding).ToNot(BeNil(), "role binding should not be nil")
 		Expect(bundle.Service).ToNot(BeNil(), "service should not be nil")


### PR DESCRIPTION
**What this PR does / why we need it**:
Updated `vm-console-proxy` to version `v0.5.0`, and changed code to support multiple `ClusterRoles`.

**Release note**:
```release-note
Updated vm-console-proxy to version v0.5.0.
```
