### PR TITLE
feat: disable renovate's regular dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,6 +18,7 @@
       "groupName": "all dependencies",
       "groupSlug": "all",
       "matchBaseBranches": ["main"],
+      "enabled": false,
       "matchPackagePatterns": [
         "*"
       ]


### PR DESCRIPTION
**What this PR does / why we need it**:
feat: disable renovate's regular dependency updates

Renovate does not work well with go dependencies.
This commit disables them, but keeps only security updates

**Release note**:
```
NONE
```
