### PR TITLE
makefile: Fix podman manifest push command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,7 +205,7 @@ container-build: unittest bundle
 # Push the container image
 .PHONY: container-push
 container-push:
-	podman manifest push ${IMG}
+	podman manifest push ${IMG} ${IMG}
 
 .PHONY: build-template-validator
 build-template-validator:
@@ -219,7 +219,7 @@ build-template-validator-container:
 
 .PHONY: push-template-validator-container
 push-template-validator-container:
-	podman manifest push ${VALIDATOR_IMG}
+	podman manifest push ${VALIDATOR_IMG} ${VALIDATOR_IMG}
 
 
 ##@ Build Dependencies


### PR DESCRIPTION
**What this PR does / why we need it**:
On older versions of podman, the command requires 2 arguments. We need it for the release workflow that runs Ubuntu 22.04 with podman v3.4.4.

Because of this issue, uploading release manifests to Quay failed for `v0.22.0` release.

**Release note**:
```release-note
None
```
