### PR TITLE
bump-common-instancetypes.sh: Allow RC releases to be sync'd

### DIFF
--- a/hack/bump-common-instancetypes.sh
+++ b/hack/bump-common-instancetypes.sh
@@ -23,13 +23,8 @@ _cluster_instancetypes_path="data/common-instancetypes-bundle/common-clusterinst
 _cluster_preferences_path="data/common-instancetypes-bundle/common-clusterpreferences-bundle.yaml"
 
 function latest_version() {
-    if [[ $target_branch == "main" ]]; then
-        curl --fail -s "https://api.github.com/repos/kubevirt/common-instancetypes/releases/latest" |
-            jq -r '.tag_name'
-    else
-        curl --fail -s https://api.github.com/repos/kubevirt/common-instancetypes/releases?per_page=100 |
-            jq -r '.[] | select(.target_commitish == '\""${target_branch}"\"') | .tag_name' | head -n1
-    fi
+    curl --fail -s https://api.github.com/repos/kubevirt/common-instancetypes/releases?per_page=100 |
+        jq -r '.[] | select(.target_commitish == '\""${target_branch}"\"') | .tag_name' | head -n1
 }
 
 function checksum() {


### PR DESCRIPTION
/cc @0xFelix 

**What this PR does / why we need it**:

The releases/latest GitHub API doesn't include pre-releases however we'd like to sync these to the main branch of kubevirt/ssp-operator for testing ahead of GA.

**Which issue(s) this PR fixes**: 
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
