### PR TITLE
deps: Updates controller-tools version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -237,7 +237,7 @@ MONITORING_LINTER ?= $(LOCALBIN)/monitoringlinter
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v4.5.7
-CONTROLLER_TOOLS_VERSION ?= v0.14.0
+CONTROLLER_TOOLS_VERSION ?= v0.17.1
 MONITORING_LINTER_REVISION ?= e2be790
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"

--- a/config/crd/bases/ssp.kubevirt.io_ssps.yaml
+++ b/config/crd/bases/ssp.kubevirt.io_ssps.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.17.1
   name: ssps.ssp.kubevirt.io
 spec:
   group: ssp.kubevirt.io
@@ -52,25 +52,19 @@ spec:
                     description: |-
                       URL of a remote Kustomize target from which to generate and deploy resources.
 
-
                       The following caveats apply to the provided URL:
 
-
                       * Only 'https://' and 'git://' URLs are supported.
-
 
                       * The URL must include '?ref=$ref' or '?version=$ref' pinning it to a specific
                         reference. It is recommended that the reference be a specific commit or tag
                         to ensure the generated contents does not change over time. As such it is
                         recommended not to use branches as the ref for the time being.
 
-
                       * Only VirtualMachineClusterPreference and VirtualMachineClusterInstancetype
                         resources generated from the URL are deployed by the operand.
 
-
                       See the following Kustomize documentation for more details:
-
 
                       remote targets
                       https://github.com/kubernetes-sigs/kustomize/blob/master/examples/remoteBuild.md
@@ -741,10 +735,8 @@ spec:
                                                 Claims lists the names of resources, defined in spec.resourceClaims,
                                                 that are used by this container.
 
-
                                                 This is an alpha field and requires enabling the
                                                 DynamicResourceAllocation feature gate.
-
 
                                                 This field is immutable. It can only be set for containers.
                                               items:
@@ -1968,21 +1960,15 @@ spec:
                       profile as invalid configurations can be catastrophic. An example custom profile
                       looks like this:
 
-
                         ciphers:
-
 
                           - ECDHE-ECDSA-CHACHA20-POLY1305
 
-
                           - ECDHE-RSA-CHACHA20-POLY1305
-
 
                           - ECDHE-RSA-AES128-GCM-SHA256
 
-
                           - ECDHE-ECDSA-AES128-GCM-SHA256
-
 
                         minTLSVersion: VersionTLS11
                     nullable: true
@@ -1992,7 +1978,6 @@ spec:
                           ciphers is used to specify the cipher algorithms that are negotiated
                           during the TLS handshake.  Operators may remove entries their operands
                           do not support.  For example, to use DES-CBC3-SHA  (yaml):
-
 
                             ciphers:
                               - DES-CBC3-SHA
@@ -2005,9 +1990,7 @@ spec:
                           that is negotiated during the TLS handshake. For example, to use TLS
                           versions 1.1, 1.2 and 1.3 (yaml):
 
-
                             minTLSVersion: VersionTLS11
-
 
                           NOTE: currently the highest minTLSVersion allowed is VersionTLS12
                         enum:
@@ -2021,48 +2004,33 @@ spec:
                     description: |-
                       intermediate is a TLS security profile based on:
 
-
                       https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29
-
 
                       and looks like this (yaml):
 
-
                         ciphers:
-
 
                           - TLS_AES_128_GCM_SHA256
 
-
                           - TLS_AES_256_GCM_SHA384
-
 
                           - TLS_CHACHA20_POLY1305_SHA256
 
-
                           - ECDHE-ECDSA-AES128-GCM-SHA256
-
 
                           - ECDHE-RSA-AES128-GCM-SHA256
 
-
                           - ECDHE-ECDSA-AES256-GCM-SHA384
-
 
                           - ECDHE-RSA-AES256-GCM-SHA384
 
-
                           - ECDHE-ECDSA-CHACHA20-POLY1305
-
 
                           - ECDHE-RSA-CHACHA20-POLY1305
 
-
                           - DHE-RSA-AES128-GCM-SHA256
 
-
                           - DHE-RSA-AES256-GCM-SHA384
-
 
                         minTLSVersion: VersionTLS12
                     nullable: true
@@ -2071,24 +2039,17 @@ spec:
                     description: |-
                       modern is a TLS security profile based on:
 
-
                       https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility
-
 
                       and looks like this (yaml):
 
