### PR TITLE
[release-v0.18] CI: Fix kubevirt and CDI versions for this branch

### DIFF
--- a/automation/common/versions.sh
+++ b/automation/common/versions.sh
@@ -53,13 +53,11 @@ function latest_version() {
     tail -n1
 }
 
-# Latest released Kubevirt version
-# KUBEVIRT_VERSION=$(latest_version "kubevirt" "kubevirt")
-# FIXME(lyarwood) Replace with above once v1.0.0 is released
-KUBEVIRT_VERSION=v1.0.0-rc.0
+# Fix kubevirt version to v1.0.x
+KUBEVIRT_VERSION=$(latest_patch_version "kubevirt" "v1.0")
 
-# Latest released CDI version
-CDI_VERSION=$(latest_version "kubevirt" "containerized-data-importer")
+# Fix CDI version to v.1.57.x
+CDI_VERSION=$(latest_patch_version "containerized-data-importer" "v1.57")
 
 # Latest released Tekton version
 TEKTON_VERSION=$(latest_version "tektoncd" "operator")


### PR DESCRIPTION
**What this PR does / why we need it**:
The SSP version in this branch should work with kubevirt `v1.0.x` and CDI `v1.57.x`.

**Release note**:
```release-note
None
```
