### PR TITLE
cleanup: Remove unused tekton and virtioImage code

### DIFF
--- a/config/manager/manager.template.yaml
+++ b/config/manager/manager.template.yaml
@@ -33,7 +33,6 @@ spec:
         env:
           - name: VALIDATOR_IMAGE
             value: "$VALIDATOR_IMG"
-          - name: VIRTIO_IMG
           - name: OPERATOR_VERSION
           - name: VM_CONSOLE_PROXY_IMAGE
         image: controller:latest

--- a/config/manager/manager.template.yaml
+++ b/config/manager/manager.template.yaml
@@ -35,8 +35,6 @@ spec:
             value: "$VALIDATOR_IMG"
           - name: VIRTIO_IMG
           - name: OPERATOR_VERSION
-          - name: TEKTON_TASKS_IMAGE
-          - name: TEKTON_TASKS_DISK_VIRT_IMAGE
           - name: VM_CONSOLE_PROXY_IMAGE
         image: controller:latest
         name: manager

--- a/config/samples/ssp_v1beta2_ssp.yaml
+++ b/config/samples/ssp_v1beta2_ssp.yaml
@@ -9,9 +9,4 @@ spec:
   templateValidator:
     replicas: 2
   featureGates:
-    deployTektonTaskResources: true
     deployVmConsoleProxy: true
-  tektonPipelines:
-    namespace: kubevirt
-  tektonTasks:
-    namespace: kubevirt