-
                         ciphers:
-
 
                           - TLS_AES_128_GCM_SHA256
 
-
                           - TLS_AES_256_GCM_SHA384
 
-
                           - TLS_CHACHA20_POLY1305_SHA256
-
 
                         minTLSVersion: VersionTLS13
                     nullable: true
@@ -2097,102 +2058,69 @@ spec:
                     description: |-
                       old is a TLS security profile based on:
 
-
                       https://wiki.mozilla.org/Security/Server_Side_TLS#Old_backward_compatibility
-
 
                       and looks like this (yaml):
 
-
                         ciphers:
-
 
                           - TLS_AES_128_GCM_SHA256
 
-
                           - TLS_AES_256_GCM_SHA384
-
 
                           - TLS_CHACHA20_POLY1305_SHA256
 
-
                           - ECDHE-ECDSA-AES128-GCM-SHA256
-
 
                           - ECDHE-RSA-AES128-GCM-SHA256
 
-
                           - ECDHE-ECDSA-AES256-GCM-SHA384
-
 
                           - ECDHE-RSA-AES256-GCM-SHA384
 
-
                           - ECDHE-ECDSA-CHACHA20-POLY1305
-
 
                           - ECDHE-RSA-CHACHA20-POLY1305
 
-
                           - DHE-RSA-AES128-GCM-SHA256
-
 
                           - DHE-RSA-AES256-GCM-SHA384
 
-
                           - DHE-RSA-CHACHA20-POLY1305
-
 
                           - ECDHE-ECDSA-AES128-SHA256
 
-
                           - ECDHE-RSA-AES128-SHA256
-
 
                           - ECDHE-ECDSA-AES128-SHA
 
-
                           - ECDHE-RSA-AES128-SHA
-
 
                           - ECDHE-ECDSA-AES256-SHA384
 
-
                           - ECDHE-RSA-AES256-SHA384
-
 
                           - ECDHE-ECDSA-AES256-SHA
 
-
                           - ECDHE-RSA-AES256-SHA
-
 
                           - DHE-RSA-AES128-SHA256
 
-
                           - DHE-RSA-AES256-SHA256
-
 
                           - AES128-GCM-SHA256
 
-
                           - AES256-GCM-SHA384
-
 
                           - AES128-SHA256
 
-
                           - AES256-SHA256
-
 
                           - AES128-SHA
 
-
                           - AES256-SHA
 
-
                           - DES-CBC3-SHA
-
 
                         minTLSVersion: VersionTLS10
                     nullable: true
@@ -2203,14 +2131,11 @@ spec:
                       the ability to specify individual TLS security profile parameters.
                       Old, Intermediate and Modern are TLS security profiles based on:
 
-
                       https://wiki.mozilla.org/Security/Server_Side_TLS#Recommended_configurations
-
 
                       The profiles are intent based, so they may change over time as new ciphers are developed and existing ciphers
                       are found to be insecure.  Depending on precisely which ciphers are available to a process, the list may be
                       reduced.
-
 
                       Note that the Modern profile is currently not supported because it is not
                       yet well adopted by common software libraries.
@@ -2981,10 +2906,8 @@ spec:
                                                 Claims lists the names of resources, defined in spec.resourceClaims,
                                                 that are used by this container.
 
-
                                                 This is an alpha field and requires enabling the
                                                 DynamicResourceAllocation feature gate.
-
 
                                                 This field is immutable. It can only be set for containers.
                                               items:
@@ -4179,21 +4102,15 @@ spec:
                       profile as invalid configurations can be catastrophic. An example custom profile
                       looks like this:
 
-
                         ciphers:
-
 
                           - ECDHE-ECDSA-CHACHA20-POLY1305
 
-
                           - ECDHE-RSA-CHACHA20-POLY1305
-
 
                           - ECDHE-RSA-AES128-GCM-SHA256
 
-
                           - ECDHE-ECDSA-AES128-GCM-SHA256
-
 
                         minTLSVersion: VersionTLS11
                     nullable: true
@@ -4203,7 +4120,6 @@ spec:
                           ciphers is used to specify the cipher algorithms that are negotiated
                           during the TLS handshake.  Operators may remove entries their operands
                           do not support.  For example, to use DES-CBC3-SHA  (yaml):
-
 
                             ciphers:
                               - DES-CBC3-SHA
