### PR TITLE
s390x enablement. Update Makefile and Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on make manager
 RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on make csv-generator
 
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal
+FROM registry.access.redhat.com/ubi9/ubi-micro
 LABEL org.kubevirt.hco.csv-generator.v1="/csv-generator"
 
 WORKDIR /

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,6 @@ RUN export ARCH=$(uname -m | sed 's/x86_64/amd64/'); curl -L https://go.dev/dl/g
 ENV PATH=$PATH:/usr/local/go/bin
 
 # Consume required variables so we can work with make
-ARG IMG_REPOSITORY
-ARG IMG_TAG
-ARG IMG
-ARG VALIDATOR_REPOSITORY
-ARG VALIDATOR_IMG_TAG
 ARG VALIDATOR_IMG
 
 WORKDIR /workspace

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal as builder
 
 RUN microdnf install -y make tar gzip which && microdnf clean all
 
-RUN curl -L https://go.dev/dl/go1.22.4.linux-amd64.tar.gz | tar -C /usr/local -xzf -
+RUN export ARCH=$(uname -m | sed 's/x86_64/amd64/'); curl -L https://go.dev/dl/go1.22.4.linux-${ARCH}.tar.gz | tar -C /usr/local -xzf -
 ENV PATH=$PATH:/usr/local/go/bin
 
 # Consume required variables so we can work with make
@@ -35,8 +35,8 @@ COPY hack/csv-generator.go hack/csv-generator.go
 COPY .golangci.yaml .golangci.yaml
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on make manager
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on make csv-generator
+RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on make manager
+RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on make csv-generator
 
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal

--- a/Makefile
+++ b/Makefile
@@ -219,14 +219,7 @@ build-template-validator:
 
 .PHONY: build-template-validator-container
 build-template-validator-container:
-	${SSP_BUILD_RUNTIME} build -t ${VALIDATOR_IMG} \
-		--build-arg IMG_REPOSITORY=${IMG_REPOSITORY} \
-		--build-arg IMG_TAG=${IMG_TAG} \
-		--build-arg IMG=${IMG} \
-		--build-arg VALIDATOR_REPOSITORY=${VALIDATOR_REPOSITORY} \
-		--build-arg VALIDATOR_IMG_TAG=${VALIDATOR_IMG_TAG} \
-		--build-arg VALIDATOR_IMG=${VALIDATOR_IMG} \
-		. -f validator.Dockerfile
+	${SSP_BUILD_RUNTIME} build -t ${VALIDATOR_IMG} . -f validator.Dockerfile
 
 .PHONY: push-template-validator-container
 push-template-validator-container:

--- a/Makefile
+++ b/Makefile
@@ -196,14 +196,14 @@ container-build: unittest bundle
 	mkdir -p data/crd
 	cp bundle/manifests/ssp-operator.clusterserviceversion.yaml data/olm-catalog/ssp-operator.clusterserviceversion.yaml
 	cp bundle/manifests/ssp.kubevirt.io_ssps.yaml data/crd/ssp.kubevirt.io_ssps.yaml
-	podman build -t ${IMG} \
-		--build-arg VALIDATOR_IMG=${VALIDATOR_IMG} \
-		.
+	podman manifest rm ${IMG} || true
+	podman build --build-arg TARGET_ARCH=amd64 --build-arg VALIDATOR_IMG=${VALIDATOR_IMG} --manifest=${IMG} . && \
+    podman build --build-arg TARGET_ARCH=s390x --build-arg VALIDATOR_IMG=${VALIDATOR_IMG} --manifest=${IMG} .
 
 # Push the container image
 .PHONY: container-push
 container-push:
-	podman push ${IMG}
+	podman manifest push ${IMG}
 
 .PHONY: build-template-validator
 build-template-validator:
@@ -244,10 +244,12 @@ kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
 $(KUSTOMIZE): $(LOCALBIN)
 	test -s $(LOCALBIN)/kustomize || curl -s $(KUSTOMIZE_INSTALL_SCRIPT) | bash -s -- $(subst v,,$(KUSTOMIZE_VERSION)) $(LOCALBIN)
 
