### PR TITLE
fix: remove tekton resources, if feature gate is set to 'false'

### DIFF
--- a/api/v1beta2/ssp_types.go
+++ b/api/v1beta2/ssp_types.go
@@ -110,8 +110,8 @@ type TektonTasks struct {
 
 // FeatureGates for SSP
 type FeatureGates struct {
-	// +kubebuilder:deprecatedversion:warning="tekton task resources are no longer deployed by SSP"
-	// Deprecated: This field is ignored.
+	// +kubebuilder:deprecatedversion:warning="This feature gate can only be used to remove existing tekton resources by setting it to false"
+	// Deprecated: This feature gate can only be used to remove existing tekton resources by setting it to "false".
 	DeployTektonTaskResources bool `json:"deployTektonTaskResources,omitempty"`
 
 	DeployVmConsoleProxy bool `json:"deployVmConsoleProxy,omitempty"`

--- a/config/crd/bases/ssp.kubevirt.io_ssps.yaml
+++ b/config/crd/bases/ssp.kubevirt.io_ssps.yaml
@@ -4489,7 +4489,8 @@ spec:
                       defaults to true.
                     type: boolean
                   deployTektonTaskResources:
-                    description: 'Deprecated: This field is ignored.'
+                    description: 'Deprecated: This feature gate can only be used to
+                      remove existing tekton resources by setting it to "false".'
                     type: boolean
                   deployVmConsoleProxy:
                     type: boolean

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -132,6 +132,7 @@ rules:
   - configmaps
   verbs:
   - create
+  - delete
   - list
   - update
   - watch
@@ -317,6 +318,7 @@ rules:
   - clusterroles
   - rolebindings
   verbs:
+  - delete
   - list
   - update
   - watch
@@ -393,6 +395,7 @@ rules:
   - pipelines
   verbs:
   - create
+  - delete
   - list
   - update
   - watch
@@ -401,6 +404,7 @@ rules:
   resources:
   - tasks
   verbs:
+  - delete
   - list
   - update
   - watch

--- a/data/crd/ssp.kubevirt.io_ssps.yaml
+++ b/data/crd/ssp.kubevirt.io_ssps.yaml
@@ -4490,7 +4490,8 @@ spec:
                       defaults to true.
                     type: boolean
                   deployTektonTaskResources:
-                    description: 'Deprecated: This field is ignored.'
+                    description: 'Deprecated: This feature gate can only be used to
+                      remove existing tekton resources by setting it to "false".'
                     type: boolean
                   deployVmConsoleProxy:
                     type: boolean

--- a/data/olm-catalog/ssp-operator.clusterserviceversion.yaml
+++ b/data/olm-catalog/ssp-operator.clusterserviceversion.yaml
@@ -183,6 +183,7 @@ spec:
           - configmaps
           verbs:
           - create
+          - delete
           - list
           - update
           - watch
@@ -368,6 +369,7 @@ spec:
           - clusterroles
           - rolebindings
           verbs:
+          - delete
           - list
           - update
           - watch
@@ -444,6 +446,7 @@ spec:
           - pipelines
           verbs:
           - create
+          - delete
           - list
           - update
           - watch
@@ -452,6 +455,7 @@ spec:
           resources:
           - tasks
           verbs:
+          - delete
           - list
           - update
           - watch

--- a/internal/common/resource.go
+++ b/internal/common/resource.go
@@ -55,6 +55,7 @@ type CleanupResult struct {
 }
 
 type ReconcileFunc = func(*Request) (ReconcileResult, error)
+type CleanupFunc = func(*Request) ([]CleanupResult, error)
 
 func CollectResourceStatus(request *Request, funcs ...ReconcileFunc) ([]ReconcileResult, error) {
 	res := make([]ReconcileResult, 0, len(funcs))

--- a/vendor/kubevirt.io/ssp-operator/api/v1beta2/ssp_types.go
+++ b/vendor/kubevirt.io/ssp-operator/api/v1beta2/ssp_types.go
@@ -110,8 +110,8 @@ type TektonTasks struct {
 
 // FeatureGates for SSP
 type FeatureGates struct {
-	// +kubebuilder:deprecatedversion:warning="tekton task resources are no longer deployed by SSP"
-	// Deprecated: This field is ignored.
+	// +kubebuilder:deprecatedversion:warning="This feature gate can only be used to remove existing tekton resources by setting it to false"
+	// Deprecated: This feature gate can only be used to remove existing tekton resources by setting it to "false".
 	DeployTektonTaskResources bool `json:"deployTektonTaskResources,omitempty"`
 
 	DeployVmConsoleProxy bool `json:"deployVmConsoleProxy,omitempty"`


### PR DESCRIPTION


**What this PR does / why we need it**:
Tekton resources are not created by ssp-operator anymore. If a user wants to remove existing old tekton resources, the feature gate can be set to `false`.


**Which issue(s) this PR fixes**: 
Fixes: https://issues.redhat.com/browse/CNV-33012

**Release note**:
```release-note
Feature gate "deployTektonTaskResources" can be set to "false" to remove existing old tekton resources.
```
