### PR TITLE
docs: Remove invalid documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ Operator that deploying and controlling additional [KubeVirt](https://kubevirt.i
 - [Common Instancetypes and Preferences Bundle](https://github.com/kubevirt/common-instancetypes/)
 - [Common Templates Bundle](https://github.com/kubevirt/common-templates)
 - [VM Console Proxy](https://github.com/kubevirt/vm-console-proxy)
-- [KubeVirt Tekton Tasks](https://github.com/kubevirt/kubevirt-tekton-tasks)
 - [Template Validator](https://github.com/kubevirt/ssp-operator/tree/main/internal/template-validator)
 - Metrics Rules (Currently there is just a single Prometheus rule that counts the number of running Virtual Machines.)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,8 +10,6 @@ that defines the desired state of SSP.
 - [Annotations](#annotations)
 - [Common Templates](#common-templates)
 - [Template Validator](#template-validator)
-- [Tekton Pipelines](#tekton-pipelines)
-- [Tekton Tasks](#tekton-tasks)
 - [Feature Gates](#feature-gates)
 
 ## SSP Custom Resource (CR)
@@ -29,28 +27,10 @@ spec:
   templateValidator:
     replicas: 2
   featureGates:
-    deployTektonTaskResources: true
     deployVmConsoleProxy: true
-  tektonPipelines:
-    namespace: kubevirt
-  tektonTasks:
-    namespace: kubevirt
 ```
 
 ## Annotations
-
-### VM Console Proxy
-
-This annotation is used by VM console proxy operand.
-
-```
-apiVersion: ssp.kubevirt.io/v1beta1
-kind: SSP
-metadata:
-  name: ssp-sample
-  namespace: kubevirt
-spec: {}
-```
 
 ### Pause Operator
 
@@ -101,36 +81,6 @@ spec:
     replicas: 2 # Customize the number of replicas for the validator deployment
 ```
 
-## Tekton Pipelines
-
-Specify the deployment namespace for Tekton Pipelines.
-
-```
-apiVersion: ssp.kubevirt.io/v1beta2
-kind: SSP
-metadata:
-  name: ssp-sample
-  namespace: kubevirt
-spec:
-  tektonPipelines:
-    namespace: kubevirt
-```
-
-## Tekton Tasks
-
-Specify the deployment namespace for Tekton Tasks.
-
-```
-apiVersion: ssp.kubevirt.io/v1beta2
-kind: SSP
-metadata:
-  name: ssp-sample
-  namespace: kubevirt
-spec:
-  tektonTasks:
-    namespace: kubevirt
-```
-
 ## Feature Gates
 
 The `featureGates` field is an optional set of optional boolean feature enabler.
@@ -138,25 +88,6 @@ The features in the list are experimental features that are not enabled by defau
 
 To enable a feature, add its name to the `featureGates` list and set it to true.
 Missing or false feature gates disables the feature.
-
-### `deployTektonTaskResources`
-
-Set the `deployTektonTaskResources` feature gate to true to allow the operator
-to deploy Tekton resources.
-
-Example pipelines and tasks will be deployed, enabling Tekton to work with
-Virtual Machines (VMs), disks, and common templates.
-
-```
-apiVersion: ssp.kubevirt.io/v1beta2
-kind: SSP
-metadata:
-  name: ssp-sample
-  namespace: kubevirt
-spec:
-  featureGates:
-    deployTektonTaskResources: true
-```
 
 ### `deployVmConsoleProxy`
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -142,10 +142,14 @@ Installs prometheus monitoring rules for `ssp-operator` metrics. The available
 metrics can be found in `docs/metrics.md`. The installed rules can be found in
 `internal/operands/metrics/resources.go`.
 
+#### `tekton-cleanup`
+
+Sets a deprecation annotation on old tekton resources created by a previous version of this operator.
+
 #### `template-validator`
 
 The main `template-validator` runs in at least one separate container than the
-`ssp-operator`. Is is built with `validator.Dockerfile`.
+`ssp-operator`. It is built with `validator.Dockerfile`.
 
 This operand deploys the `template-validator` found in
 `internal/template-validator` and installs an admission webhook, so the
@@ -160,21 +164,6 @@ for more docs.
 Installs the VM console proxy found in `data/vm-console-proxy-bundle`.
 A pull request (PR) for updating the bundle is automatically created when a new version
 of the [vm-console-proxy](https://github.com/kubevirt/vm-console-proxy) is released.
-
-#### `tekton-pipelines`
-
-Installs the Tekton Pipelines found in `data/tekton-pipelines`.
-
-Pipelines eliminate the need for manual updates when new tasks are added.
-They simply refer to tasks by their names. So, pipelines only require changes if a task's
-name is modified or if there are functional adjustments, but otherwise,
-they don't need to be updated.
-
-#### `tekton-tasks`
-
-Installs the Tekton Tasks found in `data/tekton-tasks`.
-A pull request (PR) for updating the bundle is automatically created when a new version
-of the [kubevirt-tekton-tasks](https://github.com/kubevirt/kubevirt-tekton-tasks) is released.
 
 ## Golang CI Linter
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -26,8 +26,6 @@ for successful deployment across different Kubernetes distributions.
 | `template.openshift.io/v1`                                              | `common-templates` operand (Kind `Template`)                              |
 | `virtualmachineclusterinstancetypes.instancetypes.kubevirt.io/v1beta1`  | `common-instancetypes` operand (Kind `VirtualMachineClusterInstancetype`) |
 | `virtualmachineclusterpreferences.instancetypes.kubevirt.io/v1beta1`    | `common-instancetypes` operand (Kind `VirtualMachineClusterPreference`)   |
-| `pipelines.tekton.dev`                                                  | `tekton-pipelines` operand (Kind `Pipeline`)                              |
-| `tasks.tekton.dev`                                                      | `tekton-tasks` operand (Kind `Task`)                                      |
 | `virtualMachine.kubevirt.io`                                            | `vm-controller` operand (Kind `VirtualMachine`)                           |
 
 ### Kubernetes
@@ -36,8 +34,6 @@ for successful deployment across different Kubernetes distributions.
 | ------------------------------------------------------------------------| --------------------------------------------------------------------------|
 | `virtualmachineclusterinstancetypes.instancetypes.kubevirt.io/v1beta1`  | `common-instancetypes` operand (Kind `VirtualMachineClusterInstancetype`) |
 | `virtualmachineclusterpreferences.instancetypes.kubevirt.io/v1beta1`    | `common-instancetypes` operand (Kind `VirtualMachineClusterPreference`)   |
-| `pipelines.tekton.dev`                                                  | `tekton-pipelines` operand (Kind `Pipeline`)                              |
-| `tasks.tekton.dev`                                                      | `tekton-tasks` operand (Kind `Task`)                                      |
 | `virtualMachine.kubevirt.io`                                            | `vm-controller` operand (Kind `VirtualMachine`)                           |
 
 ## Hyperconverged Cluster Operator (HCO) Installation


### PR DESCRIPTION
**What this PR does / why we need it**:
Removed invalid sections in documentation:
- Parts related to tekton.
- Mention of VM proxy annotation.

**Release note**:
```release-note
Removed invalid sections from documentation.
```
