### PR TITLE
doc: Update disclaimer in readTemplates

### DIFF
--- a/internal/template-bundle/bundle.go
+++ b/internal/template-bundle/bundle.go
@@ -73,9 +73,9 @@ func readTemplates(filename string) ([]templatev1.Template, error) {
 		if !ok {
 			return nil, err
 		}
-		// DISCLAIMER: This is a temporary solution for delivering templates related to the host architecture.
-		// Once the common templates are released based on architecture, this change will no longer be necessary.
-		// Instead, a modification will be required in setup.go to specify the bundle to read from.
+		// The template bundles are delivered separately based on architecture.
+		// However, in cases where the generic template bundle includes architectures that are
+		// not released separately, this filter can still be useful.
 		if templateArch == runtime.GOARCH {
 			bundle = append(bundle, template)
 		}


### PR DESCRIPTION
This update explains why the check of the teamplateArch is still needed. It maintains compatibility in case changes for other architectures are delivered solely through the generic common templates.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
