### PR TITLE
tests: Improve stability of metric tests

### DIFF
--- a/tests/commonTemplates_test.go
+++ b/tests/commonTemplates_test.go
@@ -189,7 +189,7 @@ var _ = Describe("Common templates", func() {
 			Entry("[test_id:5087]test template", &testTemplate),
 		)
 
-		It("[test_id: 7340] should increase metrics when restoring tamplate", func() {
+		It("[test_id: 7340] should increase metrics when restoring template", func() {
 			expectTemplateUpdateToIncreaseTotalRestoredTemplatesCount(testTemplate)
 		})
 
@@ -355,7 +355,12 @@ var _ = Describe("Common templates", func() {
 })
 
 func expectTemplateUpdateToIncreaseTotalRestoredTemplatesCount(testTemplate testResource) {
-	restoredCountBefore := totalRestoredTemplatesCount()
+	restoredCountBefore, err := totalRestoredTemplatesCount()
+	Expect(err).ToNot(HaveOccurred())
+
 	expectRestoreAfterUpdate(&testTemplate)
-	Expect(totalRestoredTemplatesCount() - restoredCountBefore).To(Equal(1))
+
+	restoredCountAfter, err := totalRestoredTemplatesCount()
+	Expect(err).ToNot(HaveOccurred())
+	Expect(restoredCountAfter - restoredCountBefore).To(Equal(1))
 }

--- a/tests/misc_test.go
+++ b/tests/misc_test.go
@@ -167,9 +167,9 @@ func validateSspIsFailingToReconcileMetric() {
 		}
 	})
 	// the reconcile cycle should now be failing, so the kubevirt_ssp_operator_reconcile_succeeded metric should be 0
-	Eventually(func() int {
+	Eventually(func() (int, error) {
 		return sspOperatorReconcileSucceededCount()
-	}, env.ShortTimeout(), time.Second).Should(Equal(0))
+	}, env.ShortTimeout(), time.Second).Should(BeZero())
 }
 
 var _ = Describe("SCC annotation", func() {

--- a/tests/port-forwarding.go
+++ b/tests/port-forwarding.go
@@ -40,7 +40,7 @@ func (p *portForwardConn) Close() error {
 func (p *portForwarderImpl) Connect(pod *core.Pod, remotePort uint16) (net.Conn, error) {
 	streamConnection, err := p.createStreamConnection(pod)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create stream connection: %w", err)
 	}
 
 	requestId := atomic.AddInt32(&p.requestId, 1)
@@ -53,16 +53,18 @@ func (p *portForwarderImpl) Connect(pod *core.Pod, remotePort uint16) (net.Conn,
 	errorStream, err := streamConnection.CreateStream(headers)
 	if err != nil {
 		streamConnection.Close()
-		return nil, err
+		return nil, fmt.Errorf("failed to create error stream: %w", err)
 	}
 	// We will not write to error stream
-	errorStream.Close()
+	if err := errorStream.Close(); err != nil {
+		return nil, fmt.Errorf("failed to close error stream: %w", err)
+	}
 
 	headers.Set(core.StreamType, core.StreamTypeData)
 	dataStream, err := streamConnection.CreateStream(headers)
 	if err != nil {
 		streamConnection.Close()
-		return nil, err
+		return nil, fmt.Errorf("failed to create data stream: %w", err)
 	}
 
 	return &portForwardConn{
@@ -74,7 +76,7 @@ func (p *portForwarderImpl) Connect(pod *core.Pod, remotePort uint16) (net.Conn,
 func (p *portForwarderImpl) createStreamConnection(pod *core.Pod) (httpstream.Connection, error) {
 	transport, upgrader, err := spdy.RoundTripperFor(p.config)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create RoundTripper: %w", err)
 	}
 
 	req := p.client.Post().
@@ -85,7 +87,11 @@ func (p *portForwarderImpl) createStreamConnection(pod *core.Pod) (httpstream.Co
 
 	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, "POST", req.URL())
 	streamConn, _, err := dialer.Dial(portforward.PortForwardProtocolV1Name)
-	return streamConn, err
+	if err != nil {
+		return nil, fmt.Errorf("failed to dial: %w", err)
+	}
+
+	return streamConn, nil
 }
 
 func NewPortForwarder(config *rest.Config, client rest.Interface) PortForwarder {


### PR DESCRIPTION
**What this PR does / why we need it**:
Sometimes the port-forwarding in metrics tests would fail, but we didn't get a reasonable error message.

This PR improve the error messages, so failures are easier to debug.


**Which issue(s) this PR fixes**: 
Fixes: https://issues.redhat.com/browse/CNV-53448

**Release note**:
```release-note
None
```
