### PR TITLE
Fix common-instancetypes func tests with HCO

### DIFF
--- a/tests/common_instancetypes_test.go
+++ b/tests/common_instancetypes_test.go
@@ -24,7 +24,12 @@ var _ = Describe("Common Instance Types", func() {
 		strategy.RevertToOriginalSspCr()
 	})
 
-	Context("operand", func() {
+	Context("when SSP is not deployed by HCO", func() {
+
+		BeforeEach(func() {
+			strategy.SkipIfDeployedByHCO()
+		})
+
 		It("should reconcile resources from internal bundle by default", func() {
 			virtualMachineClusterInstancetypes, err := common_instancetypes.FetchBundleResource[instancetypev1beta1.VirtualMachineClusterInstancetype]("../" + common_instancetypes.BundleDir + common_instancetypes.ClusterInstancetypesBundle)
 			Expect(err).ToNot(HaveOccurred())

--- a/tests/env/env.go
+++ b/tests/env/env.go
@@ -20,6 +20,7 @@ const (
 	envSspDeploymentName      = "SSP_DEPLOYMENT_NAME"
 	envSspDeploymentNamespace = "SSP_DEPLOYMENT_NAMESPACE"
 	envSspWebhookServiceName  = "SSP_WEBHOOK_SERVICE_NAME"
+	envSkipDeployedByHCO      = "SKIP_SSP_DEPLOYED_BY_HCO"
 )
 
 const (
@@ -45,6 +46,10 @@ func SkipUpdateSspTests() bool {
 
 func ShouldSkipCleanupAfterTests() bool {
 	return getBoolEnv(envSkipCleanupAfterTests)
+}
+
+func IsDeployedByHCO() bool {
+	return getBoolEnv(envSkipDeployedByHCO)
 }
 
 var timeout time.Duration

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -128,6 +128,11 @@ func (s *newSspStrategy) Init() {
 		},
 	}
 
+	// When the original env is deployed by HCO skip common-instancetypes deployment and tests
+	if env.IsDeployedByHCO() {
+		newSsp.Spec.FeatureGates.DeployCommonInstancetypes = ptr.To(false)
+	}
+
 	Eventually(func() error {
 		return apiClient.Create(ctx, newSsp)
 	}, env.Timeout(), time.Second).ShouldNot(HaveOccurred())

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -75,6 +75,7 @@ type TestSuiteStrategy interface {
 	SkipUnlessHighlyAvailableTopologyMode()
 	SkipUnlessSingleReplicaTopologyMode()
 	SkipIfUpgradeLane()
+	SkipIfDeployedByHCO()
 }
 
 type newSspStrategy struct {
@@ -226,6 +227,16 @@ func skipIfUpgradeLane() {
 	}
 }
 
+func (s *newSspStrategy) SkipIfDeployedByHCO() {
+	skipIfDeployedByHCO()
+}
+
+func skipIfDeployedByHCO() {
+	if env.IsDeployedByHCO() {
+		Skip("Skipping as SSP was deployed by HCO", 1)
+	}
+}
+
 type existingSspStrategy struct {
 	Name      string
 	Namespace string
@@ -355,6 +366,10 @@ func (s *existingSspStrategy) SkipUnlessHighlyAvailableTopologyMode() {
 
 func (s *existingSspStrategy) SkipIfUpgradeLane() {
 	skipIfUpgradeLane()
+}
+
+func (s *existingSspStrategy) SkipIfDeployedByHCO() {
+	skipIfDeployedByHCO()
 }
 
 var (

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -76,6 +76,7 @@ type TestSuiteStrategy interface {
 	SkipUnlessSingleReplicaTopologyMode()
 	SkipIfUpgradeLane()
 	SkipIfDeployedByHCO()
+	SkipIfNotDeployedByHCO()
 }
 
 type newSspStrategy struct {
@@ -236,9 +237,19 @@ func (s *newSspStrategy) SkipIfDeployedByHCO() {
 	skipIfDeployedByHCO()
 }
 
+func (s *newSspStrategy) SkipIfNotDeployedByHCO() {
+	skipIfNotDeployedByHCO()
+}
+
 func skipIfDeployedByHCO() {
 	if env.IsDeployedByHCO() {
 		Skip("Skipping as SSP was deployed by HCO", 1)
+	}
+}
+
+func skipIfNotDeployedByHCO() {
+	if !env.IsDeployedByHCO() {
+		Skip("Skipping as SSP was not deployed by HCO", 1)
 	}
 }
 
@@ -375,6 +386,10 @@ func (s *existingSspStrategy) SkipIfUpgradeLane() {
 
 func (s *existingSspStrategy) SkipIfDeployedByHCO() {
 	skipIfDeployedByHCO()
+}
+
+func (s *existingSspStrategy) SkipIfNotDeployedByHCO() {
+	skipIfNotDeployedByHCO()
 }
 
 var (


### PR DESCRIPTION
/cc @0xFelix 

**What this PR does / why we need it**:

The functional tests currently assume that SSP is deployed standalone without HCO. However these same tests are also used downstream in a slightly different context where we initially deploy the environment using HCO. As such the common-instancetypes tests are invalid and need to be skipped. This series adds some limited coverage for this scenario ensuring that SSP ignores the virt-operator deployed resources.

More comprehensive coverage needs to be added to HCO to assert the default behaviour of virt-operator and ssp-operator in environments where HCO is still actively reconciling both.

**Which issue(s) this PR fixes**: 
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
