### PR TITLE
chore(test): Add cleanup in VM delete protection test

### DIFF
--- a/tests/vm_delete_protection_test.go
+++ b/tests/vm_delete_protection_test.go
@@ -30,7 +30,7 @@ var _ = Describe("VM delete protection", func() {
 			err := apiClient.Get(ctx, client.ObjectKeyFromObject(vm), vm)
 			Expect(err).To(Or(Not(HaveOccurred()), MatchError(errors.IsNotFound, "errors.IsNotFound")))
 
-			if err == nil {
+			if err == nil && vm.DeletionTimestamp == nil {
 				Eventually(func() error {
 					if err := apiClient.Get(ctx, client.ObjectKeyFromObject(vm), vm); err != nil {
 						return err
@@ -61,6 +61,7 @@ var _ = Describe("VM delete protection", func() {
 		vm = createVMWithDeleteProtection(labelValue)
 
 		Expect(apiClient.Delete(ctx, vm)).To(Succeed())
+		waitForDeletion(client.ObjectKeyFromObject(vm), &kubevirtv1.VirtualMachine{})
 	},
 		Entry("using False as value", "False"),
 		Entry("using false as value", "false"),
@@ -71,6 +72,7 @@ var _ = Describe("VM delete protection", func() {
 		vm = createVMWithLabels(nil)
 
 		Expect(apiClient.Delete(ctx, vm)).To(Succeed())
+		waitForDeletion(client.ObjectKeyFromObject(vm), &kubevirtv1.VirtualMachine{})
 	})
 })
 


### PR DESCRIPTION
**What this PR does / why we need it**:

There is a race condition between the deletion in those test in which the deletion is expected to happen and the `AfterEach` `IsNotFound` check. This may cause that the `AfterEach` tries to update the VM to remove the label, but the VM is already gone.

It adds a `WaitForDeletion` in those test to be sure that the VM is removed before triggering the `AfterEach`. Moreover, it adds a check in the `AfterEach` to check if the VM is already being deleted.

**Which issue(s) this PR fixes**: 
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

Fixes # https://github.com/kubevirt/ssp-operator/issues/1239

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None.
```