@@ -4216,9 +4132,7 @@ spec:
                           that is negotiated during the TLS handshake. For example, to use TLS
                           versions 1.1, 1.2 and 1.3 (yaml):
 
-
                             minTLSVersion: VersionTLS11
-
 
                           NOTE: currently the highest minTLSVersion allowed is VersionTLS12
                         enum:
@@ -4232,48 +4146,33 @@ spec:
                     description: |-
                       intermediate is a TLS security profile based on:
 
-
                       https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29
-
 
                       and looks like this (yaml):
 
-
                         ciphers:
-
 
                           - TLS_AES_128_GCM_SHA256
 
-
                           - TLS_AES_256_GCM_SHA384
-
 
                           - TLS_CHACHA20_POLY1305_SHA256
 
-
                           - ECDHE-ECDSA-AES128-GCM-SHA256
-
 
                           - ECDHE-RSA-AES128-GCM-SHA256
 
-
                           - ECDHE-ECDSA-AES256-GCM-SHA384
-
 
                           - ECDHE-RSA-AES256-GCM-SHA384
 
-
                           - ECDHE-ECDSA-CHACHA20-POLY1305
-
 
                           - ECDHE-RSA-CHACHA20-POLY1305
 
-
                           - DHE-RSA-AES128-GCM-SHA256
 
-
                           - DHE-RSA-AES256-GCM-SHA384
-
 
                         minTLSVersion: VersionTLS12
                     nullable: true
@@ -4282,24 +4181,17 @@ spec:
                     description: |-
                       modern is a TLS security profile based on:
 
-
                       https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility
-
 
                       and looks like this (yaml):
 
-
                         ciphers:
-
 
                           - TLS_AES_128_GCM_SHA256
 
-
                           - TLS_AES_256_GCM_SHA384
 
-
                           - TLS_CHACHA20_POLY1305_SHA256
-
 
                         minTLSVersion: VersionTLS13
                     nullable: true
@@ -4308,102 +4200,69 @@ spec:
                     description: |-
                       old is a TLS security profile based on:
 
-
                       https://wiki.mozilla.org/Security/Server_Side_TLS#Old_backward_compatibility
-
 
                       and looks like this (yaml):
 
-
                         ciphers:
-
 
                           - TLS_AES_128_GCM_SHA256
 
-
                           - TLS_AES_256_GCM_SHA384
-
 
                           - TLS_CHACHA20_POLY1305_SHA256
 
-
                           - ECDHE-ECDSA-AES128-GCM-SHA256
-
 
                           - ECDHE-RSA-AES128-GCM-SHA256
 
-
                           - ECDHE-ECDSA-AES256-GCM-SHA384
-
 
                           - ECDHE-RSA-AES256-GCM-SHA384
 
-
                           - ECDHE-ECDSA-CHACHA20-POLY1305
-
 
                           - ECDHE-RSA-CHACHA20-POLY1305
 
-
                           - DHE-RSA-AES128-GCM-SHA256
-
 
                           - DHE-RSA-AES256-GCM-SHA384
 
-
                           - DHE-RSA-CHACHA20-POLY1305
-
 
                           - ECDHE-ECDSA-AES128-SHA256
 
-
                           - ECDHE-RSA-AES128-SHA256
-
 
                           - ECDHE-ECDSA-AES128-SHA
 
-
                           - ECDHE-RSA-AES128-SHA
-
 
                           - ECDHE-ECDSA-AES256-SHA384
 
-
                           - ECDHE-RSA-AES256-SHA384
-
 
                           - ECDHE-ECDSA-AES256-SHA
 
-
                           - ECDHE-RSA-AES256-SHA
-
 
                           - DHE-RSA-AES128-SHA256
 
-
                           - DHE-RSA-AES256-SHA256
-
 
                           - AES128-GCM-SHA256
 
-
                           - AES256-GCM-SHA384
-
 
                           - AES128-SHA256
 
-
                           - AES256-SHA256
-
 
                           - AES128-SHA
 
-
                           - AES256-SHA
 
-
                           - DES-CBC3-SHA
-
 
                         minTLSVersion: VersionTLS10
                     nullable: true
@@ -4414,14 +4273,11 @@ spec:
                       the ability to specify individual TLS security profile parameters.
                       Old, Intermediate and Modern are TLS security profiles based on:
 
-
                       https://wiki.mozilla.org/Security/Server_Side_TLS#Recommended_configurations
