### PR TITLE
doc: common instancetypes are not released to the SSP

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 Operator that deploying and controlling additional [KubeVirt](https://kubevirt.io) resources:
 
-- [Common Instancetypes and Preferences Bundle](https://github.com/kubevirt/common-instancetypes/)
 - [Common Templates Bundle](https://github.com/kubevirt/common-templates)
 - [VM Console Proxy](https://github.com/kubevirt/vm-console-proxy)
 - [Template Validator](https://github.com/kubevirt/ssp-operator/tree/main/internal/template-validator)


### PR DESCRIPTION
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
