### PR TITLE
makefile: use the same ginkgo version that is in go.mod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,8 @@ unittest: generate lint fmt vet manifests metrics-rules-test lint-monitoring
 build-functests:
 	go test -c ./tests
 
-GINKGO_VERSION ?= v2.17.1
+GOMOD_PATH ?= ./go.mod
+GINKGO_VERSION ?= $(shell grep -E '^\s*github\.com/onsi/ginkgo/v[0-9]+' $(GOMOD_PATH) | awk '{print $$2}')
 GINKGO_TIMEOUT ?= 2h
 
 .PHONY: ginkgo


### PR DESCRIPTION
**What this PR does / why we need it**:
Use the same ginkgo version in `Makefile` that is in `go.mod`.

**Release note**:
```release-note
None
```
