### PR TITLE
DRAFT - feat: Limit cache to watch only relevant objects

### DIFF
--- a/automation/e2e-upgrade-functests/run.sh
+++ b/automation/e2e-upgrade-functests/run.sh
@@ -35,17 +35,8 @@ oc apply -n $NAMESPACE -f "https://github.com/kubevirt/ssp-operator/releases/dow
 oc wait --for=condition=Available --timeout=600s -n ${NAMESPACE} deployments/ssp-operator
 
 SSP_NAME="ssp-test"
-SSP_NAMESPACE="ssp-operator-functests"
+SSP_NAMESPACE="kubevirt"
 SSP_TEMPLATES_NAMESPACE="ssp-operator-functests-templates"
-
-oc apply -f - <<EOF
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: ${SSP_NAMESPACE}
-  labels:
-    openshift.io/cluster-monitoring: "true"
-EOF
 
 oc apply -f - <<EOF
 apiVersion: v1
@@ -66,7 +57,6 @@ export VALIDATOR_IMG=${CI_VALIDATOR_IMG}
 export IMG=${CI_OPERATOR_IMG}
 export SKIP_CLEANUP_AFTER_TESTS="true"
 export TEST_EXISTING_CR_NAME="${SSP_NAME}"
-export TEST_EXISTING_CR_NAMESPACE="${SSP_NAMESPACE}"
 export IS_UPGRADE_LANE="true"
 
 make deploy functest

--- a/internal/common/labels.go
+++ b/internal/common/labels.go
@@ -8,6 +8,8 @@ import (
 )
 
 const (
+	WatchedObjectLabel = "ssp.kubevirt.io/watched"
+
 	AppKubernetesNameLabel      = "app.kubernetes.io/name"
 	AppKubernetesPartOfLabel    = "app.kubernetes.io/part-of"
 	AppKubernetesVersionLabel   = "app.kubernetes.io/version"

--- a/internal/common/resource_test.go
+++ b/internal/common/resource_test.go
@@ -28,6 +28,8 @@ const (
 	name      = "test-ssp"
 )
 
+// TODO -- add unit tests for the watch label
+
 var _ = Describe("Resource", func() {
 	var (
 		request Request
@@ -339,6 +341,11 @@ func expectEqualResourceExists(resource client.Object, request *Request) {
 	resource.SetGeneration(found.GetGeneration())
 	resource.SetResourceVersion(found.GetResourceVersion())
 	resource.SetOwnerReferences(found.GetOwnerReferences())
+
+	if resource.GetLabels() == nil {
+		resource.SetLabels(map[string]string{})
+	}
+	resource.GetLabels()[WatchedObjectLabel] = "true"
 
 	ExpectWithOffset(1, found).To(Equal(resource))
 }

--- a/internal/controllers/controller.go
+++ b/internal/controllers/controller.go
@@ -23,4 +23,8 @@ type WatchObject struct {
 	// WatchOnlyOperatorNamespace sets if the cache should only watch the object type
 	// in the same namespace where the operator is defined.
 	WatchOnlyOperatorNamespace bool
+
+	// WatchOnlyObjectsWithLabel sets if the cache should only watch objets
+	/// with label "ssp.kubevirt.io/watched".
+	WatchOnlyObjectsWithLabel bool
 }

--- a/internal/controllers/controller.go
+++ b/internal/controllers/controller.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	crd_watch "kubevirt.io/ssp-operator/internal/crd-watch"
 )
@@ -9,5 +10,17 @@ import (
 type Controller interface {
 	Name() string
 	AddToManager(mgr ctrl.Manager, crdList crd_watch.CrdList) error
-	RequiredCrds() []string
+	GetWatchObjects() []WatchObject
+}
+
+type WatchObject struct {
+	// Object is the object that this option applies to.
+	Object client.Object
+
+	// CrdName is the name of the CRD that defines this object.
+	CrdName string
+
+	// WatchOnlyOperatorNamespace sets if the cache should only watch the object type
+	// in the same namespace where the operator is defined.
+	WatchOnlyOperatorNamespace bool
 }

--- a/internal/controllers/services_controller.go
+++ b/internal/controllers/services_controller.go
@@ -123,8 +123,10 @@ func (s *serviceReconciler) AddToManager(mgr ctrl.Manager, _ crd_watch.CrdList) 
 	}))
 }
 
