### PR TITLE
tests: Increase timeout waiting for SSP deployment to be ready.

### DIFF
--- a/tests/monitoring_test.go
+++ b/tests/monitoring_test.go
@@ -157,7 +157,7 @@ var _ = Describe("Prometheus Alerts", func() {
 			Eventually(func() int32 {
 				Expect(apiClient.Get(ctx, sspDeploymentKeys, deployment)).ToNot(HaveOccurred())
 				return deployment.Status.ReadyReplicas
-			}, env.ShortTimeout(), time.Second).Should(Equal(origReplicas))
+			}, env.Timeout(), time.Second).Should(Equal(origReplicas))
 		})
 
 		It("[test_id:8365] Should fire SSPDown", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
The test scales SSP deployment down and then scales it back up. It was probably failing because one minute was not enough time to become ready.

**Release note**:
```release-note
None
```
