### PR TITLE
do-not-merge: test the arch of the images with Ubuntu latest

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -41,3 +41,25 @@ jobs:
         go-version-file: 'go.mod'
     - name: Check commited files
       run: hack/check-commited-changes.sh
+
+  publish_operator_image-test-only:
+    name: Publish images to a local repo (test only)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Golang
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Publish operator images to a test repo in quay.io
+        run: |
+          podman login -u="${{ secrets.QUAY_BOT }}" -p="${{ secrets.QUAY_PASSWORD }}" quay.io
+          export IMG_REPOSITORY="quay.io/nestor_acuna_blanco/ssp-operator"
+          export VALIDATOR_REPOSITORY="quay.io/nestor_acuna_blanco/kubevirt-template-validator"
+          make container-build
+          make container-push
+          make build-template-validator-container
+          make push-template-validator-container


### PR DESCRIPTION
Note: Please do not merge this pull request. It is solely a test to verify that the container images are correctly pushed to quay.io, specifically against my local quay namespace.

Context: Publishing with the older version of Ubuntu resulted in a manifest containing two amd64 images. While the cause of the error is not fully understood, I have tested the process using the latest version of Ubuntu, and the error has been resolved. This test aims to confirm that the behavior of the latest Ubuntu version from GitHub Actions is consistent.

Once the test is complete, this pull request will be closed.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
