### PR TITLE
feat: update validator target to be based on ubi-micro

### DIFF
--- a/validator.Dockerfile
+++ b/validator.Dockerfile
@@ -27,10 +27,8 @@ RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build -a -ldflags="-X 'kubevirt.i
 -X 'kubevirt.io/ssp-operator/internal/template-validator/version.BRANCH=$BRANCH'\
 -X 'kubevirt.io/ssp-operator/internal/template-validator/version.REVISION=$REVISION'" -o kubevirt-template-validator internal/template-validator/main.go
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal
+FROM registry.access.redhat.com/ubi9/ubi-micro
 RUN mkdir -p /etc/webhook/certs
-
-RUN microdnf update -y  && microdnf clean all
 
 WORKDIR /
 COPY --from=builder /workspace/kubevirt-template-validator /usr/sbin/kubevirt-template-validator


### PR DESCRIPTION
Since Ubi-Micro has fewer packages, it has fewer security risks; therefore, no microdnf updates are necessary. This minimizes the need to execute an architecture-specific command while building the target image.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**: 
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note NONE

```
