### PR TITLE
chore: Temporarily disable dependabot until update to golang 1.22

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,26 +1,27 @@
+# TODO: Enable dependabot when we update to golang 1.22 in downstream.
 version: 2
-updates:
-  - package-ecosystem: "gomod"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    allow:
-      - dependency-type: "all"
-    ignore:
-      # Ginkgo update needs a change in Makefile.
-      - dependency-name: "github.com/onsi/ginkgo/v2"
-    groups:
-      production-dependencies:
-        dependency-type: "production"
-      development-dependencies:
-        dependency-type: "development"
-    open-pull-requests-limit: 3
-    labels:
-      - "release-note-none"
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 3
-    labels:
-      - "release-note-none"
+updates: []
+#  - package-ecosystem: "gomod"
+#    directory: "/"
+#    schedule:
+#      interval: "daily"
+#    allow:
+#      - dependency-type: "all"
+#    ignore:
+#      # Ginkgo update needs a change in Makefile.
+#      - dependency-name: "github.com/onsi/ginkgo/v2"
+#    groups:
+#      production-dependencies:
+#        dependency-type: "production"
+#      development-dependencies:
+#        dependency-type: "development"
+#    open-pull-requests-limit: 3
+#    labels:
+#      - "release-note-none"
+#  - package-ecosystem: "github-actions"
+#    directory: "/"
+#    schedule:
+#      interval: "weekly"
+#    open-pull-requests-limit: 3
+#    labels:
+#      - "release-note-none"


### PR DESCRIPTION
**What this PR does / why we need it**:
The PRs opened by dependabot need golang 1.22, but we cannot update yet, because downstream containers don't work with this version.

**Release note**:
```release-note
None
```
