### PR TITLE
fix: regex in renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "baseBranches": ["main", "/release-v(([1-9]+\\.([0-9]+))|(0\\.([1-9][0-9]{2,}|[2-9][0-9]|1[6-9])))/"],
+  "baseBranches": ["main", "/^release-v(([1-9]+\\.([0-9]+))|(0\\.([1-9][0-9]{2,}|[2-9][0-9]|1[6-9])))$/"],
   "prConcurrentLimit": 3,
   "lockFileMaintenance": {
     "enabled": false


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: regex in renovate config

previous regex caused Renovate to evaluate branches created by renovate as matching. To fix this, the ^ and $ are added to the regex.

**Release note**:
```
NONE
```