### PR TITLE
tests: On cleanup, wait until PVCs are bound.

### DIFF
--- a/tests/dataSources_test.go
+++ b/tests/dataSources_test.go
@@ -163,7 +163,6 @@ var _ = Describe("DataSources", func() {
 			Entry("[test_id:4773]view role", &viewRole),
 			Entry("[test_id:4842]view role binding", &viewRoleBinding),
 			Entry("[test_id:4771]edit cluster role", &editClusterRole),
-			Entry("[test_id:4770]golden image NS", &goldenImageNS),
 		)
 	})
 

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -43,6 +44,7 @@ import (
 
 	sspv1beta1 "kubevirt.io/ssp-operator/api/v1beta1"
 	sspv1beta2 "kubevirt.io/ssp-operator/api/v1beta2"
+	"kubevirt.io/ssp-operator/internal"
 	"kubevirt.io/ssp-operator/internal/common"
 	"kubevirt.io/ssp-operator/tests/env"
 )
@@ -279,9 +281,18 @@ func (s *existingSspStrategy) Init() {
 }
 
 func (s *existingSspStrategy) Cleanup() {
-	if s.ssp != nil {
-		s.RevertToOriginalSspCr()
+	if s.ssp == nil {
+		return
 	}
+
+	s.RevertToOriginalSspCr()
+
+	// Waiting for DataImportCrons to import images.
+	//
+	// The tests in dataSources_test.go remove and recreate DataImportCrons, and
+	// they can cause the PVCs to be removed. To keep the cluster in healthy state after tests,
+	// we wait until PVCs are reimported.
+	s.waitForDataImportCrons()
 }
 
 func (s *existingSspStrategy) GetName() string {
@@ -355,6 +366,31 @@ func (s *existingSspStrategy) SkipUnlessHighlyAvailableTopologyMode() {
 
 func (s *existingSspStrategy) SkipIfUpgradeLane() {
 	skipIfUpgradeLane()
+}
+
+func (s *existingSspStrategy) waitForDataImportCrons() {
+	Eventually(func(g Gomega) {
+		for _, dataImportCronTemplate := range s.ssp.Spec.CommonTemplates.DataImportCronTemplates {
+			importCron := &cdiv1beta1.DataImportCron{}
+			importCronNamespacedName := types.NamespacedName{
+				Namespace: dataImportCronTemplate.Namespace,
+				Name:      dataImportCronTemplate.Name,
+			}
+			if importCronNamespacedName.Namespace == "" {
+				importCronNamespacedName.Namespace = internal.GoldenImagesNamespace
+			}
+
+			g.Expect(apiClient.Get(ctx, importCronNamespacedName, importCron)).To(Succeed(),
+				fmt.Sprintf("Could not get DataImportCron: %s", importCronNamespacedName.String()))
+
+			g.Expect(importCron.Status.Conditions).To(ContainElement(Satisfy(
+				func(condition cdiv1beta1.DataImportCronCondition) bool {
+					return condition.Type == cdiv1beta1.DataImportCronUpToDate &&
+						condition.Status == v1.ConditionTrue
+				},
+			)), fmt.Sprintf("DataImportCron %s is not up to date", importCronNamespacedName.String()))
+		}
+	}, env.Timeout(), time.Second).Should(Succeed())
 }
 
 var (


### PR DESCRIPTION
**What this PR does / why we need it**:
When running functional tests in an existing SSP deployment, the `DataImportCrons` are removed and recreated multiple times. The PVCs that they point to can be removed in the process.

One of the tests was removing the namespace that contains `DataImportCrons` and imported images. This caused a problem when the same namespace also contained `ImageStreams` for the imported images.

This PR adds code in `AfterSuite()` to wait for the PVCs to be imported again, and removes the test case, because it is already covered in unit tests.


**Release note**:
```release-note
None
```
