### PR TITLE
feat: validator: Load TLS configuration from ConfigMap

### DIFF
--- a/internal/common/crypto_policy.go
+++ b/internal/common/crypto_policy.go
@@ -10,8 +10,8 @@ import (
 )
 
 type SSPTLSOptions struct {
-	MinTLSVersion      string
-	OpenSSLCipherNames []string
+	MinTLSVersion      string   `json:"minTLSVersion,omitempty"`
+	OpenSSLCipherNames []string `json:"openSSLCipherNames,omitempty"`
 }
 
 func (s *SSPTLSOptions) IsEmpty() bool {

--- a/internal/operands/template-validator/reconcile_test.go
+++ b/internal/operands/template-validator/reconcile_test.go
@@ -26,7 +26,6 @@ import (
 )
 
 var log = logf.Log.WithName("validator_operand")
-var emptySSPTLSConfig = &common.SSPTLSOptions{}
 
 var _ = Describe("Template validator operand", func() {
 	const (
@@ -85,7 +84,8 @@ var _ = Describe("Template validator operand", func() {
 		ExpectResourceExists(newServiceAccount(namespace), request)
 		ExpectResourceExists(newClusterRoleBinding(namespace), request)
 		ExpectResourceExists(newService(namespace), request)
-		ExpectResourceExists(newDeployment(namespace, replicas, "test-img", emptySSPTLSConfig), request)
+		ExpectResourceExists(newConfigMap(namespace, ""), request)
+		ExpectResourceExists(newDeployment(namespace, replicas, "test-img"), request)
 		ExpectResourceExists(newValidatingWebhook(namespace), request)
 		ExpectResourceExists(newPrometheusService(namespace), request)
 	})
@@ -153,7 +153,7 @@ var _ = Describe("Template validator operand", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		// Set status for deployment
-		key := client.ObjectKeyFromObject(newDeployment(namespace, replicas, "test-img", emptySSPTLSConfig))
+		key := client.ObjectKeyFromObject(newDeployment(namespace, replicas, "test-img"))
 		updateDeploymentStatus(key, &request, func(deploymentStatus *apps.DeploymentStatus) {
 			deploymentStatus.Replicas = replicas
 			deploymentStatus.ReadyReplicas = 0
@@ -381,7 +381,7 @@ var _ = Describe("Template validator operand", func() {
 			_, err := operand.Reconcile(&request)
 			Expect(err).ToNot(HaveOccurred())
 			deployment := &apps.Deployment{}
-			key := client.ObjectKeyFromObject(newDeployment(namespace, replicas, "test-img", emptySSPTLSConfig))
+			key := client.ObjectKeyFromObject(newDeployment(namespace, replicas, "test-img"))
 			Expect(request.Client.Get(request.Context, key, deployment)).To(Succeed())
 			Expect(deployment.Spec.Template.Spec.Affinity.NodeAffinity).To(Equal(expectedNodeAffinity))
 			Expect(deployment.Spec.Template.Spec.Affinity.PodAffinity).To(Equal(expectedPodAffinity))

--- a/internal/template-validator/filewatch/filewatch.go
+++ b/internal/template-validator/filewatch/filewatch.go
@@ -1,0 +1,118 @@
+package filewatch
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+type Watch interface {
+	Add(path string, callback func()) error
+	Run(done <-chan struct{}) error
+	IsRunning() bool
+}
+
+func New() Watch {
+	return &watch{
+		callbacks: make(map[string]func()),
+	}
+}
+
+type watch struct {
+	lock      sync.Mutex
+	callbacks map[string]func()
+	running   atomic.Bool
+}
+
+var _ Watch = &watch{}
+
+func (w *watch) Add(path string, callback func()) error {
+	w.lock.Lock()
+	defer w.lock.Unlock()
+
+	if w.running.Load() {
+		return fmt.Errorf("cannot add to a running watch")
+	}
+
+	w.callbacks[path] = callback
+	return nil
+}
+
+func (w *watch) Run(done <-chan struct{}) error {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return fmt.Errorf("could not create fsnotify.Watcher: %w", err)
+	}
+	// watcher.Close() never returns an error
+	defer func() { _ = watcher.Close() }()
+
+	func() {
+		// Before setting running to true, we need to acquire the lock,
+		// because Add() method may be running concurrently.
+		w.lock.Lock()
+		defer w.lock.Unlock()
+		w.running.Store(true)
+	}()
+	// Setting running to false is ok without a lock.
+	defer w.running.Store(false)
+
+	err = w.addCallbacks(watcher)
+	if err != nil {
+		return fmt.Errorf("could not add callbacks: %w", err)
+	}
+
+	return w.processEvents(watcher, done)
+}
+
+func (w *watch) IsRunning() bool {
+	return w.running.Load()
+}
+
+func (w *watch) addCallbacks(watcher *fsnotify.Watcher) error {
+	for path := range w.callbacks {
+		err := watcher.Add(path)
+		if err != nil {
+			return fmt.Errorf("failed watch %s: %w", path, err)
+		}
+	}
+	return nil
+}
+
+func (w *watch) processEvents(watcher *fsnotify.Watcher, done <-chan struct{}) error {
+	for {
+		select {
+		case <-done:
+			return nil
+
+		case event, ok := <-watcher.Events:
+			if !ok {
+				return nil
+			}
+			w.handleEvent(event)
+
+		case err, ok := <-watcher.Errors:
+			if !ok {
+				return nil
+			}
+			if err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func (w *watch) handleEvent(event fsnotify.Event) {
+	const modificationEvents = fsnotify.Create | fsnotify.Write | fsnotify.Remove
+	if event.Op&modificationEvents == 0 {
+		return
+	}
+
+	for path, callback := range w.callbacks {
+		if strings.HasPrefix(event.Name, path) {
+			callback()
+		}
+	}
+}

--- a/internal/template-validator/filewatch/filewatch.go
+++ b/internal/template-validator/filewatch/filewatch.go
@@ -63,6 +63,10 @@ func (w *watch) Run(done <-chan struct{}) error {
 	if err != nil {
 		return fmt.Errorf("could not add callbacks: %w", err)
 	}
+	// Running all callbacks before processing watch events.
+	// So callbacks will notice the state of the files after
+	// watch starts, but before any events arrive.
+	w.runCallbacks()
 
 	return w.processEvents(watcher, done)
 }
@@ -79,6 +83,12 @@ func (w *watch) addCallbacks(watcher *fsnotify.Watcher) error {
 		}
 	}
 	return nil
+}
+
+func (w *watch) runCallbacks() {
+	for _, callback := range w.callbacks {
+		callback()
+	}
 }
 
 func (w *watch) processEvents(watcher *fsnotify.Watcher, done <-chan struct{}) error {

--- a/internal/template-validator/filewatch/filewatch_test.go
+++ b/internal/template-validator/filewatch/filewatch_test.go
@@ -1,0 +1,137 @@
+package filewatch
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Filewatch", func() {
+	Context("watching file", func() {
+		var (
+			callback     func()
+			tempFileName string
+		)
+
+		BeforeEach(func() {
+			tmpDir := GinkgoT().TempDir()
+			tempFileName = filepath.Join(tmpDir, "test-file")
+			Expect(os.WriteFile(tempFileName, []byte("test content"), 0777)).To(Succeed())
+
+			callback = func() {
+				defer GinkgoRecover()
+				panic("callback was not set")
+			}
+
+			startWatch(tempFileName, func() { callback() })
+		})
+
+		It("should call callback on file change", func() {
+			called := atomic.Bool{}
+			callback = func() { called.Store(true) }
+
+			Expect(os.WriteFile(tempFileName, []byte("different content"), 0777)).To(Succeed())
+
+			Eventually(called.Load, time.Second, 50*time.Millisecond).Should(BeTrue())
+		})
+
+		It("should call callback on file deletion", func() {
+			called := atomic.Bool{}
+			callback = func() { called.Store(true) }
+
+			Expect(os.Remove(tempFileName)).ToNot(HaveOccurred())
+
+			Eventually(called.Load, time.Second, 50*time.Millisecond).Should(BeTrue())
+		})
+	})
+
+	Context("watching directory", func() {
+		var (
+			callback    func()
+			tempDirName string
+		)
+
+		BeforeEach(func() {
+			tempDirName = GinkgoT().TempDir()
+
+			callback = func() {
+				defer GinkgoRecover()
+				panic("callback was not set")
+			}
+
+			startWatch(tempDirName, func() { callback() })
+		})
+
+		It("should call callback on file creation", func() {
+			called := atomic.Bool{}
+			callback = func() { called.Store(true) }
+
+			Expect(os.WriteFile(filepath.Join(tempDirName, "created-file"), []byte("content"), 0777)).To(Succeed())
+
+			Eventually(called.Load, time.Second, 50*time.Millisecond).Should(BeTrue())
+		})
+
+		It("should call callback on file change", func() {
+			called := atomic.Bool{}
+			callback = func() { called.Store(true) }
+
+			const filename = "test-file"
+			Expect(os.WriteFile(filepath.Join(tempDirName, filename), []byte("content"), 0777)).To(Succeed())
+
+			Eventually(called.Load, time.Second, 50*time.Millisecond).Should(BeTrue())
+
+			called.Store(false)
+
+			Expect(os.WriteFile(filepath.Join(tempDirName, filename), []byte("updated content"), 0777)).To(Succeed())
+
+			Eventually(called.Load, time.Second, 50*time.Millisecond).Should(BeTrue())
+		})
+
+		It("should call callback on file deletion", func() {
+			called := atomic.Bool{}
+			callback = func() { called.Store(true) }
+
+			const filename = "test-file"
+			Expect(os.WriteFile(filepath.Join(tempDirName, filename), []byte("content"), 0777)).To(Succeed())
+
+			Eventually(called.Load, time.Second, 50*time.Millisecond).Should(BeTrue())
+
+			called.Store(false)
+
+			Expect(os.Remove(filepath.Join(tempDirName, filename))).ToNot(HaveOccurred())
+
+			Eventually(called.Load, time.Second, 50*time.Millisecond).Should(BeTrue())
+		})
+	})
+})
+
+func startWatch(path string, callback func()) {
+	testWatch := New()
+	err := testWatch.Add(path, callback)
+	Expect(err).ToNot(HaveOccurred())
+
+	done := make(chan struct{})
+	DeferCleanup(func() {
+		close(done)
+	})
+
+	go func() {
+		defer GinkgoRecover()
+		Expect(testWatch.Run(done)).To(Succeed())
+	}()
+
+	// Wait for a short time to let the watch goroutine run
+	runtime.Gosched()
+	Eventually(testWatch.IsRunning, time.Second, 50*time.Millisecond).Should(BeTrue())
+}
+
+func TestFilewatch(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Filewatch Suite")
+}

--- a/internal/template-validator/filewatch/filewatch_test.go
+++ b/internal/template-validator/filewatch/filewatch_test.go
@@ -13,6 +13,15 @@ import (
 )
 
 var _ = Describe("Filewatch", func() {
+	It("should call callback immediately when watch starts", func() {
+		tempDirName := GinkgoT().TempDir()
+
+		called := atomic.Bool{}
+		startWatch(tempDirName, func() { called.Store(true) })
+
+		Eventually(called.Load, time.Second, 50*time.Millisecond).Should(BeTrue())
+	})
+
 	Context("watching file", func() {
 		var (
 			callback     func()
@@ -24,10 +33,7 @@ var _ = Describe("Filewatch", func() {
 			tempFileName = filepath.Join(tmpDir, "test-file")
 			Expect(os.WriteFile(tempFileName, []byte("test content"), 0777)).To(Succeed())
 
-			callback = func() {
-				defer GinkgoRecover()
-				panic("callback was not set")
-			}
+			callback = func() {}
 
 			startWatch(tempFileName, func() { callback() })
 		})
@@ -60,10 +66,7 @@ var _ = Describe("Filewatch", func() {
 		BeforeEach(func() {
 			tempDirName = GinkgoT().TempDir()
 
-			callback = func() {
-				defer GinkgoRecover()
-				panic("callback was not set")
-			}
+			callback = func() {}
 
 			startWatch(tempDirName, func() { callback() })
 		})

--- a/internal/template-validator/tlsinfo/tlsinfo.go
+++ b/internal/template-validator/tlsinfo/tlsinfo.go
@@ -34,10 +34,6 @@ type TLSInfo struct {
 	sspTLSOptions  common.SSPTLSOptions
 }
 
-func (ti *TLSInfo) IsEnabled() bool {
-	return ti.CertsDirectory != ""
-}
-
 func (ti *TLSInfo) Init() {
 	ti.initCerts()
 	ti.initCryptoConfig()
@@ -50,10 +46,6 @@ func (ti *TLSInfo) initCryptoConfig() {
 }
 
 func (ti *TLSInfo) initCerts() {
-	if !ti.IsEnabled() {
-		return
-	}
-
 	directory := ti.CertsDirectory
 	filesChanged, watcherCloser, err := watchDirectory(directory)
 	if err != nil {

--- a/internal/template-validator/tlsinfo/tlsinfo.go
+++ b/internal/template-validator/tlsinfo/tlsinfo.go
@@ -39,17 +39,17 @@ func (ti *TLSInfo) IsEnabled() bool {
 }
 
 func (ti *TLSInfo) Init() {
-	ti.InitCerts()
-	ti.InitCryptoConfig()
+	ti.initCerts()
+	ti.initCryptoConfig()
 }
 
-func (ti *TLSInfo) InitCryptoConfig() {
+func (ti *TLSInfo) initCryptoConfig() {
 	nonSplitCiphers, _ := os.LookupEnv(CiphersEnvName)
 	ti.sspTLSOptions.OpenSSLCipherNames = strings.Split(nonSplitCiphers, ",")
 	ti.sspTLSOptions.MinTLSVersion, _ = os.LookupEnv(TLSMinVersionEnvName)
 }
 
-func (ti *TLSInfo) InitCerts() {
+func (ti *TLSInfo) initCerts() {
 	if !ti.IsEnabled() {
 		return
 	}

--- a/internal/template-validator/tlsinfo/tlsinfo_test.go
+++ b/internal/template-validator/tlsinfo/tlsinfo_test.go
@@ -21,14 +21,12 @@ var _ = Describe("TlsInfo", func() {
 	var certDir string
 
 	BeforeEach(func() {
-		var err error
-		certDir, err = os.MkdirTemp("", "certs")
-		Expect(err).ToNot(HaveOccurred())
+		certDir = GinkgoT().TempDir()
 	})
 
 	It("should return nil if no certificate exists", func() {
 		tlsInfo := TLSInfo{CertsDirectory: certDir}
-		tlsInfo.InitCerts()
+		tlsInfo.Init()
 		defer tlsInfo.Clean()
 		tlsConfig := tlsInfo.CreateTlsConfig()
 
@@ -41,7 +39,7 @@ var _ = Describe("TlsInfo", func() {
 	It("should load certificate", func() {
 		writeCertificate(certDir)
 		tlsInfo := TLSInfo{CertsDirectory: certDir}
-		tlsInfo.InitCerts()
+		tlsInfo.Init()
 		defer tlsInfo.Clean()
 		tlsConfig := tlsInfo.CreateTlsConfig()
 
@@ -52,7 +50,7 @@ var _ = Describe("TlsInfo", func() {
 
 	It("should reload new certificate", func() {
 		tlsInfo := TLSInfo{CertsDirectory: certDir}
-		tlsInfo.InitCerts()
+		tlsInfo.Init()
 		defer tlsInfo.Clean()
 		tlsConfig := tlsInfo.CreateTlsConfig()
 
@@ -71,7 +69,7 @@ var _ = Describe("TlsInfo", func() {
 	It("should keep old certificate on failure", func() {
 		writeCertificate(certDir)
 		tlsInfo := TLSInfo{CertsDirectory: certDir}
-		tlsInfo.InitCerts()
+		tlsInfo.Init()
 		defer tlsInfo.Clean()
 		tlsConfig := tlsInfo.CreateTlsConfig()
 
@@ -84,10 +82,6 @@ var _ = Describe("TlsInfo", func() {
 		Consistently(func() (*tls.Certificate, error) {
 			return tlsConfig.GetCertificate(nil)
 		}, time.Second).ShouldNot(BeNil())
-	})
-
-	AfterEach(func() {
-		os.RemoveAll(certDir)
 	})
 })
 

--- a/internal/template-validator/tlsinfo/tlsinfo_test.go
+++ b/internal/template-validator/tlsinfo/tlsinfo_test.go
@@ -3,8 +3,10 @@ package tlsinfo
 import (
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/json"
 	"encoding/pem"
 	"math/big"
 	"os"
@@ -14,84 +16,201 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	ocpconfigv1 "github.com/openshift/api/config/v1"
+
+	"kubevirt.io/ssp-operator/internal/common"
 )
 
 const certSubject = "test.kubevirt.io"
 
 var _ = Describe("TlsInfo", func() {
 
-	var certDir string
+	var (
+		certDir       string
+		tlsOptionsDir string
+
+		tlsOptions *common.SSPTLSOptions
+
+		expectedVersion      uint16
+		expectedCipherSuites []uint16
+
+		tlsInfo *TLSInfo
+	)
 
 	BeforeEach(func() {
 		certDir = GinkgoT().TempDir()
-	})
-
-	It("should fail if no certificate exists", func() {
-		tlsInfo := TLSInfo{CertsDirectory: certDir}
-		Expect(tlsInfo.Init()).To(Succeed())
-		defer tlsInfo.Clean()
-
-		Consistently(func() error {
-			_, err := tlsInfo.CreateTlsConfig()
-			return err
-		}, time.Second).Should(MatchError(ContainSubstring("no such file or directory")))
-	})
-
-	It("should load certificate", func() {
-		writeCertificate(certDir)
-		tlsInfo := TLSInfo{CertsDirectory: certDir}
-		Expect(tlsInfo.Init()).To(Succeed())
-		defer tlsInfo.Clean()
-
-		Eventually(func(g Gomega) {
-			tlsConfig, err := tlsInfo.CreateTlsConfig()
-			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(tlsConfig.Certificates).To(HaveLen(1))
-			g.Expect(tlsConfig.Certificates[0].Leaf.Subject.CommonName).To(Equal(certSubject))
-		}, time.Second).Should(Succeed())
-	})
-
-	It("should reload new certificate", func() {
-		tlsInfo := TLSInfo{CertsDirectory: certDir}
-		Expect(tlsInfo.Init()).To(Succeed())
-		defer tlsInfo.Clean()
-
-		Consistently(func() error {
-			_, err := tlsInfo.CreateTlsConfig()
-			return err
-		}, time.Second).Should(MatchError(ContainSubstring("no such file or directory")))
+		tlsOptionsDir = GinkgoT().TempDir()
 
 		writeCertificate(certDir)
 
-		Eventually(func(g Gomega) {
-			tlsConfig, err := tlsInfo.CreateTlsConfig()
-			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(tlsConfig.Certificates).To(HaveLen(1))
-			g.Expect(tlsConfig.Certificates[0].Leaf.Subject.CommonName).To(Equal(certSubject))
-		}, time.Second).Should(Succeed())
+		var err error
+		tlsOptions, err = common.NewSSPTLSOptions(
+			&ocpconfigv1.TLSSecurityProfile{
+				Type:         ocpconfigv1.TLSProfileIntermediateType,
+				Intermediate: &ocpconfigv1.IntermediateTLSProfile{},
+			},
+			nil,
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		writeTLSOptions(tlsOptionsDir, tlsOptions)
+
+		expectedVersion = tls.VersionTLS12
+		expectedCipherSuites = []uint16{
+			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+			tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+		}
+
+		tlsInfo = &TLSInfo{
+			CertsDirectory:      certDir,
+			TLSOptionsDirectory: tlsOptionsDir,
+		}
 	})
 
-	It("should fail if certificate file is invalid", func() {
-		writeCertificate(certDir)
-		tlsInfo := TLSInfo{CertsDirectory: certDir}
-		Expect(tlsInfo.Init()).To(Succeed())
-		defer tlsInfo.Clean()
+	Context("loading certificates", func() {
+		It("should fail if no certificate exists", func() {
+			Expect(os.Remove(filepath.Join(certDir, CertFilename))).To(Succeed())
+			Expect(os.Remove(filepath.Join(certDir, KeyFilename))).To(Succeed())
 
-		Eventually(func(g Gomega) {
-			tlsConfig, err := tlsInfo.CreateTlsConfig()
-			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(tlsConfig.Certificates).To(HaveLen(1))
-			g.Expect(tlsConfig.Certificates[0].Leaf.Subject.CommonName).To(Equal(certSubject))
-		}, time.Second).Should(Succeed())
+			Expect(tlsInfo.Init()).To(Succeed())
+			defer tlsInfo.Clean()
 
-		Expect(os.WriteFile(filepath.Join(certDir, CertFilename), []byte{}, 0777)).To(Succeed())
+			Consistently(func() error {
+				_, err := tlsInfo.CreateTlsConfig()
+				return err
+			}, time.Second).Should(MatchError(ContainSubstring("no such file or directory")))
+		})
 
-		Eventually(func() error {
-			_, err := tlsInfo.CreateTlsConfig()
-			return err
-		}, time.Second).Should(MatchError(ContainSubstring(
-			"error getting certificate: failed to load certificate:",
-		)))
+		It("should load certificate", func() {
+			Expect(tlsInfo.Init()).To(Succeed())
+			defer tlsInfo.Clean()
+
+			Eventually(func(g Gomega) {
+				tlsConfig, err := tlsInfo.CreateTlsConfig()
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(tlsConfig.Certificates).To(HaveLen(1))
+				g.Expect(tlsConfig.Certificates[0].Leaf.Subject.CommonName).To(Equal(certSubject))
+			}, time.Second).Should(Succeed())
+		})
+
+		It("should reload new certificate", func() {
+			Expect(os.Remove(filepath.Join(certDir, CertFilename))).To(Succeed())
+			Expect(os.Remove(filepath.Join(certDir, KeyFilename))).To(Succeed())
+
+			Expect(tlsInfo.Init()).To(Succeed())
+			defer tlsInfo.Clean()
+
+			Consistently(func() error {
+				_, err := tlsInfo.CreateTlsConfig()
+				return err
+			}, time.Second).Should(MatchError(ContainSubstring("no such file or directory")))
+
+			writeCertificate(certDir)
+
+			Eventually(func(g Gomega) {
+				tlsConfig, err := tlsInfo.CreateTlsConfig()
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(tlsConfig.Certificates).To(HaveLen(1))
+				g.Expect(tlsConfig.Certificates[0].Leaf.Subject.CommonName).To(Equal(certSubject))
+			}, time.Second).Should(Succeed())
+		})
+
+		It("should fail if certificate file is invalid", func() {
+			Expect(tlsInfo.Init()).To(Succeed())
+			defer tlsInfo.Clean()
+
+			Eventually(func(g Gomega) {
+				tlsConfig, err := tlsInfo.CreateTlsConfig()
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(tlsConfig.Certificates).To(HaveLen(1))
+				g.Expect(tlsConfig.Certificates[0].Leaf.Subject.CommonName).To(Equal(certSubject))
+			}, time.Second).Should(Succeed())
+
+			Expect(os.WriteFile(filepath.Join(certDir, CertFilename), []byte{}, 0777)).To(Succeed())
+
+			Eventually(func() error {
+				_, err := tlsInfo.CreateTlsConfig()
+				return err
+			}, time.Second).Should(MatchError(ContainSubstring(
+				"error getting certificate: failed to load certificate:",
+			)))
+		})
+	})
+
+	Context("loading TLS options", func() {
+		It("should fail if TLS options file does not exist", func() {
+			Expect(os.Remove(filepath.Join(tlsOptionsDir, TLSOptionsFilename))).To(Succeed())
+
+			Expect(tlsInfo.Init()).To(Succeed())
+			defer tlsInfo.Clean()
+
+			Consistently(func() error {
+				_, err := tlsInfo.CreateTlsConfig()
+				return err
+			}, time.Second).Should(MatchError(ContainSubstring("no such file or directory")))
+		})
+
+		It("should load TLS options", func() {
+			Expect(tlsInfo.Init()).To(Succeed())
+			defer tlsInfo.Clean()
+
+			Eventually(func(g Gomega) {
+				tlsConfig, err := tlsInfo.CreateTlsConfig()
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(tlsConfig.CipherSuites).To(ContainElements(expectedCipherSuites))
+				g.Expect(tlsConfig.MinVersion).To(Equal(expectedVersion))
+			}, time.Second).Should(Succeed())
+		})
+
+		It("should reload TLS options", func() {
+			Expect(os.Remove(filepath.Join(tlsOptionsDir, TLSOptionsFilename))).To(Succeed())
+
+			Expect(tlsInfo.Init()).To(Succeed())
+			defer tlsInfo.Clean()
+
+			Consistently(func() error {
+				_, err := tlsInfo.CreateTlsConfig()
+				return err
+			}, time.Second).Should(MatchError(ContainSubstring("no such file or directory")))
+
+			writeTLSOptions(tlsOptionsDir, tlsOptions)
+
+			Eventually(func(g Gomega) {
+				tlsConfig, err := tlsInfo.CreateTlsConfig()
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(tlsConfig.CipherSuites).To(ContainElements(expectedCipherSuites))
+				g.Expect(tlsConfig.MinVersion).To(Equal(expectedVersion))
+			}, time.Second).Should(Succeed())
+		})
+
+		It("should fail if TLS options are invalid", func() {
+			Expect(tlsInfo.Init()).To(Succeed())
+			defer tlsInfo.Clean()
+
+			Eventually(func(g Gomega) {
+				tlsConfig, err := tlsInfo.CreateTlsConfig()
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(tlsConfig.CipherSuites).To(ContainElements(expectedCipherSuites))
+				g.Expect(tlsConfig.MinVersion).To(Equal(expectedVersion))
+			}, time.Second).Should(Succeed())
+
+			writeTLSOptions(tlsOptionsDir, &common.SSPTLSOptions{
+				MinTLSVersion:      "INVALID_TLS_VERSION",
+				OpenSSLCipherNames: []string{"invalid-cypher-name"},
+			})
+
+			Eventually(func() error {
+				_, err := tlsInfo.CreateTlsConfig()
+				return err
+			}, time.Second).Should(MatchError(ContainSubstring(
+				"error getting TLS options: TLS Configuration broken, min version misconfigured:",
+			)))
+		})
 	})
 })
 
@@ -128,6 +247,13 @@ func writeCertificate(dir string) {
 
 	Expect(os.WriteFile(filepath.Join(dir, CertFilename), certPEM, 0777)).To(Succeed())
 	Expect(os.WriteFile(filepath.Join(dir, KeyFilename), keyPEM, 0777)).To(Succeed())
+}
+
+func writeTLSOptions(dir string, tlsOptions *common.SSPTLSOptions) {
+	tlsOptionsJson, err := json.Marshal(tlsOptions)
+	Expect(err).ToNot(HaveOccurred())
+
+	Expect(os.WriteFile(filepath.Join(dir, TLSOptionsFilename), tlsOptionsJson, 0600)).To(Succeed())
 }
 
 func TestTlsInfo(t *testing.T) {

--- a/internal/template-validator/validator/app.go
+++ b/internal/template-validator/validator/app.go
@@ -26,6 +26,8 @@ import (
 const (
 	defaultPort = 8443
 	defaultHost = "0.0.0.0"
+
+	tlsOptionsDirectory = "/tls-options"
 )
 
 type App struct {
@@ -87,7 +89,8 @@ func (app *App) Run() {
 		logger.Log.Info("TLS certs directory", "directory", app.certsDir)
 
 		tlsInfo := tlsinfo.TLSInfo{
-			CertsDirectory: app.certsDir,
+			CertsDirectory:      app.certsDir,
+			TLSOptionsDirectory: tlsOptionsDirectory,
 		}
 
 		if err := tlsInfo.Init(); err != nil {

--- a/internal/template-validator/validator/app.go
+++ b/internal/template-validator/validator/app.go
@@ -89,7 +89,10 @@ func (app *App) Run() {
 			CertsDirectory: app.certsDir,
 		}
 
-		tlsInfo.Init()
+		if err := tlsInfo.Init(); err != nil {
+			logger.Log.Error(err, "Failed initializing TLSInfo")
+			panic(err)
+		}
 		defer tlsInfo.Clean()
 
 		server := &http.Server{Addr: app.Address(), TLSConfig: tlsInfo.CreateTlsConfig()}

--- a/tests/crypto_policy_test.go
+++ b/tests/crypto_policy_test.go
@@ -110,8 +110,8 @@ var _ = Describe("Crypto Policy", func() {
 		DescribeTable("Adhere to defined TLSConfig", func(tlsConfigTestPermutation tlsConfigTestPermutation) {
 			pod := operatorPod()
 			applyTLSConfig(tlsConfigTestPermutation.openshiftTLSPolicy)
-			testMetricsEndpoint(pod, tlsConfigTestPermutation)
-			testWebhookEndpoint(pod, tlsConfigTestPermutation)
+			Expect(testMetricsEndpoint(pod, tlsConfigTestPermutation)).To(Succeed())
+			Expect(testWebhookEndpoint(pod, tlsConfigTestPermutation)).To(Succeed())
 		},
 			Entry("[test_id:9360] old", oldPermutation),
 			Entry("[test_id:9276] intermediate", intermediatePermutation),
@@ -175,7 +175,7 @@ func getCaCertificate() []byte {
 	return ca
 }
 
-func tryToAccessEndpoint(pod core.Pod, subpath string, port uint16, tlsConfig clientTLSOptions) (attemptedUrl string, err error) {
+func tryToAccessEndpoint(pod core.Pod, serviceName string, subpath string, port uint16, tlsConfig clientTLSOptions) (attemptedUrl string, err error) {
 	conn, err := portForwarder.Connect(&pod, port)
 	Expect(err).ToNot(HaveOccurred())
 	defer conn.Close()
@@ -196,41 +196,58 @@ func tryToAccessEndpoint(pod core.Pod, subpath string, port uint16, tlsConfig cl
 		subpath = "/" + subpath
 	}
 
-	// ${webhookServiceName}.${deploymentNamespace}.svc is used to access the endpoints we are testing.
-	// It is used here for the metrics as well for simplicity, as it is the CN in the ca_cert
-	// and the metrics just sit on a different port on the same pod.
-	attemptedUrl = fmt.Sprintf("https://%s.%s.svc:%d%s", strategy.GetSSPWebhookServiceName(), strategy.GetSSPDeploymentNameSpace(), port, subpath)
+	// ${serviceName}.${serviceNamespace}.svc is used to access the endpoints we are testing.
+	attemptedUrl = fmt.Sprintf("https://%s.%s.svc:%d%s", serviceName, pod.Namespace, port, subpath)
 	_, err = httpClient.Get(attemptedUrl)
 	return attemptedUrl, err
 }
 
-func (c tlsConfigTestPermutation) testTLSEndpointAccessible(pod core.Pod, subpath string, port uint16, tlsConfig clientTLSOptions) {
-	_, err := tryToAccessEndpoint(pod, subpath, port, tlsConfig)
-	Expect(err).ToNot(HaveOccurred(), "Can't access pod %s, at port %d, with tlsConfig %#v", pod.Name, port, tlsConfig)
+func (c tlsConfigTestPermutation) testTLSEndpointAccessible(pod core.Pod, serviceName string, subpath string, port uint16, tlsConfig clientTLSOptions) error {
+	_, err := tryToAccessEndpoint(pod, serviceName, subpath, port, tlsConfig)
+	if err != nil {
+		return fmt.Errorf("can't access pod %s, at port %d, with tlsConfig %#v: %w", pod.Name, port, tlsConfig, err)
+	}
+	return nil
 }
 
-func (c tlsConfigTestPermutation) testTLSEndpointNotAccessible(pod core.Pod, subpath string, port uint16, tlsConfig clientTLSOptions) {
-	attemptedUrl, err := tryToAccessEndpoint(pod, subpath, port, tlsConfig)
+func (c tlsConfigTestPermutation) testTLSEndpointNotAccessible(pod core.Pod, serviceName string, subpath string, port uint16, tlsConfig clientTLSOptions) error {
+	attemptedUrl, err := tryToAccessEndpoint(pod, serviceName, subpath, port, tlsConfig)
 	expectedErrString1 := fmt.Sprintf("Get \"%s\": remote error: tls: protocol version not supported", attemptedUrl)
 	expectedErrString2 := fmt.Sprintf("Get \"%s\": remote error: tls: handshake failure", attemptedUrl)
-	Expect(err).To(SatisfyAny(MatchError(expectedErrString1), MatchError(expectedErrString2)), "Should not have been able to access pod %s, at port %s, with tlsConfig %#v, %#v, %#v", pod.Name, port, tlsConfig, tlsConfig.MaxTLSVersion, tlsConfig.CipherIDs())
+
+	if err == nil {
+		return fmt.Errorf("should not have been able to access pod %s, at port %d, with tlsConfig %#v, %#v, %#v", pod.Name, port, tlsConfig, tlsConfig.MaxTLSVersion, tlsConfig.CipherIDs())
+	}
+	if err.Error() == expectedErrString1 || err.Error() == expectedErrString2 {
+		return nil
+	}
+	return fmt.Errorf("unexpected error when accessing endpoint: %w", err)
 }
 
-func (c tlsConfigTestPermutation) testEndpointAccessabilityWithTLS(pod core.Pod, subpath string, port uint16) {
+func (c tlsConfigTestPermutation) testEndpointAccessabilityWithTLS(pod core.Pod, serviceName string, subpath string, port uint16) error {
 	for _, config := range c.allowedConfigs {
-		c.testTLSEndpointAccessible(pod, subpath, port, config)
+		err := c.testTLSEndpointAccessible(pod, serviceName, subpath, port, config)
+		if err != nil {
+			return fmt.Errorf("failed accessing endpoint with allowed config: %w", err)
+		}
 	}
 	for _, config := range c.disallowedConfigs {
-		c.testTLSEndpointNotAccessible(pod, subpath, port, config)
+		err := c.testTLSEndpointNotAccessible(pod, serviceName, subpath, port, config)
+		if err != nil {
+			return fmt.Errorf("error when accessing endpoint with disallowed config: %w", err)
+		}
 	}
+	return nil
 }
 
-func testMetricsEndpoint(pod core.Pod, tlsConfig tlsConfigTestPermutation) {
-	tlsConfig.testEndpointAccessabilityWithTLS(pod, "metrics", 8443)
+func testMetricsEndpoint(pod core.Pod, tlsConfig tlsConfigTestPermutation) error {
+	// webhook service name is used here for the metrics for simplicity, as it is the CN in the ca_cert
+	// and the metrics just sit on a different port on the same pod.
+	return tlsConfig.testEndpointAccessabilityWithTLS(pod, strategy.GetSSPWebhookServiceName(), "metrics", 8443)
 }
 
-func testWebhookEndpoint(pod core.Pod, tlsConfig tlsConfigTestPermutation) {
-	tlsConfig.testEndpointAccessabilityWithTLS(pod, "", 9443)
+func testWebhookEndpoint(pod core.Pod, tlsConfig tlsConfigTestPermutation) error {
+	return tlsConfig.testEndpointAccessabilityWithTLS(pod, strategy.GetSSPWebhookServiceName(), "", 9443)
 }
 
 func applyTLSConfig(tlsSecurityProfile *ocpv1.TLSSecurityProfile) {

--- a/tests/crypto_policy_test.go
+++ b/tests/crypto_policy_test.go
@@ -7,9 +7,11 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	template_validator "kubevirt.io/ssp-operator/internal/operands/template-validator"
 
 	ocpv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/library-go/pkg/crypto"
@@ -109,9 +111,17 @@ var _ = Describe("Crypto Policy", func() {
 	Context("setting Crypto Policy", func() {
 		DescribeTable("Adhere to defined TLSConfig", func(tlsConfigTestPermutation tlsConfigTestPermutation) {
 			pod := operatorPod()
+			validatorPod := templateValidatorPod()
+
 			applyTLSConfig(tlsConfigTestPermutation.openshiftTLSPolicy)
 			Expect(testMetricsEndpoint(pod, tlsConfigTestPermutation)).To(Succeed())
 			Expect(testWebhookEndpoint(pod, tlsConfigTestPermutation)).To(Succeed())
+
+			// Using larger timeout, because it usually takes more than a minute
+			// for the ConfigMap to be propagated to the pod.
+			Eventually(func() error {
+				return testValidatorEndpoint(validatorPod, tlsConfigTestPermutation)
+			}, env.Timeout(), time.Second).Should(Succeed())
 		},
 			Entry("[test_id:9360] old", oldPermutation),
 			Entry("[test_id:9276] intermediate", intermediatePermutation),
@@ -127,6 +137,17 @@ func operatorPod() core.Pod {
 	Expect(err).ToNot(HaveOccurred())
 	Expect(pods.Items).ToNot(BeEmpty())
 	Expect(pods.Items).To(HaveLen(1))
+	return pods.Items[0]
+}
+
+func templateValidatorPod() core.Pod {
+	pods := &core.PodList{}
+	err := apiClient.List(context.TODO(), pods, client.MatchingLabels{
+		common.AppKubernetesNameLabel:      "template-validator",
+		common.AppKubernetesComponentLabel: string(common.AppComponentTemplating),
+	})
+	Expect(err).ToNot(HaveOccurred())
+	Expect(pods.Items).ToNot(BeEmpty())
 	return pods.Items[0]
 }
 
@@ -248,6 +269,10 @@ func testMetricsEndpoint(pod core.Pod, tlsConfig tlsConfigTestPermutation) error
 
 func testWebhookEndpoint(pod core.Pod, tlsConfig tlsConfigTestPermutation) error {
 	return tlsConfig.testEndpointAccessabilityWithTLS(pod, strategy.GetSSPWebhookServiceName(), "", 9443)
+}
+
+func testValidatorEndpoint(pod core.Pod, tlsConfig tlsConfigTestPermutation) error {
+	return tlsConfig.testEndpointAccessabilityWithTLS(pod, template_validator.ServiceName, "", 8443)
 }
 
 func applyTLSConfig(tlsSecurityProfile *ocpv1.TLSSecurityProfile) {

--- a/tests/validator_test.go
+++ b/tests/validator_test.go
@@ -57,6 +57,7 @@ var _ = Describe("Template validator operand", func() {
 		webhookConfigRes      testResource
 		serviceAccountRes     testResource
 		serviceRes            testResource
+		configMapRes          testResource
 		serviceMetricsRes     testResource
 		deploymentRes         testResource
 
@@ -118,6 +119,20 @@ var _ = Describe("Template validator operand", func() {
 				return reflect.DeepEqual(old.Spec, new.Spec)
 			},
 		}
+		configMapRes = testResource{
+			Name:           validator.ConfigMapName,
+			Namespace:      strategy.GetNamespace(),
+			Resource:       &core.ConfigMap{},
+			ExpectedLabels: expectedLabels,
+			UpdateFunc: func(configMap *core.ConfigMap) {
+				configMap.Data = nil
+			},
+			EqualsFunc: func(old *core.ConfigMap, new *core.ConfigMap) bool {
+				return reflect.DeepEqual(old.Immutable, new.Immutable) &&
+					reflect.DeepEqual(old.Data, new.Data) &&
+					reflect.DeepEqual(old.BinaryData, new.BinaryData)
+			},
+		}
 		serviceMetricsRes = testResource{
 			Name:           validator.MetricsServiceName,
 			Namespace:      strategy.GetNamespace(),
@@ -154,6 +169,7 @@ var _ = Describe("Template validator operand", func() {
 		},
 			Entry("[test_id:4910] service account", &serviceAccountRes),
 			Entry("[test_id:4911] service", &serviceRes),
+			Entry("[test_id:TODO] ConfigMap", &configMapRes),
 			Entry("[test_id:8366] metrics service", &serviceMetricsRes),
 			Entry("[test_id:4912] deployment", &deploymentRes),
 		)
@@ -164,6 +180,7 @@ var _ = Describe("Template validator operand", func() {
 			Entry("[test_id:5826]validating webhook configuration", &webhookConfigRes),
 			Entry("[test_id:6201]service account", &serviceAccountRes),
 			Entry("[test_id:5827]service", &serviceRes),
+			Entry("[test_id:TODO]ConfigMap", &configMapRes),
 			Entry("[test_id:8367]metrics service", &serviceMetricsRes),
 			Entry("[test_id:5828]deployment", &deploymentRes),
 		)
@@ -176,6 +193,7 @@ var _ = Describe("Template validator operand", func() {
 			Entry("[test_id:4918] validating webhook configuration", &webhookConfigRes),
 			Entry("[test_id:4920] service account", &serviceAccountRes),
 			Entry("[test_id:4922] service", &serviceRes),
+			Entry("[test_id:TODO] ConfigMap", &configMapRes),
 			Entry("[test_id:8370] metrics service", &serviceMetricsRes),
 			Entry("[test_id:4924] deployment", &deploymentRes),
 		)
@@ -187,6 +205,7 @@ var _ = Describe("Template validator operand", func() {
 			Entry("[test_id:4917] cluster role binding", &clusterRoleBindingRes),
 			Entry("[test_id:4919] validating webhook configuration", &webhookConfigRes),
 			Entry("[test_id:4923] service", &serviceRes),
+			Entry("[test_id:TODO] ConfigMap", &configMapRes),
 			Entry("[test_id:8371] metrics service", &serviceMetricsRes),
 			Entry("[test_id:4925] deployment", &deploymentRes),
 		)
@@ -205,6 +224,7 @@ var _ = Describe("Template validator operand", func() {
 				Entry("[test_id:5535] cluster role binding", &clusterRoleBindingRes),
 				Entry("[test_id:5536] validating webhook configuration", &webhookConfigRes),
 				Entry("[test_id:5538] service", &serviceRes),
+				Entry("[test_id:TODO] ConfigMap", &configMapRes),
 				Entry("[test_id:8368] metrics service", &serviceMetricsRes),
 				Entry("[test_id:5539] deployment", &deploymentRes),
 			)
@@ -215,6 +235,7 @@ var _ = Describe("Template validator operand", func() {
 			Entry("[test_id:6206] cluster role binding", &clusterRoleBindingRes),
 			Entry("[test_id:6207] validating webhook configuration", &webhookConfigRes),
 			Entry("[test_id:6208] service", &serviceRes),
+			Entry("[test_id:TODO] ConfigMap", &configMapRes),
 			Entry("[test_id:8369] metrics service", &serviceMetricsRes),
 			Entry("[test_id:6209] deployment", &deploymentRes),
 		)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR moves the TLS configuration of `template-validator` to a ConfigMap. It is mounded as a file in the pod, and validator is able to update its configuration without restarting the pod.

**Which issue(s) this PR fixes**: 
Jira: https://issues.redhat.com/browse/CNV-28716

**Release note**:
```release-note
None
```