-
 
                       The profiles are intent based, so they may change over time as new ciphers are developed and existing ciphers
                       are found to be insecure.  Depending on precisely which ciphers are available to a process, the list may be
                       reduced.
-
 
                       Note that the Modern profile is currently not supported because it is not
                       yet well adopted by common software libraries.

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,8 +7,19 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
+  verbs:
+  - create
+  - delete
+  - list
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - endpoints
-  - pods
+  - persistentvolumeclaims/status
+  - persistentvolumes
   verbs:
   - get
   - list
@@ -16,6 +27,7 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - namespaces
   - services
   verbs:
   - create
@@ -25,20 +37,47 @@ rules:
   - update
   - watch
 - apiGroups:
-  - admissionregistration.k8s.io
+  - ""
   resources:
-  - validatingadmissionpolicies
-  - validatingadmissionpolicybindings
+  - persistentvolumeclaims
+  - serviceaccounts
   verbs:
   - create
   - delete
   - get
   - list
+  - patch
   - update
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts/token
+  verbs:
+  - create
+- apiGroups:
   - admissionregistration.k8s.io
   resources:
+  - validatingadmissionpolicies
+  - validatingadmissionpolicybindings
   - validatingwebhookconfigurations
   verbs:
   - create
@@ -92,29 +131,7 @@ rules:
   - cdi.kubevirt.io
   resources:
   - dataimportcrons
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - cdi.kubevirt.io
-  resources:
   - datasources
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - cdi.kubevirt.io
-  resources:
   - datavolumes
   verbs:
   - create
@@ -138,122 +155,9 @@ rules:
   verbs:
   - get
 - apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - create
-  - list
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  - serviceaccounts
-  verbs:
-  - create
-  - delete
-  - list
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - namespaces
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - persistentvolumeclaims
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - persistentvolumeclaims/status
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - persistentvolumes
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - create
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - create
-  - get
-  - list
-  - patch
-- apiGroups:
-  - ""
-  resources:
-  - serviceaccounts
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - serviceaccounts/token
-  verbs:
-  - create
-- apiGroups:
-  - ""
-  resources:
-  - services
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
   - instancetype.kubevirt.io
   resources:
   - virtualmachineclusterinstancetypes
-  verbs:
-  - delete
-  - list
-  - watch
-- apiGroups:
-  - instancetype.kubevirt.io
-  resources:
   - virtualmachineclusterpreferences
   verbs:
   - delete
@@ -270,14 +174,6 @@ rules:
   - get
   - list
   - update
-  - watch
-- apiGroups:
-  - kubevirt.io
-  resources:
-  - virtualmachines
-  verbs:
-  - get
-  - list
   - watch
 - apiGroups:
   - kubevirt.io
@@ -300,39 +196,6 @@ rules:
   resources:
   - clusterrolebindings
   - clusterroles
-  verbs:
-  - create
-  - delete
-  - list
-  - update
-  - watch
-- apiGroups:
-  - rbac.authorization.k8s.io
-  resources:
-  - clusterrolebindings
-  - clusterroles
-  - rolebindings
-  verbs:
-  - create
-  - delete
-  - list
-  - update
-  - watch
-- apiGroups:
-  - rbac.authorization.k8s.io
-  resources:
-  - clusterroles
-  - rolebindings
-  verbs:
-  - list
-  - update
-  - watch
-- apiGroups:
-  - rbac.authorization.k8s.io
-  resources:
-  - clusterroles
-  - rolebindings
-  - roles
   verbs:
   - create
   - delete
@@ -372,11 +235,6 @@ rules:
   - ssp.kubevirt.io
   resources:
   - ssps/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - ssp.kubevirt.io
-  resources:
   - ssps/status
   verbs:
   - update

--- a/data/crd/ssp.kubevirt.io_ssps.yaml
+++ b/data/crd/ssp.kubevirt.io_ssps.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.17.1
   creationTimestamp: null
   name: ssps.ssp.kubevirt.io
 spec:
@@ -54,25 +54,19 @@ spec:
                     description: |-
                       URL of a remote Kustomize target from which to generate and deploy resources.
 
-
                       The following caveats apply to the provided URL:
 
-
                       * Only 'https://' and 'git://' URLs are supported.
