### PR TITLE
fix: common-instancetypes: Clear URL when deploying from bundle

### DIFF
--- a/internal/operands/common-instancetypes/reconcile.go
+++ b/internal/operands/common-instancetypes/reconcile.go
@@ -272,6 +272,11 @@ func (c *CommonInstancetypes) reconcileFromURL(request *common.Request) ([]commo
 
 func (c *CommonInstancetypes) reconcileFromBundle(request *common.Request) ([]common.ReconcileResult, error) {
 	request.Logger.Info("Reconciling common-instancetypes from internal bundle")
+
+	// We need to clear the resourceURL, otherwise when switching between using and not using URL,
+	// the operator would not deploy resources from the URL.
+	c.resourceURL = ""
+
 	var err error
 	c.virtualMachineClusterInstancetypes, c.virtualMachineClusterPreferences, err = c.fetchResourcesFromBundle()
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Previously, this order of operations would trigger a bug:
- set `.spec.commonInstancetypes.url` to a URL - The operator will deploy resources from the URL
- unset `.spec.commonInstancetypes.url` - The operator will deploy resources from internal bundle
- set `.spec.commonInstancetypes.url` to the same URL - The operator will ignore the resources and not deploy anything

**Release note**:
```release-note
None
```
