### PR TITLE
chore: Move downstream edited constants to a single file.

### DIFF
--- a/internal/constants.go
+++ b/internal/constants.go
@@ -1,5 +1,8 @@
 package internal
 
+// Constants in this file are edited in downstream builds.
+// Moving or renaming them can cause downstream builds to fail.
 const (
-	GoldenImagesNamespace = "kubevirt-os-images"
+	GoldenImagesNamespace  = "kubevirt-os-images"
+	DefaultOperatorVersion = "devel"
 )

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -13,6 +13,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/discovery"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"kubevirt.io/ssp-operator/internal"
 )
 
 const (
@@ -21,8 +23,6 @@ const (
 	VmConsoleProxyImageKey    = "VM_CONSOLE_PROXY_IMAGE"
 
 	podNamespaceKey = "POD_NAMESPACE"
-
-	defaultOperatorVersion = "devel"
 )
 
 func EnvOrDefault(envName string, defVal string) string {
@@ -34,7 +34,7 @@ func EnvOrDefault(envName string, defVal string) string {
 }
 
 func GetOperatorVersion() string {
-	return EnvOrDefault(OperatorVersionKey, defaultOperatorVersion)
+	return EnvOrDefault(OperatorVersionKey, internal.DefaultOperatorVersion)
 }
 
 func RunningOnOpenshift(ctx context.Context, cl client.Reader) (bool, error) {

--- a/internal/env/env_test.go
+++ b/internal/env/env_test.go
@@ -6,6 +6,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"kubevirt.io/ssp-operator/internal"
 )
 
 var _ = Describe("environments", func() {
@@ -18,7 +20,7 @@ var _ = Describe("environments", func() {
 
 	It("should return correct value for OPERATOR_VERSION when variable is not set", func() {
 		res := GetOperatorVersion()
-		Expect(res).To(Equal(defaultOperatorVersion), "OPERATOR_VERSION should equal")
+		Expect(res).To(Equal(internal.DefaultOperatorVersion), "OPERATOR_VERSION should equal")
 	})
 
 	It("should return namespace from POD_NAMESAPCE env", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
These constants are edited in the downstream `Dockerfile`. Having them in a single file is more convenient.

**Special notes for your reviewer**:
Currently downstream builds from `main` branch fail, because the constant `defaultOperatorVersion` was moved in a previous PR: https://github.com/kubevirt/ssp-operator/pull/987

**Release note**:
```release-note
None
```