-
 
                       * The URL must include '?ref=$ref' or '?version=$ref' pinning it to a specific
                         reference. It is recommended that the reference be a specific commit or tag
                         to ensure the generated contents does not change over time. As such it is
                         recommended not to use branches as the ref for the time being.
 
-
                       * Only VirtualMachineClusterPreference and VirtualMachineClusterInstancetype
                         resources generated from the URL are deployed by the operand.
 
-
                       See the following Kustomize documentation for more details:
-
 
                       remote targets
                       https://github.com/kubernetes-sigs/kustomize/blob/master/examples/remoteBuild.md
@@ -743,10 +737,8 @@ spec:
                                                 Claims lists the names of resources, defined in spec.resourceClaims,
                                                 that are used by this container.
 
-
                                                 This is an alpha field and requires enabling the
                                                 DynamicResourceAllocation feature gate.
-
 
                                                 This field is immutable. It can only be set for containers.
                                               items:
@@ -1970,21 +1962,15 @@ spec:
                       profile as invalid configurations can be catastrophic. An example custom profile
                       looks like this:
 
-
                         ciphers:
-
 
                           - ECDHE-ECDSA-CHACHA20-POLY1305
 
-
                           - ECDHE-RSA-CHACHA20-POLY1305
-
 
                           - ECDHE-RSA-AES128-GCM-SHA256
 
-
                           - ECDHE-ECDSA-AES128-GCM-SHA256
-
 
                         minTLSVersion: VersionTLS11
                     nullable: true
@@ -1994,7 +1980,6 @@ spec:
                           ciphers is used to specify the cipher algorithms that are negotiated
                           during the TLS handshake.  Operators may remove entries their operands
                           do not support.  For example, to use DES-CBC3-SHA  (yaml):
-
 
                             ciphers:
                               - DES-CBC3-SHA
@@ -2007,9 +1992,7 @@ spec:
                           that is negotiated during the TLS handshake. For example, to use TLS
                           versions 1.1, 1.2 and 1.3 (yaml):
 
-
                             minTLSVersion: VersionTLS11
-
 
                           NOTE: currently the highest minTLSVersion allowed is VersionTLS12
                         enum:
@@ -2023,48 +2006,33 @@ spec:
                     description: |-
                       intermediate is a TLS security profile based on:
 
-
                       https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29
-
 
                       and looks like this (yaml):
 
-
                         ciphers:
-
 
                           - TLS_AES_128_GCM_SHA256
 
-
                           - TLS_AES_256_GCM_SHA384
-
 
                           - TLS_CHACHA20_POLY1305_SHA256
 
-
                           - ECDHE-ECDSA-AES128-GCM-SHA256
-
 
                           - ECDHE-RSA-AES128-GCM-SHA256
 
-
                           - ECDHE-ECDSA-AES256-GCM-SHA384
-
 
                           - ECDHE-RSA-AES256-GCM-SHA384
 
-
                           - ECDHE-ECDSA-CHACHA20-POLY1305
-
 
                           - ECDHE-RSA-CHACHA20-POLY1305
 
-
                           - DHE-RSA-AES128-GCM-SHA256
 
-
                           - DHE-RSA-AES256-GCM-SHA384
-
 
                         minTLSVersion: VersionTLS12
                     nullable: true
@@ -2073,24 +2041,17 @@ spec:
                     description: |-
                       modern is a TLS security profile based on:
 
-
                       https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility
-
 
                       and looks like this (yaml):
 
-
                         ciphers:
-
 
                           - TLS_AES_128_GCM_SHA256
 
-
                           - TLS_AES_256_GCM_SHA384
 
-
                           - TLS_CHACHA20_POLY1305_SHA256
-
 
                         minTLSVersion: VersionTLS13
                     nullable: true
@@ -2099,102 +2060,69 @@ spec:
                     description: |-
                       old is a TLS security profile based on:
 
-
                       https://wiki.mozilla.org/Security/Server_Side_TLS#Old_backward_compatibility
-
 
                       and looks like this (yaml):
 
-
                         ciphers:
-
 
                           - TLS_AES_128_GCM_SHA256
 
-
                           - TLS_AES_256_GCM_SHA384
-
 
                           - TLS_CHACHA20_POLY1305_SHA256
 
-
                           - ECDHE-ECDSA-AES128-GCM-SHA256
-
 
                           - ECDHE-RSA-AES128-GCM-SHA256
 
-
                           - ECDHE-ECDSA-AES256-GCM-SHA384
