### PR TITLE
[release-v0.16] deps: Update golang version to 1.19

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -8,12 +8,12 @@ jobs:
   validate_metrics_docs:
     runs-on: ubuntu-latest
     steps:
-      - name: Install Golang 1.18
-        uses: actions/setup-go@v2
-        with:
-          go-version: '1.18'
       - name: Checkout code
         uses: actions/checkout@v3
+      - name: Install Golang
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: 'go.mod'
       - name: Generate metrics docs
         run: make generate-doc
       - name: Validate no changes
@@ -22,13 +22,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - name: Install Golang 1.18
-      uses: actions/setup-go@v2
-      with:
-        go-version: '1.18'
-
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
+    - name: Install Golang
+      uses: actions/setup-go@v3
+      with:
+        go-version-file: 'go.mod'
 
     - name: Build and Test csv-generator
       run: make container-build && ./tests/e2e-test-csv-generator.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal as builder
 
 RUN microdnf install -y make tar gzip which && microdnf clean all
 
-RUN curl -L https://go.dev/dl/go1.18.1.linux-amd64.tar.gz | tar -C /usr/local -xzf -
+RUN curl -L https://go.dev/dl/go1.19.13.linux-amd64.tar.gz | tar -C /usr/local -xzf -
 ENV PATH=$PATH:/usr/local/go/bin
 
 # Consume required variables so we can work with make

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module kubevirt.io/ssp-operator/api
 
-go 1.18
+go 1.19
 
 require (
 	github.com/openshift/api v0.0.0-20220124143425-d74727069f6f // release-4.10

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module kubevirt.io/ssp-operator
 
-go 1.18
+go 1.19
 
 require (
 	github.com/blang/semver/v4 v4.0.0

--- a/validator.Dockerfile
+++ b/validator.Dockerfile
@@ -1,7 +1,7 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal as builder
 
 RUN microdnf install -y make tar gzip which && microdnf clean all
-RUN curl -L https://go.dev/dl/go1.18.1.linux-amd64.tar.gz | tar -C /usr/local -xzf -
+RUN curl -L https://go.dev/dl/go1.19.13.linux-amd64.tar.gz | tar -C /usr/local -xzf -
 ENV PATH=$PATH:/usr/local/go/bin
 
 ARG VERSION=latest


### PR DESCRIPTION
**What this PR does / why we need it**:
This will allow update of some modules.

**Special notes for your reviewer**:
Downstream builds already use golang 1.19.
This PR will unblock: https://github.com/kubevirt/ssp-operator/pull/1246

**Release note**:
```release-note
None
```
