### PR TITLE
Update vm-console-proxy

### DIFF
--- a/data/vm-console-proxy-bundle/vm-console-proxy.yaml
+++ b/data/vm-console-proxy-bundle/vm-console-proxy.yaml
@@ -156,7 +156,7 @@ spec:
       - args: []
         command:
         - /console
-        image: quay.io/kubevirt/vm-console-proxy:v0.5.0
+        image: quay.io/kubevirt/vm-console-proxy:v0.6.1
         imagePullPolicy: Always
         name: console
         ports:

--- a/internal/operands/vm-console-proxy/defaults.go
+++ b/internal/operands/vm-console-proxy/defaults.go
@@ -3,6 +3,6 @@ package vm_console_proxy
 // This file is updated by GitHub action defined in .github/workflows/release-vm-console-proxy.yaml
 
 const (
-	defaultVmConsoleProxyImageTag = "v0.5.0"
+	defaultVmConsoleProxyImageTag = "v0.6.1"
 	defaultVmConsoleProxyImage    = "quay.io/kubevirt/vm-console-proxy:" + defaultVmConsoleProxyImageTag
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
- Updated the `vm-console-proxy` to latest released version `v0.6.1`.
- Passed TLS configuration to the `ConfigMap` that is read by `vm-cosole-proxy`.

**Which issue(s) this PR fixes**: 
Fixes: https://issues.redhat.com/browse/CNV-45064

**Release note**:
```release-note
Updated vm-console-proxy to version v0.6.1
```