-
 
                           - ECDHE-RSA-AES256-GCM-SHA384
 
-
                           - ECDHE-ECDSA-CHACHA20-POLY1305
-
 
                           - ECDHE-RSA-CHACHA20-POLY1305
 
-
                           - DHE-RSA-AES128-GCM-SHA256
-
 
                           - DHE-RSA-AES256-GCM-SHA384
 
-
                           - DHE-RSA-CHACHA20-POLY1305
-
 
                           - ECDHE-ECDSA-AES128-SHA256
 
-
                           - ECDHE-RSA-AES128-SHA256
-
 
                           - ECDHE-ECDSA-AES128-SHA
 
-
                           - ECDHE-RSA-AES128-SHA
-
 
                           - ECDHE-ECDSA-AES256-SHA384
 
-
                           - ECDHE-RSA-AES256-SHA384
-
 
                           - ECDHE-ECDSA-AES256-SHA
 
-
                           - ECDHE-RSA-AES256-SHA
-
 
                           - DHE-RSA-AES128-SHA256
 
-
                           - DHE-RSA-AES256-SHA256
-
 
                           - AES128-GCM-SHA256
 
-
                           - AES256-GCM-SHA384
-
 
                           - AES128-SHA256
 
-
                           - AES256-SHA256
-
 
                           - AES128-SHA
 
-
                           - AES256-SHA
 
-
                           - DES-CBC3-SHA
-
 
                         minTLSVersion: VersionTLS10
                     nullable: true
@@ -2205,14 +2133,11 @@ spec:
                       the ability to specify individual TLS security profile parameters.
                       Old, Intermediate and Modern are TLS security profiles based on:
 
-
                       https://wiki.mozilla.org/Security/Server_Side_TLS#Recommended_configurations
-
 
                       The profiles are intent based, so they may change over time as new ciphers are developed and existing ciphers
                       are found to be insecure.  Depending on precisely which ciphers are available to a process, the list may be
                       reduced.
-
 
                       Note that the Modern profile is currently not supported because it is not
                       yet well adopted by common software libraries.
@@ -2983,10 +2908,8 @@ spec:
                                                 Claims lists the names of resources, defined in spec.resourceClaims,
                                                 that are used by this container.
 
-
                                                 This is an alpha field and requires enabling the
                                                 DynamicResourceAllocation feature gate.
-
 
                                                 This field is immutable. It can only be set for containers.
                                               items:
@@ -4181,21 +4104,15 @@ spec:
                       profile as invalid configurations can be catastrophic. An example custom profile
                       looks like this:
 
-
                         ciphers:
-
 
                           - ECDHE-ECDSA-CHACHA20-POLY1305
 
-
                           - ECDHE-RSA-CHACHA20-POLY1305
-
 
                           - ECDHE-RSA-AES128-GCM-SHA256
 
-
                           - ECDHE-ECDSA-AES128-GCM-SHA256
-
 
                         minTLSVersion: VersionTLS11
                     nullable: true
@@ -4205,7 +4122,6 @@ spec:
                           ciphers is used to specify the cipher algorithms that are negotiated
                           during the TLS handshake.  Operators may remove entries their operands
                           do not support.  For example, to use DES-CBC3-SHA  (yaml):
-
 
                             ciphers:
                               - DES-CBC3-SHA
@@ -4218,9 +4134,7 @@ spec:
                           that is negotiated during the TLS handshake. For example, to use TLS
                           versions 1.1, 1.2 and 1.3 (yaml):
 
-
                             minTLSVersion: VersionTLS11
-
 
                           NOTE: currently the highest minTLSVersion allowed is VersionTLS12
                         enum:
@@ -4234,48 +4148,33 @@ spec:
                     description: |-
                       intermediate is a TLS security profile based on:
 
-
                       https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29
-
 
                       and looks like this (yaml):
 
-
                         ciphers:
-
 
                           - TLS_AES_128_GCM_SHA256
 
-
                           - TLS_AES_256_GCM_SHA384
-
 
                           - TLS_CHACHA20_POLY1305_SHA256
 
-
                           - ECDHE-ECDSA-AES128-GCM-SHA256
-
 
                           - ECDHE-RSA-AES128-GCM-SHA256
 
-
                           - ECDHE-ECDSA-AES256-GCM-SHA384
-
 
                           - ECDHE-RSA-AES256-GCM-SHA384
 
