### PR TITLE
[release-v0.18] Alert VMStorageClassWarning only for Windows VMs

### DIFF
--- a/internal/operands/metrics/resources.go
+++ b/internal/operands/metrics/resources.go
@@ -166,10 +166,10 @@ func getAlertRules() ([]promv1.Rule, error) {
 		},
 		{
 			Alert: "VMStorageClassWarning",
-			Expr:  intstr.FromString("(count(kubevirt_ssp_vm_rbd_block_volume_without_rxbounce > 0) or vector(0)) > 0"),
+			Expr:  intstr.FromString("(count(kubevirt_ssp_vm_rbd_block_volume_without_rxbounce * on(name, namespace) (kubevirt_vmi_info{guest_os_name=\"Microsoft Windows\"} > 0 or kubevirt_vmi_info{os=~\"windows.*\"} > 0) > 0) or vector(0)) > 0"),
 			Annotations: map[string]string{
-				"description": "{{ $value }} Virtual Machines are in risk of causing CRC errors and major service outages",
-				"summary":     "When running VMs using ODF storage with 'rbd' mounter or 'rbd.csi.ceph.com provisioner', it will report bad crc/signature errors and cluster performance will be severely degraded if krbd:rxbounce is not set.",
+				"summary":     "{{ $value }} Windows Virtual Machines may cause reports of bad crc/signature errors due to certain I/O patterns.",
+				"description": "When running Windows VMs using ODF storage with 'rbd' mounter or 'rbd.csi.ceph.com provisioner', VMs may cause reports of bad crc/signature errors due to certain I/O patterns. Cluster performance can be severely degraded if the number of re-transmissions due to crc errors causes network saturation.",
 				"runbook_url": fmt.Sprintf(runbookURLTemplate, "VMStorageClassWarning"),
 			},
 			Labels: map[string]string{

--- a/tests/monitoring_test.go
+++ b/tests/monitoring_test.go
@@ -276,7 +276,7 @@ var _ = Describe("Prometheus Alerts", func() {
 			alertShouldNotBeActive("VMStorageClassWarning")
 		})
 
-		It("[test_id:TODO] Should fire VMStorageClassWarning when rxbounce is disabled", func() {
+		PIt("[test_id:TODO] Should fire VMStorageClassWarning when rxbounce is disabled", func() {
 			vmName := createResources(true, false)
 			waitForSeriesToBeDetected(fmt.Sprintf("kubevirt_ssp_vm_rbd_block_volume_without_rxbounce{name='%s'} == 1", vmName))
 			waitForAlertToActivate("VMStorageClassWarning")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This is a manual cherry-pick of #984

**Which issue(s) this PR fixes**: 
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

Fixes #

jira-ticket: https://issues.redhat.com/browse/CNV-50785

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Alert VMStorageClassWarning only for Windows VMs
```
