### PR TITLE
Add guest OS labels to cnv:vmi_status_running:count

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,7 +1,7 @@
 # SSP Operator metrics
 
 ### cnv:vmi_status_running:count
-The total number of running VMIs by status. Type: Gauge.
+The total number of running VMIs, labeled with node, instance type, preference and guest OS information. Type: Gauge.
 
 ### kubevirt_ssp_common_templates_restored_increase
 The increase in the number of common templates restored by the operator back to their original state, over the last hour. Type: Gauge.

--- a/pkg/monitoring/rules/recordingrules/vmi.go
+++ b/pkg/monitoring/rules/recordingrules/vmi.go
@@ -10,9 +10,10 @@ var vmiRecordingRules = []operatorrules.RecordingRule{
 	{
 		MetricsOpts: operatormetrics.MetricOpts{
 			Name: "cnv:vmi_status_running:count",
-			Help: "The total number of running VMIs by status",
+			Help: "The total number of running VMIs, labeled with node, instance type, preference and guest OS information",
 		},
 		MetricType: operatormetrics.GaugeType,
-		Expr:       intstr.FromString("sum(kubevirt_vmi_phase_count{phase=\"running\"}) by (node,os,workload,flavor,instance_type,preference)"),
+		Expr: intstr.FromString("sum(kubevirt_vmi_phase_count{phase=\"running\"}) by " +
+			"(node,os,workload,flavor,instance_type,preference,guest_os_kernel_release,guest_os_machine,guest_os_name,guest_os_version_id)"),
 	},
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
With https://github.com/kubevirt/kubevirt/pull/11283 we added guest OS labels to `kubevirt_vmi_phase_count` metric.
Now, we are able to use those labels in `cnv:vmi_status_running:count` recording rule.

**Which issue(s) this PR fixes**: 
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

Fixes https://issues.redhat.com/browse/CNV-37369 and required by https://issues.redhat.com/browse/CNV-38482.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add guest OS labels to cnv:vmi_status_running:count recording rule
```
