### PR TITLE
docs: Add vm-delete-protection operand

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Operator that deploying and controlling additional [KubeVirt](https://kubevirt.i
 - [VM Console Proxy](https://github.com/kubevirt/vm-console-proxy)
 - [Template Validator](https://github.com/kubevirt/ssp-operator/tree/main/internal/template-validator)
 - Metrics Rules (Currently there is just a single Prometheus rule that counts the number of running Virtual Machines.)
+- Virtual Machine (VM) Delete Protection (deploys ValidatingAdmissionPolicy (VAP) that prevents VM from being deleted
+  when protection is enabled.)
 
 ## Installation
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -142,6 +142,16 @@ Installs prometheus monitoring rules for `ssp-operator` metrics. The available
 metrics can be found in `docs/metrics.md`. The installed rules can be found in
 `internal/operands/metrics/resources.go`.
 
+#### `vm-delete-protection`
+
+Installs a [ValidatingAdmissionPolicy](https://kubernetes.io/docs/reference/access-authn-authz/validating-admission-policy/)
+(VAP)
+and [ValidatingAdmissionPolicyBinding](https://kubernetes.io/docs/reference/access-authn-authz/validating-admission-policy)
+which binds the VAP to all namespaces. The VAP prevents VirtualMachine (VM) objects
+from being deleted when protection is enabled. To enable the delete protection, the label
+`kubevirt.io/vm-delete-protection: "True"` has to be added to the VM object. The generated VAP resources can
+be found in `internal/operands/vm-delete-protection/resources.go`.
+
 #### `tekton-cleanup`
 
 Sets a deprecation annotation on old tekton resources created by a previous version of this operator.


### PR DESCRIPTION
**What this PR does / why we need it**:

Highlights what it is the new operand, how to use the feature and where the VAP can be located.

**Which issue(s) this PR fixes**: 

Fixes # [CNV-50737](https://issues.redhat.com/browse/CNV-50737)

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
