### PR TITLE
feat: Remove unused git from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,8 +42,6 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on make csv-generator
 FROM registry.access.redhat.com/ubi9/ubi-minimal
 LABEL org.kubevirt.hco.csv-generator.v1="/csv-generator"
 
-RUN microdnf update -y && microdnf install git -y && microdnf clean all
-
 WORKDIR /
 COPY --from=builder /workspace/bin/manager .
 COPY data/ data/


### PR DESCRIPTION
**What this PR does / why we need it**:
Git was used by kustomize, that was used to read instance types from a URL. Recently instance types and preferences were removed from SSP.

**Which issue(s) this PR fixes**: 
Jira: https://issues.redhat.com/browse/CNV-44449

**Release note**:
```release-note
None
```
