### PR TITLE
test: delete ssp deployment after end-to-end tests

### DIFF
--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -155,6 +155,10 @@ func (s *newSspStrategy) Cleanup() {
 
 	waitForDeletion(client.ObjectKey{Name: s.GetNamespace()}, &v1.Namespace{})
 	waitForDeletion(client.ObjectKey{Name: s.GetTemplatesNamespace()}, &v1.Namespace{})
+
+	err_ssp_deployment := apiClient.Delete(ctx, &apps.Deployment{ObjectMeta: metav1.ObjectMeta{Name: sspDeploymentName, Namespace: sspDeploymentNamespace}})
+	expectSuccessOrNotFound(err_ssp_deployment)
+	waitForDeletion(client.ObjectKey{Name: sspDeploymentName, Namespace: sspDeploymentNamespace}, &apps.Deployment{})
 }
 
 func (s *newSspStrategy) GetName() string {


### PR DESCRIPTION
Experiments indicate that certain tests require a fresh environment to yield reliable and consistent results. One potential solution is to remove the SSP deployment during the cleanup phase, but only if the "skip cleanup" flag is not set.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**: 
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
