### PR TITLE
fix: test: Prepare SSP object for TLS policy tests

### DIFF
--- a/tests/crypto_policy_test.go
+++ b/tests/crypto_policy_test.go
@@ -102,6 +102,10 @@ var _ = Describe("Crypto Policy", func() {
 
 	BeforeEach(func() {
 		strategy.SkipSspUpdateTestsIfNeeded()
+
+		updateSsp(func(foundSsp *ssp.SSP) {
+			foundSsp.Spec.TLSSecurityProfile = nil
+		})
 		waitUntilDeployed()
 	})
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Before running these tests, the SSP should not have any TLS policy defined. The tests wait for reconciliation, and it would not happen if the same TLS policy is already defined on SSP.

**Which issue(s) this PR fixes**: 
Jira: https://issues.redhat.com/browse/CNV-47164

**Release note**:
```release-note
None
```