--- a/data/olm-catalog/ssp-operator.clusterserviceversion.yaml
+++ b/data/olm-catalog/ssp-operator.clusterserviceversion.yaml
@@ -17,14 +17,7 @@ metadata:
               "namespace": "kubevirt"
             },
             "featureGates": {
-              "deployTektonTaskResources": true,
               "deployVmConsoleProxy": true
-            },
-            "tektonPipelines": {
-              "namespace": "kubevirt"
-            },
-            "tektonTasks": {
-              "namespace": "kubevirt"
             },
             "templateValidator": {
               "replicas": 2
@@ -518,8 +511,6 @@ spec:
                 - name: VIRTIO_IMG
                 - name: OPERATOR_VERSION
                   value: 0.14.0
-                - name: TEKTON_TASKS_IMAGE
-                - name: TEKTON_TASKS_DISK_VIRT_IMAGE
                 - name: VM_CONSOLE_PROXY_IMAGE
                 image: quay.io/kubevirt/ssp-operator:latest
                 livenessProbe:

--- a/data/olm-catalog/ssp-operator.clusterserviceversion.yaml
+++ b/data/olm-catalog/ssp-operator.clusterserviceversion.yaml
@@ -508,7 +508,6 @@ spec:
                 env:
                 - name: VALIDATOR_IMAGE
                   value: quay.io/kubevirt/kubevirt-template-validator:latest
-                - name: VIRTIO_IMG
                 - name: OPERATOR_VERSION
                   value: 0.14.0
                 - name: VM_CONSOLE_PROXY_IMAGE

--- a/hack/csv-generator.go
+++ b/hack/csv-generator.go
@@ -36,19 +36,17 @@ import (
 )
 
 type generatorFlags struct {
-	file                     string
-	dumpCRDs                 bool
-	removeCerts              bool
-	webhookPort              int32
-	csvVersion               string
-	namespace                string
-	operatorImage            string
-	operatorVersion          string
-	validatorImage           string
-	tektonTasksImage         string
-	tektonTasksDiskVirtImage string
-	virtioImage              string
-	vmConsoleProxyImage      string
+	file                string
+	dumpCRDs            bool
+	removeCerts         bool
+	webhookPort         int32
+	csvVersion          string
+	namespace           string
+	operatorImage       string
+	operatorVersion     string
+	validatorImage      string
+	virtioImage         string
+	vmConsoleProxyImage string
 }
 
 var (
@@ -81,8 +79,6 @@ func init() {
 	rootCmd.Flags().StringVar(&f.operatorImage, "operator-image", "", "Link to operator image (required)")
 	rootCmd.Flags().StringVar(&f.operatorVersion, "operator-version", "", "Operator version (required)")
 	rootCmd.Flags().StringVar(&f.validatorImage, "validator-image", "", "Link to template-validator image")
-	rootCmd.Flags().StringVar(&f.tektonTasksImage, "tekton-tasks-image", "", "Link to tekton tasks image")
-	rootCmd.Flags().StringVar(&f.tektonTasksDiskVirtImage, "tekton-tasks-disk-virt-image", "", "Link to tekton tasks disk virt image")
 	rootCmd.Flags().StringVar(&f.virtioImage, "virtio-image", "", "Link to virtio image")
 	rootCmd.Flags().StringVar(&f.vmConsoleProxyImage, "vm-console-proxy-image", "", "Link to VM console proxy image")
 	rootCmd.Flags().Int32Var(&f.webhookPort, "webhook-port", 0, "Container port for the admission webhook")
@@ -194,22 +190,6 @@ func buildRelatedImages(flags generatorFlags) ([]interface{}, error) {
 		relatedImages = append(relatedImages, relatedImage)
 	}
 
-	if flags.tektonTasksImage != "" {
-		relatedImage, err := buildRelatedImage(flags.tektonTasksImage, "tekton-tasks")
-		if err != nil {
-			return nil, err
-		}
-		relatedImages = append(relatedImages, relatedImage)
-	}
-
-	if flags.tektonTasksDiskVirtImage != "" {
-		relatedImage, err := buildRelatedImage(flags.tektonTasksDiskVirtImage, "tekton-tasks-disk-virt")
-		if err != nil {
-			return nil, err
-		}
-		relatedImages = append(relatedImages, relatedImage)
-	}
-
 	if flags.virtioImage != "" {
 		relatedImage, err := buildRelatedImage(flags.virtioImage, "virtio-container")
 		if err != nil {
@@ -268,14 +248,6 @@ func updateContainerEnvVars(flags generatorFlags, container v1.Container) []v1.E
 		case common.OperatorVersionKey:
 			if flags.operatorVersion != "" {
 				envVariable.Value = flags.operatorVersion
-			}
-		case common.TektonTasksImageKey:
-			if flags.tektonTasksImage != "" {
-				envVariable.Value = flags.tektonTasksImage
-			}
-		case common.TektonTasksDiskVirtImageKey:
-			if flags.tektonTasksDiskVirtImage != "" {
-				envVariable.Value = flags.tektonTasksDiskVirtImage
 			}
 		case common.VirtioImageKey:
 			if flags.virtioImage != "" {

--- a/hack/csv-generator.go
+++ b/hack/csv-generator.go
@@ -45,7 +45,6 @@ type generatorFlags struct {
 	operatorImage       string
 	operatorVersion     string
 	validatorImage      string
-	virtioImage         string
 	vmConsoleProxyImage string
 }
 
@@ -79,7 +78,6 @@ func init() {
 	rootCmd.Flags().StringVar(&f.operatorImage, "operator-image", "", "Link to operator image (required)")
 	rootCmd.Flags().StringVar(&f.operatorVersion, "operator-version", "", "Operator version (required)")
 	rootCmd.Flags().StringVar(&f.validatorImage, "validator-image", "", "Link to template-validator image")
-	rootCmd.Flags().StringVar(&f.virtioImage, "virtio-image", "", "Link to virtio image")
 	rootCmd.Flags().StringVar(&f.vmConsoleProxyImage, "vm-console-proxy-image", "", "Link to VM console proxy image")
 	rootCmd.Flags().Int32Var(&f.webhookPort, "webhook-port", 0, "Container port for the admission webhook")
 	rootCmd.Flags().BoolVar(&f.removeCerts, "webhook-remove-certs", false, "Remove the webhook certificate volume and mount")
@@ -190,14 +188,6 @@ func buildRelatedImages(flags generatorFlags) ([]interface{}, error) {
 		relatedImages = append(relatedImages, relatedImage)
 	}
 
-	if flags.virtioImage != "" {
-		relatedImage, err := buildRelatedImage(flags.virtioImage, "virtio-container")
-		if err != nil {
-			return nil, err
-		}
-		relatedImages = append(relatedImages, relatedImage)
-	}
-
 	if flags.vmConsoleProxyImage != "" {
 		relatedImage, err := buildRelatedImage(flags.vmConsoleProxyImage, "vm-console-proxy")
 		if err != nil {
@@ -248,10 +238,6 @@ func updateContainerEnvVars(flags generatorFlags, container v1.Container) []v1.E
 		case common.OperatorVersionKey:
 			if flags.operatorVersion != "" {
 				envVariable.Value = flags.operatorVersion
-			}
-		case common.VirtioImageKey:
-			if flags.virtioImage != "" {
-				envVariable.Value = flags.virtioImage
 			}
 		case common.VmConsoleProxyImageKey:
 			if flags.vmConsoleProxyImage != "" {

--- a/hack/csv-generator_test.go
+++ b/hack/csv-generator_test.go
@@ -24,13 +24,11 @@ var _ = Describe("csv generator", func() {
 
 		operatorImage:       "test",
 		validatorImage:      "test",
-		virtioImage:         "testVirtioImage",
 		vmConsoleProxyImage: "testVmConsoleProxyImage",
 	}
 	envValues := []v1.EnvVar{
 		{Name: common.TemplateValidatorImageKey},
 		{Name: common.OperatorVersionKey},
-		{Name: common.VirtioImageKey},
 	}
 
 	csv := csvv1.ClusterServiceVersion{
@@ -77,9 +75,6 @@ var _ = Describe("csv generator", func() {
 					}
 					if envVariable.Name == common.OperatorVersionKey {
 						Expect(envVariable.Value).To(Equal(flags.operatorVersion))
-					}
-					if envVariable.Name == common.VirtioImageKey {
-						Expect(envVariable.Value).To(Equal(flags.virtioImage))
 					}
 					if envVariable.Name == common.VmConsoleProxyImageKey {
 						Expect(envVariable.Value).To(Equal(flags.vmConsoleProxyImage))

--- a/hack/csv-generator_test.go
+++ b/hack/csv-generator_test.go
@@ -22,18 +22,14 @@ var _ = Describe("csv generator", func() {
 		namespace:       "testOperatorNamespace",
 		operatorVersion: "testOperatorVersion",
 
-		operatorImage:            "test",
-		validatorImage:           "test",
-		tektonTasksImage:         "testTektonTasksImage",
-		tektonTasksDiskVirtImage: "testTektonTasksDiskVirtImage",
-		virtioImage:              "testVirtioImage",
-		vmConsoleProxyImage:      "testVmConsoleProxyImage",
+		operatorImage:       "test",
+		validatorImage:      "test",
+		virtioImage:         "testVirtioImage",
+		vmConsoleProxyImage: "testVmConsoleProxyImage",
 	}
 	envValues := []v1.EnvVar{
 		{Name: common.TemplateValidatorImageKey},
 		{Name: common.OperatorVersionKey},
-		{Name: common.TektonTasksImageKey},
-		{Name: common.TektonTasksDiskVirtImageKey},
 		{Name: common.VirtioImageKey},
 	}
 
@@ -81,12 +77,6 @@ var _ = Describe("csv generator", func() {
 					}
 					if envVariable.Name == common.OperatorVersionKey {
 						Expect(envVariable.Value).To(Equal(flags.operatorVersion))
-					}
-					if envVariable.Name == common.TektonTasksImageKey {
-						Expect(envVariable.Value).To(Equal(flags.tektonTasksImage))
-					}
-					if envVariable.Name == common.TektonTasksDiskVirtImageKey {
-						Expect(envVariable.Value).To(Equal(flags.tektonTasksDiskVirtImage))
 					}
 					if envVariable.Name == common.VirtioImageKey {
 						Expect(envVariable.Value).To(Equal(flags.virtioImage))

--- a/internal/common/environment.go
+++ b/internal/common/environment.go
@@ -18,29 +18,15 @@ import (
 )
 
 const (
-	OperatorVersionKey          = "OPERATOR_VERSION"
-	TemplateValidatorImageKey   = "VALIDATOR_IMAGE"
-	TektonTasksImageKey         = "TEKTON_TASKS_IMAGE"
-	TektonTasksDiskVirtImageKey = "TEKTON_TASKS_DISK_VIRT_IMAGE"
-	VirtioImageKey              = "VIRTIO_IMG"
-	VmConsoleProxyImageKey      = "VM_CONSOLE_PROXY_IMAGE"
+	OperatorVersionKey        = "OPERATOR_VERSION"
+	TemplateValidatorImageKey = "VALIDATOR_IMAGE"
+	VirtioImageKey            = "VIRTIO_IMG"
+	VmConsoleProxyImageKey    = "VM_CONSOLE_PROXY_IMAGE"
 
-	DefaultTektonTasksIMG         = "quay.io/kubevirt/tekton-tasks:" + TektonTasksVersion
-	DeafultTektonTasksDiskVirtIMG = "quay.io/kubevirt/tekton-tasks-disk-virt:" + TektonTasksVersion
-	DefaultVirtioIMG              = "quay.io/kubevirt/virtio-container-disk:v1.2.0"
+	DefaultVirtioIMG = "quay.io/kubevirt/virtio-container-disk:v1.2.0"
 
 	defaultOperatorVersion = "devel"
 )
-
-// GetSSHKeysStatusImage returns generate-ssh-keys task image url
-func GetTektonTasksImage() string {
-	return EnvOrDefault(TektonTasksImageKey, DefaultTektonTasksIMG)
-}
-
-// GetDiskVirtSysprepImage returns disk-virt-sysprep task image url
-func GetTektonTasksDiskVirtImage() string {
-	return EnvOrDefault(TektonTasksDiskVirtImageKey, DeafultTektonTasksDiskVirtIMG)
-}
 
 // GetVirtioImage returns virtio image url
 func GetVirtioImage() string {

--- a/internal/common/environment.go
+++ b/internal/common/environment.go
@@ -20,18 +20,10 @@ import (
 const (
 	OperatorVersionKey        = "OPERATOR_VERSION"
 	TemplateValidatorImageKey = "VALIDATOR_IMAGE"
-	VirtioImageKey            = "VIRTIO_IMG"
 	VmConsoleProxyImageKey    = "VM_CONSOLE_PROXY_IMAGE"
-
-	DefaultVirtioIMG = "quay.io/kubevirt/virtio-container-disk:v1.2.0"
 
 	defaultOperatorVersion = "devel"
 )
-
-// GetVirtioImage returns virtio image url
-func GetVirtioImage() string {
-	return EnvOrDefault(VirtioImageKey, DefaultVirtioIMG)
-}
 
 func EnvOrDefault(envName string, defVal string) string {
 	val := os.Getenv(envName)

--- a/internal/common/environment_test.go
+++ b/internal/common/environment_test.go
@@ -8,8 +8,6 @@ import (
 )
 
 var _ = Describe("environments", func() {
-	testURL := "test:test"
-
 	It("should return correct value for OPERATOR_VERSION when variable is set", func() {
 		os.Setenv(OperatorVersionKey, "v0.0.1")
 		res := GetOperatorVersion()
@@ -21,29 +19,4 @@ var _ = Describe("environments", func() {
 		res := GetOperatorVersion()
 		Expect(res).To(Equal(defaultOperatorVersion), "OPERATOR_VERSION should equal")
 	})
-
-	It("should return correct value for TEKTON_TASKS_IMG when variable is set", func() {
-		os.Setenv(TektonTasksImageKey, testURL)
-		res := GetTektonTasksImage()
-		Expect(res).To(Equal(testURL), "TEKTON_TASKS_IMG should equal")
-		os.Unsetenv(TektonTasksImageKey)
-	})
-
-	It("should return correct value for TEKTON_TASKS_IMG when variable is not set", func() {
-		res := GetTektonTasksImage()
-		Expect(res).To(Equal(DefaultTektonTasksIMG), "TEKTON_TASKS_IMG should equal")
-	})
-
-	It("should return correct value for TEKTON_TASKS_DISK_VIRT_IMG when variable is set", func() {
-		os.Setenv(TektonTasksDiskVirtImageKey, testURL)
-		res := GetTektonTasksDiskVirtImage()
-		Expect(res).To(Equal(testURL), "TEKTON_TASKS_DISK_VIRT_IMG should equal")
-		os.Unsetenv(TektonTasksDiskVirtImageKey)
-	})
-
-	It("should return correct value for TEKTON_TASKS_DISK_VIRT_IMG when variable is not set", func() {
-		res := GetTektonTasksDiskVirtImage()
-		Expect(res).To(Equal(DeafultTektonTasksDiskVirtIMG), "TEKTON_TASKS_DISK_VIRT_IMG should equal")
-	})
-
 })

--- a/internal/common/labels.go
+++ b/internal/common/labels.go
@@ -14,8 +14,7 @@ const (
 	AppKubernetesManagedByLabel = "app.kubernetes.io/managed-by"
 	AppKubernetesComponentLabel = "app.kubernetes.io/component"
 
-	AppKubernetesManagedByValue       string = "ssp-operator"
-	TektonAppKubernetesManagedByValue string = "tekton-tasks-operator"
+	AppKubernetesManagedByValue string = "ssp-operator"
 )
 
 type AppComponent string

--- a/internal/common/resource.go
+++ b/internal/common/resource.go
@@ -8,7 +8,6 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 	libhandler "github.com/operator-framework/operator-lib/handler"
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
-	tekton "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	apps "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
 	rbac "k8s.io/api/rbac/v1"
@@ -490,9 +489,6 @@ func defaultUpdateFunc(newObj, foundObj client.Object) {
 
 	case *promv1.ServiceMonitor:
 		foundObj.(*promv1.ServiceMonitor).Spec = newTyped.Spec
-
-	case *tekton.Task: //nolint:staticcheck
-		foundObj.(*tekton.Task).Spec = newTyped.Spec //nolint:staticcheck
 
 	default:
 		panic(fmt.Sprintf("Default update is not supported for type: %T", newObj))

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -121,15 +121,8 @@ func (s *newSspStrategy) Init() {
 			CommonTemplates: sspv1beta2.CommonTemplates{
 				Namespace: s.GetTemplatesNamespace(),
 			},
-			TektonPipelines: &sspv1beta2.TektonPipelines{
-				Namespace: s.GetNamespace(),
-			},
-			TektonTasks: &sspv1beta2.TektonTasks{
-				Namespace: s.GetNamespace(),
-			},
 			FeatureGates: &sspv1beta2.FeatureGates{
-				DeployTektonTaskResources: false,
-				DeployVmConsoleProxy:      true,
+				DeployVmConsoleProxy: true,
 			},
 		},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This removes minor usages of tekton from these places:
- CSV generator
- Environment variables used by operator
- SSP CR example
- Default update function for reconcile code
- SSP CR created by functional tests

Removes unused `virtioImage` code.

**Release note**:
```release-note
None
```
