### PR TITLE
feat: architecture dependent template reading

### DIFF
--- a/internal/template-bundle/bundle_test.go
+++ b/internal/template-bundle/bundle_test.go
@@ -1,48 +1,59 @@
 package template_bundle
 
 import (
+	"runtime"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
+func retrieveSuffix() string {
+	switch runtime.GOARCH {
+	case "s390x":
+		return "-s390x"
+	default:
+		return ""
+	}
+}
+
 var _ = Describe("Template bundle", Ordered, func() {
 	var (
 		testBundle Bundle
+		nameSuffix string
 	)
 
 	BeforeAll(func() {
 		var err error
 		testBundle, err = ReadBundle("template-bundle-test.yaml")
 		Expect(err).ToNot(HaveOccurred())
+		nameSuffix = retrieveSuffix()
 	})
 
 	It("should correctly read templates", func() {
 		templates := testBundle.Templates
 		Expect(templates).To(HaveLen(4))
-
 		{
 			templ := templates[0]
-			Expect(templ.Name).To(Equal("centos-stream8-server-medium"))
+			Expect(templ.Name).To(Equal("centos-stream8-server-medium" + nameSuffix))
 			Expect(templ.Annotations).To(HaveKey("name.os.template.kubevirt.io/centos-stream8"))
 			Expect(templ.Objects).To(HaveLen(1))
 		}
 		{
 			templ := templates[1]
-			Expect(templ.Name).To(Equal("centos-stream8-desktop-large"))
+			Expect(templ.Name).To(Equal("centos-stream8-desktop-large" + nameSuffix))
 			Expect(templ.Annotations).To(HaveKey("name.os.template.kubevirt.io/centos-stream8"))
 			Expect(templ.Objects).To(HaveLen(1))
 		}
 		{
 			templ := templates[2]
-			Expect(templ.Name).To(Equal("windows10-desktop-medium"))
+			Expect(templ.Name).To(Equal("windows10-desktop-medium" + nameSuffix))
 			Expect(templ.Annotations).To(HaveKey("name.os.template.kubevirt.io/win10"))
 			Expect(templ.Objects).To(HaveLen(1))
 		}
 		{
 			templ := templates[3]
-			Expect(templ.Name).To(Equal("rhel8-saphana-tiny"))
+			Expect(templ.Name).To(Equal("rhel8-saphana-tiny" + nameSuffix))
 			Expect(templ.Annotations).To(HaveKey("name.os.template.kubevirt.io/rhel8.4"))
 			Expect(templ.Objects).To(HaveLen(1))
 		}

--- a/internal/template-bundle/template-bundle-test.yaml
+++ b/internal/template-bundle/template-bundle-test.yaml
@@ -80,6 +80,7 @@ objects:
             kubevirt.io/domain: ${NAME}
             kubevirt.io/size: medium
         spec:
+          architecture: amd64
           domain:
             cpu:
               sockets: 1
@@ -212,6 +213,7 @@ objects:
             kubevirt.io/domain: ${NAME}
             kubevirt.io/size: large
         spec:
+          architecture: amd64
           domain:
             cpu:
               sockets: 2
@@ -370,6 +372,7 @@ objects:
             kubevirt.io/domain: ${NAME}
             kubevirt.io/size: medium
         spec:
+          architecture: amd64
           domain:
             clock:
               utc: {}
@@ -510,6 +513,655 @@ objects:
             kubevirt.io/domain: ${NAME}
             kubevirt.io/size: tiny
         spec:
+          architecture: amd64
+          hostname: ${NAME}
+          domain:
+            ioThreadsPolicy: auto
+            cpu:
+              cores: ${{CPU_CORES}}
+              threads: ${{CPU_THREADS}}
+              sockets: ${{CPU_SOCKETS}}
+              model: host-passthrough
+              isolateEmulatorThread: true
+              dedicatedCpuPlacement: true
+              features:
+                - name: "invtsc"
+                  policy: "require"
+              numa:
+                guestMappingPassthrough : {}
+            devices:
+              blockMultiQueue: true
+              networkInterfaceMultiqueue: true
+              disks:
+                - disk:
+                    bus: virtio
+                  dedicatedIOThread: true
+                  name: ${NAME}
+                - disk:
+                    bus: virtio
+                  name: cloudinitdisk
+                - disk:
+                    bus: virtio
+                  name: downwardmetrics
+              interfaces:
+                - masquerade: {}
+                  name: default
+                  model: virtio
+                - name: sriov-net1
+                  sriov: {}
+                  model: virtio
+                - name: sriov-net2
+                  sriov: {}
+                  model: virtio
+                - name: sriov-net3
+                  sriov: {}
+                  model: virtio
+            machine:
+              type: ""
+            resources:
+              requests:
+                memory: ${MEMORY_OVERHEAD}
+            memory:
+              guest: ${MEMORY}
+              hugepages:
+                pageSize: ${HUGEPAGES_PAGE_SIZE}
+          terminationGracePeriodSeconds: 3600
+          volumes:
+            - dataVolume:
+                name: ${NAME}
+              name: ${NAME}
+            - cloudInitNoCloud:
+                userData: |-
+                  #cloud-config
+                  user: cloud-user
+                  password: ${CLOUD_USER_PASSWORD}
+                  chpasswd: { expire: False }
+              name: cloudinitdisk
+            - downwardMetrics: {}
+              name: downwardmetrics
+          networks:
+            - name: default
+              pod: {}
+            - multus:
+                networkName: ${SRIOV_NETWORK_NAME1}
+              name: sriov-net1
+            - multus:
+                networkName: ${SRIOV_NETWORK_NAME2}
+              name: sriov-net2
+            - multus:
+                networkName: ${SRIOV_NETWORK_NAME3}
+              name: sriov-net3
+          nodeSelector:
+            kubernetes.io/hostname: ${TARGET_NODE_NAME}
+parameters:
+  - description: Name for the new VM
+    displayName: Name
+    name: NAME
+    required: true
+  - description: Name of the node where this VM needs to run
+    displayName: Target Node
+    name: TARGET_NODE_NAME
+    required: true
+  - description: Amount of memory
+    displayName: Memory
+    name: MEMORY
+    value: 24Gi
+  - description: Amount of memory overhead for qemu
+    displayName: Memory Overhead
+    name: MEMORY_OVERHEAD
+    value: 44Gi
+  - description: Amount of cores
+    displayName: CPU Cores
+    name: CPU_CORES
+    value: "4"
+  - description: Amount of threads
+    displayName: CPU Threads
+    name: CPU_THREADS
+    value: "1"
+  - description: Amount of sockets
+    displayName: CPU Sockets
+    name: CPU_SOCKETS
+    value: "1"
+  - description: Name of the SR-IOV network1
+    displayName: SR-IOV network1
+    name: SRIOV_NETWORK_NAME1
+    value: "default/sriov-net1"
+  - description: Name of the SR-IOV network2
+    displayName: SR-IOV network2
+    name: SRIOV_NETWORK_NAME2
+    value: "default/sriov-net2"
+  - description: Name of the SR-IOV network3
+    displayName: SR-IOV network3
+    name: SRIOV_NETWORK_NAME3
+    value: "default/sriov-net3"
+  - description: Page size of huge pages
+    displayName: Huge page size
+    name: HUGEPAGES_PAGE_SIZE
+    value: "1Gi"
+  - name: SRC_CONTAINERDISK
+    description: Name of the source container disk to import
+    displayName: Source container disk
+    value: "docker://registry.access.redhat.com/rhel8/rhel-guest-image:8.4.0"
+  - description: Randomized password for the cloud-init user cloud-user
+    displayName: Cloud user password
+    from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+    generate: expression
+    name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/centos-stream8-server-medium-s390x.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: centos-stream8-server-medium-s390x
+  annotations:
+    openshift.io/display-name: "CentOS Stream 8 VM"
+    description: >-
+      Template for CentOS Stream 8 VM or newer.
+      A PVC with the CentOS Stream disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,linux,centosstream"
+    iconClass: "icon-centos"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/centos-stream8: CentOS Stream 8 or higher
+  labels:
+    os.template.kubevirt.io/centos-stream8: "true"
+    workload.template.kubevirt.io/server: "true"
+    flavor.template.kubevirt.io/medium: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.19.0"
+objects:
+  - apiVersion: kubevirt.io/v1
+    kind: VirtualMachine
+    metadata:
+      name: ${NAME}
+      labels:
+        vm.kubevirt.io/template: centos-stream8-server-medium-s390x
+        vm.kubevirt.io/template.version: "v0.19.0"
+        vm.kubevirt.io/template.revision: "23"
+        app: ${NAME}
+      annotations:
+        vm.kubevirt.io/validations: |
+          [
+            {
+              "name": "minimal-required-memory",
+              "path": "jsonpath::.spec.domain.resources.requests.memory",
+              "rule": "integer",
+              "message": "This VM requires more memory.",
+              "min": 1610612736
+            }
+          ]
+    spec:
+      dataVolumeTemplates:
+        - apiVersion: cdi.kubevirt.io/v1beta1
+          kind: DataVolume
+          metadata:
+            name: ${NAME}
+          spec:
+            storage:
+              resources:
+                requests:
+                  storage: 30Gi
+            sourceRef:
+              kind: DataSource
+              name: ${SRC_PVC_NAME}
+              namespace: ${SRC_PVC_NAMESPACE}
+      running: false
+      template:
+        metadata:
+          annotations:
+            vm.kubevirt.io/os: "centos-stream8"
+            vm.kubevirt.io/workload: "server"
+            vm.kubevirt.io/flavor: "medium"
+          labels:
+            kubevirt.io/domain: ${NAME}
+            kubevirt.io/size: medium
+        spec:
+          architecture: s390x
+          domain:
+            cpu:
+              sockets: 1
+              cores: 1
+              threads: 1
+            resources:
+              requests:
+                memory: 4Gi
+            devices:
+              rng: {}
+              networkInterfaceMultiqueue: true
+              disks:
+                - disk:
+                    bus: virtio
+                  name: ${NAME}
+                - disk:
+                    bus: virtio
+                  name: cloudinitdisk
+              interfaces:
+                - masquerade: {}
+                  name: default
+          terminationGracePeriodSeconds: 180
+          networks:
+            - name: default
+              pod: {}
+          volumes:
+            - dataVolume:
+                name: ${NAME}
+              name: ${NAME}
+            - cloudInitNoCloud:
+                userData: |-
+                  #cloud-config
+                  user: centos
+                  password: ${CLOUD_USER_PASSWORD}
+                  chpasswd: { expire: False }
+              name: cloudinitdisk
+parameters:
+  - description: VM name
+    from: 'centos-stream8-[a-z0-9]{16}'
+    generate: expression
+    name: NAME
+  - name: SRC_PVC_NAME
+    description: Name of the DataSource to clone
+    value: 'centos-stream8'
+  - name: SRC_PVC_NAMESPACE
+    description: Namespace of the DataSource
+    value: kubevirt-os-images
+  - description: Randomized password for the cloud-init user centos
+    from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+    generate: expression
+    name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/centos-stream8-desktop-large-s390x.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: centos-stream8-desktop-large-s390x
+  annotations:
+    openshift.io/display-name: "CentOS Stream 8 VM"
+    description: >-
+      Template for CentOS Stream 8 VM or newer.
+      A PVC with the CentOS Stream disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,linux,centosstream"
+    iconClass: "icon-centos"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/centos-stream8: CentOS Stream 8 or higher
+  labels:
+    os.template.kubevirt.io/centos-stream8: "true"
+    workload.template.kubevirt.io/desktop: "true"
+    flavor.template.kubevirt.io/large: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.19.1"
+objects:
+  - apiVersion: kubevirt.io/v1
+    kind: VirtualMachine
+    metadata:
+      name: ${NAME}
+      labels:
+        vm.kubevirt.io/template: centos-stream8-desktop-large-s390x
+        vm.kubevirt.io/template.version: "v0.19.1"
+        vm.kubevirt.io/template.revision: "1"
+        app: ${NAME}
+      annotations:
+        vm.kubevirt.io/validations: |
+          [
+            {
+              "name": "minimal-required-memory",
+              "path": "jsonpath::.spec.domain.resources.requests.memory",
+              "rule": "integer",
+              "message": "This VM requires more memory.",
+              "min": 1610612736
+            }
+          ]
+    spec:
+      dataVolumeTemplates:
+        - apiVersion: cdi.kubevirt.io/v1beta1
+          kind: DataVolume
+          metadata:
+            name: ${NAME}
+          spec:
+            storage:
+              resources:
+                requests:
+                  storage: 30Gi
+            sourceRef:
+              kind: DataSource
+              name: ${SRC_PVC_NAME}
+              namespace: ${SRC_PVC_NAMESPACE}
+      running: false
+      template:
+        metadata:
+          annotations:
+            vm.kubevirt.io/os: "centos-stream8"
+            vm.kubevirt.io/workload: "desktop"
+            vm.kubevirt.io/flavor: "large"
+          labels:
+            kubevirt.io/domain: ${NAME}
+            kubevirt.io/size: large
+        spec:
+          architecture: s390x
+          domain:
+            cpu:
+              sockets: 2
+              cores: 1
+              threads: 1
+            resources:
+              requests:
+                memory: 8Gi
+            devices:
+              rng: {}
+              networkInterfaceMultiqueue: true
+              inputs:
+                - type: tablet
+                  bus: virtio
+                  name: tablet
+              disks:
+                - disk:
+                    bus: virtio
+                  name: ${NAME}
+                - disk:
+                    bus: virtio
+                  name: cloudinitdisk
+              interfaces:
+                - masquerade: {}
+                  name: default
+          terminationGracePeriodSeconds: 180
+          networks:
+            - name: default
+              pod: {}
+          volumes:
+            - dataVolume:
+                name: ${NAME}
+              name: ${NAME}
+            - cloudInitNoCloud:
+                userData: |-
+                  #cloud-config
+                  user: centos
+                  password: ${CLOUD_USER_PASSWORD}
+                  chpasswd: { expire: False }
+              name: cloudinitdisk
+parameters:
+  - description: VM name
+    from: 'centos-stream8-[a-z0-9]{16}'
+    generate: expression
+    name: NAME
+  - name: SRC_PVC_NAME
+    description: Name of the DataSource to clone
+    value: 'centos-stream8'
+  - name: SRC_PVC_NAMESPACE
+    description: Namespace of the DataSource
+    value: kubevirt-os-images
+  - description: Randomized password for the cloud-init user centos
+    from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+    generate: expression
+    name: CLOUD_USER_PASSWORD
+---
+# Source: dist/templates/windows10-desktop-medium-s390x.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: windows10-desktop-medium-s390x
+  annotations:
+    openshift.io/display-name: "Microsoft Windows 10 VM"
+    description: >-
+      Template for Microsoft Windows 10 VM.
+      A PVC with the Windows disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,windows"
+    iconClass: "icon-windows"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    defaults.template.kubevirt.io/network: default
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/win10: Microsoft Windows 10
+  labels:
+    os.template.kubevirt.io/win10: "true"
+    workload.template.kubevirt.io/desktop: "true"
+    flavor.template.kubevirt.io/medium: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.17.0"
+    template.kubevirt.io/default-os-variant: "true"
+objects:
+  - apiVersion: kubevirt.io/v1
+    kind: VirtualMachine
+    metadata:
+      name: ${NAME}
+      labels:
+        vm.kubevirt.io/template: windows10-desktop-medium-s390x
+        vm.kubevirt.io/template.version: "v0.17.0"
+        vm.kubevirt.io/template.revision: "1"
+        app: ${NAME}
+      annotations:
+        vm.kubevirt.io/validations: |
+          [
+            {
+              "name": "minimal-required-memory",
+              "path": "jsonpath::.spec.domain.resources.requests.memory",
+              "rule": "integer",
+              "message": "This VM requires more memory.",
+              "min": 2147483648
+            }, {
+              "name": "windows-virtio-bus",
+              "path": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+              "valid": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+              "rule": "enum",
+              "message": "virto disk bus type has better performance, install virtio drivers in VM and change bus type",
+              "values": ["virtio"],
+              "justWarning": true
+            }, {
+              "name": "windows-disk-bus",
+              "path": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+              "valid": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+              "rule": "enum",
+              "message": "disk bus has to be either virtio or sata or scsi",
+              "values": ["virtio", "sata", "scsi"]
+            }, {
+              "name": "windows-cd-bus",
+              "path": "jsonpath::.spec.domain.devices.disks[*].cdrom.bus",
+              "valid": "jsonpath::.spec.domain.devices.disks[*].cdrom.bus",
+              "rule": "enum",
+              "message": "cd bus has to be sata",
+              "values": ["sata"]
+            }
+          ]
+    spec:
+      dataVolumeTemplates:
+        - apiVersion: cdi.kubevirt.io/v1beta1
+          kind: DataVolume
+          metadata:
+            name: ${NAME}
+          spec:
+            storage:
+              resources:
+                requests:
+                  storage: 60Gi
+            sourceRef:
+              kind: DataSource
+              name: ${SRC_PVC_NAME}
+              namespace: ${SRC_PVC_NAMESPACE}
+      running: false
+      template:
+        metadata:
+          annotations:
+            vm.kubevirt.io/os: "windows10"
+            vm.kubevirt.io/workload: "desktop"
+            vm.kubevirt.io/flavor: "medium"
+          labels:
+            kubevirt.io/domain: ${NAME}
+            kubevirt.io/size: medium
+        spec:
+          architecture: s390x
+          domain:
+            clock:
+              utc: {}
+              timer:
+                hpet:
+                  present: false
+                pit:
+                  tickPolicy: delay
+                rtc:
+                  tickPolicy: catchup
+                hyperv: {}
+            cpu:
+              sockets: 1
+              cores: 1
+              threads: 1
+            resources:
+              requests:
+                memory: 4Gi
+            features:
+              acpi: {}
+              apic: {}
+              hyperv:
+                relaxed: {}
+                vapic: {}
+                vpindex: {}
+                spinlocks:
+                  spinlocks: 8191
+                synic: {}
+                synictimer:
+                  direct: {}
+                tlbflush: {}
+                frequencies: {}
+                reenlightenment: {}
+                ipi: {}
+                runtime: {}
+                reset: {}
+            devices:
+              disks:
+                - disk:
+                    bus: sata
+                  name: ${NAME}
+              interfaces:
+                - masquerade: {}
+                  model: e1000e
+                  name: default
+              inputs:
+                - type: tablet
+                  bus: usb
+                  name: tablet
+          terminationGracePeriodSeconds: 3600
+          volumes:
+            - dataVolume:
+                name: ${NAME}
+              name: ${NAME}
+          networks:
+            - name: default
+              pod: {}
+parameters:
+  - name: NAME
+    description: VM name
+    generate: expression
+    from: "windows-[a-z0-9]{6}"
+  - name: SRC_PVC_NAME
+    description: Name of the DataSource to clone
+    value: win10
+  - name: SRC_PVC_NAMESPACE
+    description: Namespace of the DataSource
+    value: kubevirt-os-images
+---
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: rhel8-saphana-tiny-s390x
+  annotations:
+    openshift.io/display-name: "Red Hat Enterprise Linux 8.4 VM for SAP HANA workloads"
+    description: >-
+      Template for Red Hat Enterprise Linux 8.4 for SAP HANA workloads.
+      Please consult the SAP HANA guide for node setup requirements.
+    tags: "hidden,kubevirt,virtualmachine,linux,rhel,sap,hana"
+    iconClass: "icon-rhel"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    name.os.template.kubevirt.io/rhel8.4: Red Hat Enterprise Linux 8.0 or higher
+  labels:
+    os.template.kubevirt.io/rhel8.4: "true"
+    workload.template.kubevirt.io/saphana: "true"
+    flavor.template.kubevirt.io/tiny: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.18.1"
+objects:
+  - apiVersion: kubevirt.io/v1
+    kind: VirtualMachine
+    metadata:
+      labels:
+        vm.kubevirt.io/template: rhel8-saphana-tiny-s390x
+        vm.kubevirt.io/template.version: "v0.18.1"
+        vm.kubevirt.io/template.revision: "4"
+        app: ${NAME}
+      name: ${NAME}
+      annotations:
+        vm.kubevirt.io/validations: |
+          [
+             {
+               "name": "minimal-required-memory",
+               "path": "jsonpath::.spec.domain.resources.requests.memory",
+               "rule": "integer",
+               "message": "This VM requires more memory.",
+               "min": 1610612736
+             }
+          ]
+    spec:
+      dataVolumeTemplates:
+        - apiVersion: cdi.kubevirt.io/v1beta1
+          kind: DataVolume
+          metadata:
+            name: ${NAME}
+          spec:
+            storage:
+              resources:
+                requests:
+                  storage: 50Gi
+            source:
+              registry:
+                url: ${SRC_CONTAINERDISK}
+                pullMethod: node
+      running: false
+      template:
+        metadata:
+          annotations:
+            vm.kubevirt.io/os: "rhel8"
+            vm.kubevirt.io/workload: "saphana"
+            vm.kubevirt.io/flavor: "tiny"
+          labels:
+            kubevirt.io/domain: ${NAME}
+            kubevirt.io/size: tiny
+        spec:
+          architecture: s390x
           hostname: ${NAME}
           domain:
             ioThreadsPolicy: auto

--- a/tests/commonTemplates_test.go
+++ b/tests/commonTemplates_test.go
@@ -22,7 +22,7 @@ import (
 func createTestTemplate() testResource {
 	expectedLabels := expectedLabelsFor("common-templates", common.AppComponentTemplating)
 	return testResource{
-		Name:           "rhel8-desktop-tiny",
+		Name:           "rhel8-desktop-tiny" + templatesSuffix,
 		Namespace:      strategy.GetTemplatesNamespace(),
 		Resource:       &templatev1.Template{},
 		ExpectedLabels: expectedLabels,


### PR DESCRIPTION
This change requires templates to define their architecture.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: s390x enablement

**Which issue(s) this PR fixes**: 
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
