### PR TITLE
feat: improve renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -23,5 +23,8 @@
   },
   "osvVulnerabilityAlerts": true,
   "assigneesFromCodeOwners": true,
-  "separateMajorMinor": true
+  "separateMajorMinor": true,
+  "ignorePaths": [
+    "**/vendor/**"
+  ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -13,7 +13,7 @@
       "groupName": "all dependencies",
       "groupSlug": "all",
       "enabled": false,
-      "matchPackagePatterns": [
+      "matchPackageNames": [
         "*"
       ]
     }


### PR DESCRIPTION
**What this PR does / why we need it**:
feat: ignore packages in vendor folder

Renovate identified some other dependencies (e.g. bazel) in vendor folder.
This caused incorrect PRs which bumped bazel dep, without proper update
of go.mod file

fix: replace matchPackagePatterns with matchPackageNames
This change was adviced by triggered renovate run. The matchPackagePatterns attribute is probably deprecated - https://github.com/renovatebot/renovate/pull/28602
```
 WARN: Config needs migrating
       "configType": "RENOVATE_CONFIG",
       "originalConfig": {
         "$schema": "https://docs.renovatebot.com/renovate-schema.json",
         "baseBranches": [
           "main",
           "/^release-v(([1-9]+\\.([0-9]+))|(0\\.([1-9][0-9]{2,}|[2-9][0-9]|1[6-9])))$/"
         ],
         "prConcurrentLimit": 3,
         "lockFileMaintenance": {"enabled": false},
         "postUpdateOptions": ["gomodTidy"],
         "labels": ["release-note-none"],
         "extends": [":gitSignOff"],
         "packageRules": [
           {
             "groupName": "all dependencies",
             "groupSlug": "all",
             "enabled": false,
             "matchPackagePatterns": ["*"]
           }
         ],
         "vulnerabilityAlerts": {"enabled": true},
         "osvVulnerabilityAlerts": true,
         "assigneesFromCodeOwners": true,
         "separateMajorMinor": true,
         "ignorePaths": ["**/vendor/**"]
       },
       "migratedConfig": {
         "$schema": "https://docs.renovatebot.com/renovate-schema.json",
         "baseBranches": [
           "main",
           "/^release-v(([1-9]+\\.([0-9]+))|(0\\.([1-9][0-9]{2,}|[2-9][0-9]|1[6-9])))$/"
         ],
         "prConcurrentLimit": 3,
         "lockFileMaintenance": {"enabled": false},
         "postUpdateOptions": ["gomodTidy"],
         "labels": ["release-note-none"],
         "extends": [":gitSignOff"],
         "packageRules": [
           {
             "groupName": "all dependencies",
             "groupSlug": "all",
             "enabled": false,
             "matchPackageNames": ["*"]
           }
         ],
         "vulnerabilityAlerts": {"enabled": true},
         "osvVulnerabilityAlerts": true,
         "assigneesFromCodeOwners": true,
         "separateMajorMinor": true,
         "ignorePaths": ["**/vendor/**"]

```

**Release note**:
```
NONE
```
