### PR TITLE
fix: Do not force IPv4 on metrics service

### DIFF
--- a/controllers/services_controller.go
+++ b/controllers/services_controller.go
@@ -29,7 +29,6 @@ const (
 
 func ServiceObject(namespace string, appKubernetesPartOfValue string) *v1.Service {
 	policyCluster := v1.ServiceInternalTrafficPolicyCluster
-	familyPolicy := v1.IPFamilyPolicySingleStack
 	labels := map[string]string{
 		common.AppKubernetesManagedByLabel: ServiceManagedByLabelValue,
 		common.AppKubernetesVersionLabel:   common.GetOperatorVersion(),
@@ -47,8 +46,6 @@ func ServiceObject(namespace string, appKubernetesPartOfValue string) *v1.Servic
 		},
 		Spec: v1.ServiceSpec{
 			InternalTrafficPolicy: &policyCluster,
-			IPFamilies:            []v1.IPFamily{v1.IPv4Protocol},
-			IPFamilyPolicy:        &familyPolicy,
 			Ports: []v1.ServicePort{
 				{
 					Name:       metrics.MetricsPortName,


### PR DESCRIPTION
**What this PR does / why we need it**:
The service that exposes metrics used to force IPv4 protocol. It failed in clusters that have only IPv6.

Fixes: https://issues.redhat.com/browse/CNV-40159

**Release note**:
```release-note
None
```