-
                           - ECDHE-ECDSA-CHACHA20-POLY1305
-
 
                           - ECDHE-RSA-CHACHA20-POLY1305
 
-
                           - DHE-RSA-AES128-GCM-SHA256
 
-
                           - DHE-RSA-AES256-GCM-SHA384
-
 
                         minTLSVersion: VersionTLS12
                     nullable: true
@@ -4284,24 +4183,17 @@ spec:
                     description: |-
                       modern is a TLS security profile based on:
 
-
                       https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility
-
 
                       and looks like this (yaml):
 
-
                         ciphers:
-
 
                           - TLS_AES_128_GCM_SHA256
 
-
                           - TLS_AES_256_GCM_SHA384
 
-
                           - TLS_CHACHA20_POLY1305_SHA256
-
 
                         minTLSVersion: VersionTLS13
                     nullable: true
@@ -4310,102 +4202,69 @@ spec:
                     description: |-
                       old is a TLS security profile based on:
 
-
                       https://wiki.mozilla.org/Security/Server_Side_TLS#Old_backward_compatibility
-
 
                       and looks like this (yaml):
 
-
                         ciphers:
-
 
                           - TLS_AES_128_GCM_SHA256
 
-
                           - TLS_AES_256_GCM_SHA384
-
 
                           - TLS_CHACHA20_POLY1305_SHA256
 
-
                           - ECDHE-ECDSA-AES128-GCM-SHA256
-
 
                           - ECDHE-RSA-AES128-GCM-SHA256
 
-
                           - ECDHE-ECDSA-AES256-GCM-SHA384
-
 
                           - ECDHE-RSA-AES256-GCM-SHA384
 
-
                           - ECDHE-ECDSA-CHACHA20-POLY1305
-
 
                           - ECDHE-RSA-CHACHA20-POLY1305
 
-
                           - DHE-RSA-AES128-GCM-SHA256
-
 
                           - DHE-RSA-AES256-GCM-SHA384
 
-
                           - DHE-RSA-CHACHA20-POLY1305
-
 
                           - ECDHE-ECDSA-AES128-SHA256
 
-
                           - ECDHE-RSA-AES128-SHA256
-
 
                           - ECDHE-ECDSA-AES128-SHA
 
-
                           - ECDHE-RSA-AES128-SHA
-
 
                           - ECDHE-ECDSA-AES256-SHA384
 
-
                           - ECDHE-RSA-AES256-SHA384
-
 
                           - ECDHE-ECDSA-AES256-SHA
 
-
                           - ECDHE-RSA-AES256-SHA
-
 
                           - DHE-RSA-AES128-SHA256
 
-
                           - DHE-RSA-AES256-SHA256
-
 
                           - AES128-GCM-SHA256
 
-
                           - AES256-GCM-SHA384
-
 
                           - AES128-SHA256
 
-
                           - AES256-SHA256
-
 
                           - AES128-SHA
 
-
                           - AES256-SHA
 
-
                           - DES-CBC3-SHA
-
 
                         minTLSVersion: VersionTLS10
                     nullable: true
@@ -4416,14 +4275,11 @@ spec:
                       the ability to specify individual TLS security profile parameters.
                       Old, Intermediate and Modern are TLS security profiles based on:
 
-
                       https://wiki.mozilla.org/Security/Server_Side_TLS#Recommended_configurations
-
 
                       The profiles are intent based, so they may change over time as new ciphers are developed and existing ciphers
                       are found to be insecure.  Depending on precisely which ciphers are available to a process, the list may be
                       reduced.
-
 
                       Note that the Modern profile is currently not supported because it is not
                       yet well adopted by common software libraries.

--- a/data/olm-catalog/ssp-operator.clusterserviceversion.yaml
+++ b/data/olm-catalog/ssp-operator.clusterserviceversion.yaml
@@ -75,8 +75,19 @@ spec:
         - apiGroups:
           - ""
           resources:
+          - configmaps
+          verbs:
+          - create
+          - delete
+          - list
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
           - endpoints
-          - pods
+          - persistentvolumeclaims/status
+          - persistentvolumes
           verbs:
           - get
           - list
@@ -84,6 +95,7 @@ spec:
         - apiGroups:
           - ""
           resources:
+          - namespaces
           - services
           verbs:
           - create
@@ -93,20 +105,47 @@ spec:
           - update
           - watch
         - apiGroups:
