### PR TITLE
[release-v0.18] fix: add required labels to pods

### DIFF
--- a/internal/common/labels.go
+++ b/internal/common/labels.go
@@ -1,10 +1,10 @@
 package common
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 	ssp "kubevirt.io/ssp-operator/api/v1beta2"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -36,24 +36,28 @@ const (
 // Name will translate into the AppKubernetesNameLabel
 // Component will translate into the AppKubernetesComponentLabel
 // Instance wide labels will be taken from the request if available
-func AddAppLabels(requestInstance *ssp.SSP, name string, component AppComponent, obj client.Object) client.Object {
+func AddAppLabels(requestInstance *ssp.SSP, name string, component AppComponent, obj metav1.Object) metav1.Object {
 	labels := getOrCreateLabels(obj)
-	addInstanceLabels(requestInstance, labels)
-
-	labels[AppKubernetesNameLabel] = name
-	labels[AppKubernetesComponentLabel] = component.String()
-	labels[AppKubernetesManagedByLabel] = AppKubernetesManagedByValue
+	addCommonLabels(labels, requestInstance, name, component)
 
 	return obj
 }
 
-func getOrCreateLabels(obj client.Object) map[string]string {
+func getOrCreateLabels(obj metav1.Object) map[string]string {
 	labels := obj.GetLabels()
 	if labels == nil {
 		labels = map[string]string{}
 		obj.SetLabels(labels)
 	}
 	return labels
+}
+
+func addCommonLabels(labels map[string]string, requestInstance *ssp.SSP, name string, component AppComponent) {
+	addInstanceLabels(requestInstance, labels)
+
+	labels[AppKubernetesNameLabel] = name
+	labels[AppKubernetesComponentLabel] = component.String()
+	labels[AppKubernetesManagedByLabel] = AppKubernetesManagedByValue
 }
 
 func addInstanceLabels(requestInstance *ssp.SSP, to map[string]string) {

--- a/internal/operands/template-validator/reconcile.go
+++ b/internal/operands/template-validator/reconcile.go
@@ -138,6 +138,7 @@ func reconcileDeployment(request *common.Request) (common.ReconcileResult, error
 	}
 
 	deployment := newDeployment(request.Namespace, numberOfReplicas, image, sspTLSOptions)
+	common.AddAppLabels(request.Instance, operandName, operandComponent, &deployment.Spec.Template.ObjectMeta)
 	injectPlacementMetadata(&deployment.Spec.Template.Spec, validatorSpec)
 	return common.CreateOrUpdate(request).
 		NamespacedResource(deployment).

--- a/internal/operands/vm-console-proxy/reconcile.go
+++ b/internal/operands/vm-console-proxy/reconcile.go
@@ -292,6 +292,7 @@ func reconcileDeployment(deployment apps.Deployment) common.ReconcileFunc {
 	return func(request *common.Request) (common.ReconcileResult, error) {
 		deployment.Namespace = request.Instance.Namespace
 		deployment.Spec.Template.Spec.Containers[0].Image = getVmConsoleProxyImage()
+		common.AddAppLabels(request.Instance, operandName, operandComponent, &deployment.Spec.Template.ObjectMeta)
 		return common.CreateOrUpdate(request).
 			NamespacedResource(&deployment).
 			WithAppLabels(operandName, operandComponent).


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

This is a manual cherry-pick of #787. 

**What this PR does / why we need it**:

Add required labels (managed-by, part-of, version, component) to template-validator and vm-console-proxy pods.

Jira-Url: https://issues.redhat.com/browse/CNV-44518

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add required labels to template-validator and vm-console-proxy pods.
```