### PR TITLE
deps: Update ci-builder to go 1.22.5

### DIFF
--- a/ci-builder/Dockerfile
+++ b/ci-builder/Dockerfile
@@ -1,7 +1,7 @@
 # This Dockerfile is used in openshift CI
-FROM quay.io/fedora/fedora:37
+FROM quay.io/fedora/fedora:40
 
-RUN curl -L https://go.dev/dl/go1.21.6.linux-amd64.tar.gz | tar -C /usr/local -xzf -
+RUN curl -L https://go.dev/dl/go1.22.5.linux-amd64.tar.gz | tar -C /usr/local -xzf -
 ENV PATH=$PATH:/usr/local/go/bin
 
 # Install dependencies and tools


### PR DESCRIPTION
**What this PR does / why we need it**:
Updated the CI builder to use golang 1.22.5.

This has to be done before any PR that needs it: https://github.com/kubevirt/ssp-operator/pull/1008

**Release note**:
```release-note
None
```
