### PR TITLE
chore: Allow dependabot to update ginkgo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,6 @@ updates:
       interval: "daily"
     allow:
       - dependency-type: "all"
-    ignore:
-      # Ginkgo update needs a change in Makefile.
-      - dependency-name: "github.com/onsi/ginkgo/v2"
     groups:
       production-dependencies:
         dependency-type: "production"


### PR DESCRIPTION
**What this PR does / why we need it**:
Updated dependabot config to allow updating ginkgo.
The ignore config did not work.

Makefile was changed to read ginkgo version from go.mod

**Release note**:
```release-note
None
```
