### PR TITLE
Fix flaky test fire VMStorageClassWarning when rxbounce is disabled

### DIFF
--- a/tests/tests_common_test.go
+++ b/tests/tests_common_test.go
@@ -18,6 +18,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/utils/ptr"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/controller-lifecycle-operator-sdk/api"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -362,7 +363,6 @@ func NewMinimalVMIWithNS(namespace, name string) *kubevirtv1.VirtualMachineInsta
 }
 
 func NewVirtualMachine(vmi *kubevirtv1.VirtualMachineInstance) *kubevirtv1.VirtualMachine {
-	running := false
 	name := vmi.Name
 	namespace := vmi.Namespace
 	vm := &kubevirtv1.VirtualMachine{
@@ -371,7 +371,7 @@ func NewVirtualMachine(vmi *kubevirtv1.VirtualMachineInstance) *kubevirtv1.Virtu
 			Namespace: namespace,
 		},
 		Spec: kubevirtv1.VirtualMachineSpec{
-			Running: &running,
+			RunStrategy: ptr.To(kubevirtv1.RunStrategyHalted),
 			Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels:    map[string]string{"kubevirt.io/vm": name},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Fix flaky test: [test_id:10549] Should fire VMStorageClassWarning when rxbounce is disabled

jira-ticket: https://issues.redhat.com/browse/CNV-47434

**Which issue(s) this PR fixes**: 
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
