### PR TITLE
renovate: not update gomodules.xyz/jsonpatch/v2

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "baseBranches": ["main", "release-v0.20", "release-v0.19", "release-v0.18"],
-  "constraints": {
-    "go": "1.22"
-  },
   "prConcurrentLimit": 3,
   "groupName": "all dependencies",
   "groupSlug": "all",

--- a/renovate.json
+++ b/renovate.json
@@ -18,10 +18,12 @@
       "groupName": "all dependencies",
       "groupSlug": "all",
       "matchBaseBranches": ["main"],
-      "enabled": false,
       "matchPackagePatterns": [
         "*"
       ]
+    },{
+      "enabled": false,
+      "matchPackageNames": ["gomodules.xyz/jsonpatch/v2"]
     }, {
       "enabled": false,
       "matchBaseBranches": ["release-v0.20", "release-v0.19", "release-v0.18"],


### PR DESCRIPTION
The new upcomming version of k8s.io/apimachinery would enforce an update of the golang version. So let's delay updating the dependency until we want to pick up golang 1.23 .

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

gomodules.xyz/jsonpatch/v2 seems to confuse renovate which lead to invalid PRs.

**Which issue(s) this PR fixes**: 
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

I hope it fixes https://github.com/kubevirt/ssp-operator/pull/1109 .

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
NONE