+# The final line allows for downloading and copying into the LOCALBIN folder when cross-compiling, as GOBIN is not compatible with setting a different GOARCH
 .PHONY: controller-gen
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary.
 $(CONTROLLER_GEN): $(LOCALBIN)
-	test -s $(LOCALBIN)/controller-gen || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_TOOLS_VERSION)
+	test -s $(LOCALBIN)/controller-gen || \
+	GOBIN=$(LOCALBIN) GOARCH=$(ARCH) go install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_TOOLS_VERSION)
 
 # Download operator-sdk locally if necessary
 $(OPERATOR_SDK): $(LOCALBIN)

--- a/Makefile
+++ b/Makefile
@@ -75,9 +75,6 @@ else
 OC = oc
 endif
 
-# Default to podman
-SSP_BUILD_RUNTIME ?= podman
-
 ifndef ignore-not-found
   ignore-not-found = false
 endif
@@ -199,7 +196,7 @@ container-build: unittest bundle
 	mkdir -p data/crd
 	cp bundle/manifests/ssp-operator.clusterserviceversion.yaml data/olm-catalog/ssp-operator.clusterserviceversion.yaml
 	cp bundle/manifests/ssp.kubevirt.io_ssps.yaml data/crd/ssp.kubevirt.io_ssps.yaml
-	${SSP_BUILD_RUNTIME} build -t ${IMG} \
+	podman build -t ${IMG} \
 		--build-arg IMG_REPOSITORY=${IMG_REPOSITORY} \
 		--build-arg IMG_TAG=${IMG_TAG} \
 		--build-arg IMG=${IMG} \
@@ -211,7 +208,7 @@ container-build: unittest bundle
 # Push the container image
 .PHONY: container-push
 container-push:
-	${SSP_BUILD_RUNTIME} push ${IMG}
+	podman push ${IMG}
 
 .PHONY: build-template-validator
 build-template-validator:
@@ -219,11 +216,11 @@ build-template-validator:
 
 .PHONY: build-template-validator-container
 build-template-validator-container:
-	${SSP_BUILD_RUNTIME} build -t ${VALIDATOR_IMG} . -f validator.Dockerfile
+	podman build -t ${VALIDATOR_IMG} . -f validator.Dockerfile
 
 .PHONY: push-template-validator-container
 push-template-validator-container:
-	${SSP_BUILD_RUNTIME} push ${VALIDATOR_IMG}
+	podman push ${VALIDATOR_IMG}
 
 
 ##@ Build Dependencies
@@ -282,7 +279,7 @@ bundle: operator-sdk manifests kustomize csv-generator manager-envsubst
 # Build the bundle image.
 .PHONY: bundle-build
 bundle-build:
-	${SSP_BUILD_RUNTIME} build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
+	podman build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
 
 .PHONY: release
 release: container-build container-push build-template-validator-container push-template-validator-container bundle build-functests

--- a/Makefile
+++ b/Makefile
@@ -216,11 +216,13 @@ build-template-validator:
 
 .PHONY: build-template-validator-container
 build-template-validator-container:
-	podman build -t ${VALIDATOR_IMG} . -f validator.Dockerfile
+	podman manifest rm ${VALIDATOR_IMG} || true && \
+	podman build --build-arg TARGET_ARCH=amd64 --manifest=${VALIDATOR_IMG} . -f validator.Dockerfile && \
+	podman build --build-arg TARGET_ARCH=s390x --manifest=${VALIDATOR_IMG} . -f validator.Dockerfile
 
 .PHONY: push-template-validator-container
 push-template-validator-container:
-	podman push ${VALIDATOR_IMG}
+	podman manifest push ${VALIDATOR_IMG}
 
 
 ##@ Build Dependencies

--- a/Makefile
+++ b/Makefile
@@ -256,7 +256,7 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 
 # Download operator-sdk locally if necessary
 $(OPERATOR_SDK): $(LOCALBIN)