-          - admissionregistration.k8s.io
+          - ""
           resources:
-          - validatingadmissionpolicies
-          - validatingadmissionpolicybindings
+          - persistentvolumeclaims
+          - serviceaccounts
           verbs:
           - create
           - delete
           - get
           - list
+          - patch
           - update
           - watch
         - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - create
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          verbs:
+          - create
+          - get
+          - list
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - serviceaccounts/token
+          verbs:
+          - create
+        - apiGroups:
           - admissionregistration.k8s.io
           resources:
+          - validatingadmissionpolicies
+          - validatingadmissionpolicybindings
           - validatingwebhookconfigurations
           verbs:
           - create
@@ -160,29 +199,7 @@ spec:
           - cdi.kubevirt.io
           resources:
           - dataimportcrons
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - cdi.kubevirt.io
-          resources:
           - datasources
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - cdi.kubevirt.io
-          resources:
           - datavolumes
           verbs:
           - create
@@ -206,122 +223,9 @@ spec:
           verbs:
           - get
         - apiGroups:
-          - ""
-          resources:
-          - configmaps
-          verbs:
-          - create
-          - list
-          - update
-          - watch
-        - apiGroups:
-          - ""
-          resources:
-          - configmaps
-          - serviceaccounts
-          verbs:
-          - create
-          - delete
-          - list
-          - update
-          - watch
-        - apiGroups:
-          - ""
-          resources:
-          - namespaces
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - update
-          - watch
-        - apiGroups:
-          - ""
-          resources:
-          - persistentvolumeclaims
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - ""
-          resources:
-          - persistentvolumeclaims/status
-          verbs:
-          - get
-          - list
-          - watch
-        - apiGroups:
-          - ""
-          resources:
-          - persistentvolumes
-          verbs:
-          - get
-          - list
-          - watch
-        - apiGroups:
-          - ""
-          resources:
-          - pods
-          verbs:
-          - create
-          - get
-          - list
-          - watch
-        - apiGroups:
-          - ""
-          resources:
-          - secrets
-          verbs:
-          - create
-          - get
-          - list
-          - patch
-        - apiGroups:
-          - ""
-          resources:
-          - serviceaccounts
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - ""
-          resources:
-          - serviceaccounts/token
-          verbs:
-          - create
-        - apiGroups:
-          - ""
-          resources:
-          - services
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - update
-          - watch
-        - apiGroups:
           - instancetype.kubevirt.io
           resources:
           - virtualmachineclusterinstancetypes
-          verbs:
-          - delete
-          - list
-          - watch
-        - apiGroups:
-          - instancetype.kubevirt.io
-          resources:
           - virtualmachineclusterpreferences
           verbs:
           - delete
@@ -338,14 +242,6 @@ spec:
           - get
           - list
           - update
-          - watch
-        - apiGroups:
-          - kubevirt.io
-          resources:
-          - virtualmachines
-          verbs:
-          - get
-          - list
           - watch
         - apiGroups:
           - kubevirt.io
@@ -368,39 +264,6 @@ spec:
           resources:
           - clusterrolebindings
           - clusterroles
-          verbs:
-          - create
-          - delete
-          - list
-          - update
-          - watch
-        - apiGroups:
-          - rbac.authorization.k8s.io
-          resources:
-          - clusterrolebindings
-          - clusterroles
-          - rolebindings
-          verbs:
-          - create
-          - delete
-          - list
-          - update
-          - watch
-        - apiGroups:
-          - rbac.authorization.k8s.io
-          resources:
-          - clusterroles
-          - rolebindings
-          verbs:
-          - list
-          - update
-          - watch
-        - apiGroups:
-          - rbac.authorization.k8s.io
-          resources:
-          - clusterroles
-          - rolebindings
-          - roles
           verbs:
           - create
           - delete
@@ -440,11 +303,6 @@ spec:
           - ssp.kubevirt.io
           resources:
           - ssps/finalizers
-          verbs:
-          - update
-        - apiGroups:
-          - ssp.kubevirt.io
-          resources:
           - ssps/status
           verbs:
           - update


### PR DESCRIPTION
**What this PR does / why we need it**:

It will help to unlock further updates in SSP. Currently, the controller-gen tool fails with latest external deps updates.


**Special notes for your reviewer**:

This should unlock dep updates such as https://github.com/kubevirt/ssp-operator/pull/1221

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
