### PR TITLE
feat: Update golang version to 1.23.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ARG TARGET_ARCH
 RUN microdnf install -y make tar gzip which && microdnf clean all
 
 RUN ARCH=$(uname -m | sed 's/x86_64/amd64/') && \
-    curl -L https://go.dev/dl/go1.22.4.linux-${ARCH}.tar.gz -o go.tar.gz && \
+    curl -L https://go.dev/dl/go1.23.2.linux-${ARCH}.tar.gz -o go.tar.gz && \
     tar -C /usr/local -xzf go.tar.gz && \
     rm go.tar.gz
 

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module kubevirt.io/ssp-operator/api
 
-go 1.22.9
+go 1.23.2
 
 require (
 	github.com/openshift/api v0.0.0-20240702171116-4b89b3a92a17 // release-4.16

--- a/ci-builder/Dockerfile
+++ b/ci-builder/Dockerfile
@@ -1,7 +1,7 @@
 # This Dockerfile is used in openshift CI
 FROM quay.io/fedora/fedora:40
 
-RUN curl -L https://go.dev/dl/go1.22.4.linux-amd64.tar.gz | tar -C /usr/local -xzf -
+RUN curl -L https://go.dev/dl/go1.23.2.linux-amd64.tar.gz | tar -C /usr/local -xzf -
 ENV PATH=$PATH:/usr/local/go/bin
 
 # Install dependencies and tools

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module kubevirt.io/ssp-operator
 
-go 1.22.9
+go 1.23.2
 
 require (
 	github.com/blang/semver/v4 v4.0.0

--- a/validator.Dockerfile
+++ b/validator.Dockerfile
@@ -11,7 +11,7 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal as builder
 ARG TARGET_ARCH
 
 RUN microdnf install -y make tar gzip which && microdnf clean all
-RUN export ARCH=$(uname -m | sed 's/x86_64/amd64/'); curl -L https://go.dev/dl/go1.22.4.linux-${ARCH}.tar.gz | tar -C /usr/local -xzf -
+RUN export ARCH=$(uname -m | sed 's/x86_64/amd64/'); curl -L https://go.dev/dl/go1.23.2.linux-${ARCH}.tar.gz | tar -C /usr/local -xzf -
 ENV PATH=$PATH:/usr/local/go/bin
 
 ARG VERSION=latest

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1032,7 +1032,7 @@ kubevirt.io/controller-lifecycle-operator-sdk/api
 kubevirt.io/qe-tools/pkg/ginkgo-reporters
 kubevirt.io/qe-tools/pkg/polarion-xml
 # kubevirt.io/ssp-operator/api v0.0.0 => ./api
-## explicit; go 1.22.9
+## explicit; go 1.23.2
 kubevirt.io/ssp-operator/api/v1beta2
 kubevirt.io/ssp-operator/api/v1beta3
 # kubevirt.io/vm-console-proxy/api v0.7.0


### PR DESCRIPTION
**What this PR does / why we need it**:
Downstream build now supports golang version 1.23.2.

This PR will unblock dependabot's PRs for automatic updates.

**Release note**:
```release-note
None
```