-	curl --create-dirs -JL https://github.com/operator-framework/operator-sdk/releases/download/$(OPERATOR_SDK_VERSION)/operator-sdk_linux_amd64 -o $(OPERATOR_SDK)
+	curl --create-dirs -JL https://github.com/operator-framework/operator-sdk/releases/download/$(OPERATOR_SDK_VERSION)/operator-sdk_linux_$(ARCH) -o $(OPERATOR_SDK)
 	chmod 0755 $(OPERATOR_SDK)
 
 .PHONY: operator-sdk

--- a/Makefile
+++ b/Makefile
@@ -197,11 +197,6 @@ container-build: unittest bundle
 	cp bundle/manifests/ssp-operator.clusterserviceversion.yaml data/olm-catalog/ssp-operator.clusterserviceversion.yaml
 	cp bundle/manifests/ssp.kubevirt.io_ssps.yaml data/crd/ssp.kubevirt.io_ssps.yaml
 	podman build -t ${IMG} \
-		--build-arg IMG_REPOSITORY=${IMG_REPOSITORY} \
-		--build-arg IMG_TAG=${IMG_TAG} \
-		--build-arg IMG=${IMG} \
-		--build-arg VALIDATOR_REPOSITORY=${VALIDATOR_REPOSITORY} \
-		--build-arg VALIDATOR_IMG_TAG=${VALIDATOR_IMG_TAG} \
 		--build-arg VALIDATOR_IMG=${VALIDATOR_IMG} \
 		.
 

--- a/validator.Dockerfile
+++ b/validator.Dockerfile
@@ -1,4 +1,14 @@
+# Build this Dockerfile using the command: make build-template-validator-container
+#
+# This multi-stage image approach prevents issues related to cached builder images,
+# which may be incompatible due to different architectures, potentially slowing down or breaking the build process.
+#
+# By utilizing Go cross-compilation, we can build the target Go binary from the host architecture
+# and then copy it to the target image with the desired architecture.
+
+ARG TARGET_ARCH=amd64
 FROM registry.access.redhat.com/ubi9/ubi-minimal as builder
+ARG TARGET_ARCH
 
 RUN microdnf install -y make tar gzip which && microdnf clean all
 RUN export ARCH=$(uname -m | sed 's/x86_64/amd64/'); curl -L https://go.dev/dl/go1.22.4.linux-${ARCH}.tar.gz | tar -C /usr/local -xzf -
@@ -22,7 +32,8 @@ COPY api/ api/
 COPY internal/ internal/
 COPY pkg/ pkg/
 
-RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build -a -ldflags="-X 'kubevirt.io/ssp-operator/internal/template-validator/version.COMPONENT=$COMPONENT'\
+# Compile for the TARGET_ARCH
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGET_ARCH} GO111MODULE=on go build -a -ldflags="-X 'kubevirt.io/ssp-operator/internal/template-validator/version.COMPONENT=$COMPONENT'\
 -X 'kubevirt.io/ssp-operator/internal/template-validator/version.VERSION=$VERSION'\
 -X 'kubevirt.io/ssp-operator/internal/template-validator/version.BRANCH=$BRANCH'\
 -X 'kubevirt.io/ssp-operator/internal/template-validator/version.REVISION=$REVISION'" -o kubevirt-template-validator internal/template-validator/main.go
@@ -30,7 +41,8 @@ RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build -a -ldflags="-X 'kubevirt.i
 # Hack: Create an empty directory in the builder image and copy it to the target image to avoid triggering any architecture-specific commands
 RUN mkdir emptydir
 
-FROM registry.access.redhat.com/ubi9/ubi-micro
+
+FROM --platform=linux/${TARGET_ARCH} registry.access.redhat.com/ubi9/ubi-micro
 
 # Hack: Refer to the last comment in the builder image.
 COPY --from=builder /workspace/emptydir /etc/webhook/certs


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This update adapts the Makefile and the Dockerfiles (ssp and validator) to enable automatic building on both s390x and amd64 architectures using make commands.

**Which issue(s) this PR fixes**: 
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note NONE

```