-func (s *serviceReconciler) RequiredCrds() []string {
-	return nil
+func (s *serviceReconciler) GetWatchObjects() []WatchObject {
+	return []WatchObject{{
+		Object: &v1.Service{},
+	}}
 }
 
 func (s *serviceReconciler) setServiceOwnerReference(service *v1.Service) error {

--- a/internal/controllers/setup.go
+++ b/internal/controllers/setup.go
@@ -25,7 +25,7 @@ import (
 )
 
 // Need to watch CRDs
-// +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=list;watch
+// +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch
 
 func StartControllers(ctx context.Context, mgr controllerruntime.Manager, controllers []Controller) error {
 	mgrCtx, cancel := context.WithCancel(ctx)

--- a/internal/controllers/setup.go
+++ b/internal/controllers/setup.go
@@ -105,7 +105,11 @@ func CreateControllers(ctx context.Context, apiReader client.Reader) ([]Controll
 func setupManager(ctx context.Context, cancel context.CancelFunc, mgr controllerruntime.Manager, controllers []Controller) error {
 	var requiredCrds []string
 	for _, controller := range controllers {
-		requiredCrds = append(requiredCrds, controller.RequiredCrds()...)
+		for _, watchObject := range controller.GetWatchObjects() {
+			if watchObject.CrdName != "" {
+				requiredCrds = append(requiredCrds, watchObject.CrdName)
+			}
+		}
 	}
 
 	crdWatch := crd_watch.New(mgr.GetCache(), requiredCrds...)

--- a/internal/controllers/ssp_controller.go
+++ b/internal/controllers/ssp_controller.go
@@ -96,11 +96,11 @@ var _ Controller = &sspController{}
 
 var _ reconcile.Reconciler = &sspController{}
 
-// +kubebuilder:rbac:groups=ssp.kubevirt.io,resources=ssps,verbs=list;watch;update
+// +kubebuilder:rbac:groups=ssp.kubevirt.io,resources=ssps,verbs=get;list;watch;update
 // +kubebuilder:rbac:groups=ssp.kubevirt.io,resources=ssps/status,verbs=update
 // +kubebuilder:rbac:groups=ssp.kubevirt.io,resources=ssps/finalizers,verbs=update
 // +kubebuilder:rbac:groups=config.openshift.io,resources=infrastructures;clusterversions,verbs=get
-// +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=list
+// +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list
 
 func (s *sspController) Name() string {
 	return "ssp-controller"
@@ -146,12 +146,14 @@ func (s *sspController) GetWatchObjects() []WatchObject {
 				Object:                     watchType.Object,
 				CrdName:                    watchType.Crd,
 				WatchOnlyOperatorNamespace: true,
+				WatchOnlyObjectsWithLabel:  watchType.WatchOnlyWithLabel,
 			})
 		}
 		for _, watchType := range operand.WatchClusterTypes() {
 			results = append(results, WatchObject{
-				Object:  watchType.Object,
-				CrdName: watchType.Crd,
+				Object:                    watchType.Object,
+				CrdName:                   watchType.Crd,
+				WatchOnlyObjectsWithLabel: watchType.WatchOnlyWithLabel,
 			})
 		}
 	}

--- a/internal/controllers/ssp_controller.go
+++ b/internal/controllers/ssp_controller.go
@@ -131,27 +131,31 @@ func (s *sspController) AddToManager(mgr ctrl.Manager, crdList crd_watch.CrdList
 	return builder.Complete(s)
 }
 
-func (r *sspController) RequiredCrds() []string {
-	var result []string
-	for _, operand := range r.operands {
-		result = append(result, getRequiredCrds(operand)...)
-	}
-	return result
-}
+func (s *sspController) GetWatchObjects() []WatchObject {
+	var results []WatchObject
 
-func getRequiredCrds(operand operands.Operand) []string {
-	var result []string
-	for _, watchType := range operand.WatchTypes() {
-		if watchType.Crd != "" {
-			result = append(result, watchType.Crd)
+	results = append(results, WatchObject{
+		Object:                     &ssp.SSP{},
+		CrdName:                    "ssps.ssp.kubevirt.io",
+		WatchOnlyOperatorNamespace: true,
+	})
+
+	for _, operand := range s.operands {
+		for _, watchType := range operand.WatchTypes() {
+			results = append(results, WatchObject{
+				Object:  watchType.Object,
+				CrdName: watchType.Crd,
+			})
+		}
+		for _, watchType := range operand.WatchClusterTypes() {
+			results = append(results, WatchObject{
+				Object:  watchType.Object,
+				CrdName: watchType.Crd,
+			})
 		}
 	}
-	for _, watchType := range operand.WatchClusterTypes() {
-		if watchType.Crd != "" {
-			result = append(result, watchType.Crd)
-		}
-	}
-	return result
+
+	return results
 }
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to

--- a/internal/controllers/ssp_controller.go
+++ b/internal/controllers/ssp_controller.go
@@ -143,8 +143,9 @@ func (s *sspController) GetWatchObjects() []WatchObject {
 	for _, operand := range s.operands {
 		for _, watchType := range operand.WatchTypes() {
 			results = append(results, WatchObject{
-				Object:  watchType.Object,
-				CrdName: watchType.Crd,
+				Object:                     watchType.Object,
+				CrdName:                    watchType.Crd,
+				WatchOnlyOperatorNamespace: true,
 			})
 		}
 		for _, watchType := range operand.WatchClusterTypes() {

--- a/internal/controllers/vm_controller.go
+++ b/internal/controllers/vm_controller.go
@@ -57,8 +57,15 @@ func (v *vmController) AddToManager(mgr ctrl.Manager, crdList crd_watch.CrdList)
 		Complete(v)
 }
 
-func (v *vmController) RequiredCrds() []string {
-	return []string{getVmCrd()}
+func (v *vmController) GetWatchObjects() []WatchObject {
+	return []WatchObject{{
+		Object:  &kubevirtv1.VirtualMachine{},
+		CrdName: getVmCrd(),
+	}, {
+		Object: &corev1.PersistentVolumeClaim{},
+	}, {
+		Object: &corev1.PersistentVolume{},
+	}}
 }
 
 func (v *vmController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {

--- a/internal/controllers/webhook_controller.go
+++ b/internal/controllers/webhook_controller.go
@@ -60,8 +60,10 @@ func (w *webhookCtrl) AddToManager(mgr ctrl.Manager, _ crd_watch.CrdList) error 
 		Complete(w)
 }
 
-func (w *webhookCtrl) RequiredCrds() []string {
-	return nil
+func (w *webhookCtrl) GetWatchObjects() []WatchObject {
+	return []WatchObject{{
+		Object: &admissionv1.ValidatingWebhookConfiguration{},
+	}}
 }
 
 func (w *webhookCtrl) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {

--- a/internal/operands/common-instancetypes/reconcile.go
+++ b/internal/operands/common-instancetypes/reconcile.go
@@ -24,8 +24,8 @@ import (
 )
 
 // Define RBAC rules needed by this operand:
-// +kubebuilder:rbac:groups=instancetype.kubevirt.io,resources=virtualmachineclusterinstancetypes,verbs=list;watch;create;update;delete
-// +kubebuilder:rbac:groups=instancetype.kubevirt.io,resources=virtualmachineclusterpreferences,verbs=list;watch;create;update;delete
+// +kubebuilder:rbac:groups=instancetype.kubevirt.io,resources=virtualmachineclusterinstancetypes,verbs=get;list;watch;create;update;delete
+// +kubebuilder:rbac:groups=instancetype.kubevirt.io,resources=virtualmachineclusterpreferences,verbs=get;list;watch;create;update;delete
 
 const (
 	operandName                          = "common-instancetypes"
@@ -57,10 +57,17 @@ func (c *CommonInstancetypes) Name() string {
 }
 
 func WatchClusterTypes() []operands.WatchType {
-	return []operands.WatchType{
-		{Object: &instancetypev1beta1.VirtualMachineClusterInstancetype{}, Crd: virtualMachineClusterInstancetypeCrd, WatchFullObject: true},
-		{Object: &instancetypev1beta1.VirtualMachineClusterPreference{}, Crd: virtualMachineClusterPreferenceCrd, WatchFullObject: true},
-	}
+	return []operands.WatchType{{
+		Object:             &instancetypev1beta1.VirtualMachineClusterInstancetype{},
+		Crd:                virtualMachineClusterInstancetypeCrd,
+		WatchFullObject:    true,
+		WatchOnlyWithLabel: true,
+	}, {
+		Object:             &instancetypev1beta1.VirtualMachineClusterPreference{},
+		Crd:                virtualMachineClusterPreferenceCrd,
+		WatchFullObject:    true,
+		WatchOnlyWithLabel: true,
+	}}
 }
 
 func (c *CommonInstancetypes) WatchClusterTypes() []operands.WatchType {

--- a/internal/operands/common-templates/reconcile.go
+++ b/internal/operands/common-templates/reconcile.go
@@ -30,9 +30,11 @@ func init() {
 }
 
 func WatchClusterTypes() []operands.WatchType {
-	return []operands.WatchType{
-		{Object: &templatev1.Template{}},
-	}
+	return []operands.WatchType{{
+		Object: &templatev1.Template{},
+		// TODO -- consider setting to "true" in the future
+		WatchOnlyWithLabel: false,
+	}}
 }
 
 type commonTemplates struct {

--- a/internal/operands/metrics/reconcile.go
+++ b/internal/operands/metrics/reconcile.go
@@ -10,8 +10,8 @@ import (
 )
 
 // Define RBAC rules needed by this operand:
-// +kubebuilder:rbac:groups=monitoring.coreos.com,resources=prometheusrules;servicemonitors,verbs=list;watch;create;update
-// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings,verbs=list;watch;create;update;delete
+// +kubebuilder:rbac:groups=monitoring.coreos.com,resources=prometheusrules;servicemonitors,verbs=get;list;watch;create;update
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups="",resources=pods;endpoints,verbs=get;list;watch
 
 const prometheusRulesCrd = "prometheusrules.monitoring.coreos.com"
@@ -28,10 +28,15 @@ func WatchTypes() []operands.WatchType {
 }
 
 func WatchClusterTypes() []operands.WatchType {
-	return []operands.WatchType{
-		{Object: &rbac.ClusterRole{}, Crd: prometheusRulesCrd},
-		{Object: &rbac.ClusterRoleBinding{}, Crd: prometheusRulesCrd},
-	}
+	return []operands.WatchType{{
+		Object:             &rbac.ClusterRole{},
+		Crd:                prometheusRulesCrd,
+		WatchOnlyWithLabel: true,
+	}, {
+		Object:             &rbac.ClusterRoleBinding{},
+		Crd:                prometheusRulesCrd,
+		WatchOnlyWithLabel: true,
+	}}
 }
 
 type metrics struct{}

--- a/internal/operands/operand.go
+++ b/internal/operands/operand.go
@@ -34,4 +34,8 @@ type WatchType struct {
 	// Otherwise, only these changes in spec, labels, and annotations.
 	// If an object does not have spec field, the full object is watched by default.
 	WatchFullObject bool
+
+	// WatchOnlyWithLabel sets if the cache should only watch objets
+	/// with label "ssp.kubevirt.io/watched".
+	WatchOnlyWithLabel bool
 }

--- a/internal/operands/tekton-cleanup/reconcile.go
+++ b/internal/operands/tekton-cleanup/reconcile.go
@@ -16,11 +16,11 @@ import (
 	"kubevirt.io/ssp-operator/internal/operands"
 )
 
-// +kubebuilder:rbac:groups=tekton.dev,resources=pipelines,verbs=list;watch;create;update
-// +kubebuilder:rbac:groups=tekton.dev,resources=tasks,verbs=list;watch;update
-// +kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=list;watch;update
-// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;rolebindings,verbs=list;watch;update
-// +kubebuilder:rbac:groups=core,resources=configmaps,verbs=list;watch;create;update
+// +kubebuilder:rbac:groups=tekton.dev,resources=pipelines,verbs=get;list;watch;create;update
+// +kubebuilder:rbac:groups=tekton.dev,resources=tasks,verbs=get;list;watch;update
+// +kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=get;list;watch;update
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;rolebindings,verbs=get;list;watch;update
+// +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;update
 
 // Below are RBAC for deployed ClusterRoles. We still need these permissions so we can update annotations on existing ClusterRoles
 
@@ -50,6 +50,8 @@ func init() {
 
 func WatchClusterTypes() []operands.WatchType {
 	return []operands.WatchType{
+		// Watch resources without label, because this is for cleanup.
+		// TODO -- think about adding the label to old resources too.
 		{Object: &v1.ConfigMap{}},
 		{Object: &rbac.ClusterRole{}},
 		{Object: &rbac.RoleBinding{}},

--- a/internal/operands/template-validator/reconcile.go
+++ b/internal/operands/template-validator/reconcile.go
@@ -13,11 +13,11 @@ import (
 )
 
 // Define RBAC rules needed by this operand:
-// +kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=list;watch;create;update;delete
+// +kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;delete
-// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;clusterrolebindings,verbs=list;watch;create;update;delete
-// +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=validatingwebhookconfigurations,verbs=list;watch;create;update;delete
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;clusterrolebindings,verbs=get;list;watch;create;update;delete
+// +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=validatingwebhookconfigurations,verbs=get;list;watch;create;update;delete
 
 // RBAC for created roles
 // +kubebuilder:rbac:groups=template.openshift.io,resources=templates,verbs=list;watch
@@ -32,11 +32,16 @@ func WatchTypes() []operands.WatchType {
 }
 
 func WatchClusterTypes() []operands.WatchType {
-	return []operands.WatchType{
-		{Object: &rbac.ClusterRole{}},
-		{Object: &rbac.ClusterRoleBinding{}},
-		{Object: &admission.ValidatingWebhookConfiguration{}},
-	}
+	return []operands.WatchType{{
+		Object:             &rbac.ClusterRole{},
+		WatchOnlyWithLabel: true,
+	}, {
+		Object:             &rbac.ClusterRoleBinding{},
+		WatchOnlyWithLabel: true,
+	}, {
+		Object:             &admission.ValidatingWebhookConfiguration{},
+		WatchOnlyWithLabel: true,
+	}}
 }
 
 type templateValidator struct{}

--- a/internal/operands/vm-console-proxy/reconcile.go
+++ b/internal/operands/vm-console-proxy/reconcile.go
@@ -27,13 +27,13 @@ const (
 
 // Define RBAC rules needed by this operand:
 // +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;delete
-// +kubebuilder:rbac:groups=core,resources=configmaps;serviceaccounts,verbs=list;watch;create;update;delete
+// +kubebuilder:rbac:groups=core,resources=configmaps;serviceaccounts,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;delete
-// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;clusterrolebindings;rolebindings,verbs=list;watch;create;update;delete
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;clusterrolebindings;rolebindings,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups=apiregistration.k8s.io,resources=apiservices,verbs=get;list;watch;create;update;delete
 
 // Deprecated:
-// +kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=list;watch;delete
+// +kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=get;list;watch;delete
 
 // RBAC for created roles
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
@@ -52,11 +52,16 @@ func init() {
 }
 
 func WatchClusterTypes() []operands.WatchType {
-	return []operands.WatchType{
-		{Object: &rbac.ClusterRole{}},
-		{Object: &rbac.ClusterRoleBinding{}},
-		{Object: &apiregv1.APIService{}},
-	}
+	return []operands.WatchType{{
+		Object:             &rbac.ClusterRole{},
+		WatchOnlyWithLabel: true,
+	}, {
+		Object:             &rbac.ClusterRoleBinding{},
+		WatchOnlyWithLabel: true,
+	}, {
+		Object:             &apiregv1.APIService{},
+		WatchOnlyWithLabel: true,
+	}}
 }
 
 func WatchTypes() []operands.WatchType {

--- a/tests/env/env.go
+++ b/tests/env/env.go
@@ -10,7 +10,6 @@ import (
 
 const (
 	envExistingCrName         = "TEST_EXISTING_CR_NAME"
-	envExistingCrNamespace    = "TEST_EXISTING_CR_NAMESPACE"
 	envSkipUpdateSspTests     = "SKIP_UPDATE_SSP_TESTS"
 	envSkipCleanupAfterTests  = "SKIP_CLEANUP_AFTER_TESTS"
 	envTimeout                = "TIMEOUT_MINUTES"
@@ -29,10 +28,6 @@ const (
 
 func ExistingCrName() string {
 	return os.Getenv(envExistingCrName)
-}
-
-func ExistingCrNamespace() string {
-	return os.Getenv(envExistingCrNamespace)
 }
 
 func IsUpgradeLane() bool {

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -87,17 +87,6 @@ func (s *newSspStrategy) Init() {
 	validateDeploymentExists()
 
 	Eventually(func() error {
-		namespaceObj := &v1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: s.GetNamespace(),
-				Labels: map[string]string{
-					"openshift.io/cluster-monitoring": "true",
-				},
-			}}
-		return apiClient.Create(ctx, namespaceObj)
-	}, env.Timeout(), time.Second).ShouldNot(HaveOccurred())
-
-	Eventually(func() error {
 		namespaceObj := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: s.GetTemplatesNamespace()}}
 		return apiClient.Create(ctx, namespaceObj)
 	}, env.Timeout(), time.Second).ShouldNot(HaveOccurred())
@@ -147,12 +136,9 @@ func (s *newSspStrategy) Cleanup() {
 		}, &sspv1beta2.SSP{})
 	}
 
-	err1 := apiClient.Delete(ctx, &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: s.GetNamespace()}})
-	err2 := apiClient.Delete(ctx, &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: s.GetTemplatesNamespace()}})
-	expectSuccessOrNotFound(err1)
-	expectSuccessOrNotFound(err2)
+	err := apiClient.Delete(ctx, &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: s.GetTemplatesNamespace()}})
+	expectSuccessOrNotFound(err)
 
-	waitForDeletion(client.ObjectKey{Name: s.GetNamespace()}, &v1.Namespace{})
 	waitForDeletion(client.ObjectKey{Name: s.GetTemplatesNamespace()}, &v1.Namespace{})
 }
 
@@ -161,8 +147,7 @@ func (s *newSspStrategy) GetName() string {
 }
 
 func (s *newSspStrategy) GetNamespace() string {
-	const testNamespace = "ssp-operator-functests"
-	return testNamespace
+	return sspDeploymentNamespace
 }
 
 func (s *newSspStrategy) GetTemplatesNamespace() string {
@@ -227,8 +212,7 @@ func skipIfUpgradeLane() {
 }
 
 type existingSspStrategy struct {
-	Name      string
-	Namespace string
+	Name string
 
 	ssp *sspv1beta2.SSP
 }
@@ -237,7 +221,7 @@ var _ TestSuiteStrategy = &existingSspStrategy{}
 
 func (s *existingSspStrategy) Init() {
 	existingSsp := &sspv1beta2.SSP{}
-	err := apiClient.Get(ctx, client.ObjectKey{Name: s.Name, Namespace: s.Namespace}, existingSsp)
+	err := apiClient.Get(ctx, client.ObjectKey{Name: s.Name, Namespace: sspDeploymentNamespace}, existingSsp)
 	Expect(err).ToNot(HaveOccurred())
 
 	templatesNamespace := existingSsp.Spec.CommonTemplates.Namespace
@@ -289,7 +273,7 @@ func (s *existingSspStrategy) GetName() string {
 }
 
 func (s *existingSspStrategy) GetNamespace() string {
-	return s.Namespace
+	return sspDeploymentNamespace
 }
 
 func (s *existingSspStrategy) GetTemplatesNamespace() string {
@@ -373,9 +357,7 @@ var _ = BeforeSuite(func() {
 	if existingCrName == "" {
 		strategy = &newSspStrategy{}
 	} else {
-		existingCrNamespace := env.ExistingCrNamespace()
-		Expect(existingCrNamespace).ToNot(BeEmpty(), "Existing CR Namespace needs to be defined")
-		strategy = &existingSspStrategy{Name: existingCrName, Namespace: existingCrNamespace}
+		strategy = &existingSspStrategy{Name: existingCrName}
 	}
 
 	fmt.Println(fmt.Sprintf("timeout set to %d minutes", env.Timeout()))

--- a/tests/webhook_test.go
+++ b/tests/webhook_test.go
@@ -134,6 +134,31 @@ var _ = Describe("Validation webhook", func() {
 				})
 			})
 
+			Context("with second namespace", func() {
+				var (
+					namespace *corev1.Namespace
+				)
+
+				BeforeEach(func() {
+					namespace = &corev1.Namespace{
+						ObjectMeta: v1.ObjectMeta{
+							GenerateName: "test-webhook-namespace-",
+						},
+					}
+					Expect(apiClient.Create(ctx, namespace)).To(Succeed())
+				})
+
+				AfterEach(func() {
+					Expect(apiClient.Delete(ctx, namespace)).To(Succeed())
+				})
+
+				It("[test_id:TODO] should fail to create SSP CR in a different namespace", func() {
+					newSsp.Namespace = namespace.Name
+					Expect(apiClient.Create(ctx, newSsp, client.DryRunAll)).
+						To(MatchError(ContainSubstring("SSP object must be in namespace:")))
+				})
+			})
+
 			It("[test_id:TODO] should fail when DataImportCronTemplate does not have a name", func() {
 				newSsp.Spec.CommonTemplates.DataImportCronTemplates = []sspv1beta2.DataImportCronTemplate{{
 					ObjectMeta: metav1.ObjectMeta{Name: ""},


### PR DESCRIPTION
**WORK IN PROGRESS**

**What this PR does / why we need it**:
Currently the cache watches all objects of specific types in all namespaces. This adds unnecessary memory load to the operator. The allocated memory scales with objects in the cluster that are not related to the operator, for example deployments created by users.

This PR limits which objects the cache watches.

**Which issue(s) this PR fixes**: 
Jira: https://issues.redhat.com/browse/CNV-41247
Jira: https://issues.redhat.com/browse/CNV-38130

**Release note**:
```release-note
None
```
