### PR TITLE
feat: Set "openshift.io/required-scc" annotation on deployments

### DIFF
--- a/config/manager/manager.template.yaml
+++ b/config/manager/manager.template.yaml
@@ -3,6 +3,8 @@ kind: Deployment
 metadata:
   name: operator
   namespace: kubevirt
+  annotations:
+    openshift.io/required-scc: restricted-v2
   labels:
     control-plane: ssp-operator
     name: ssp-operator
@@ -14,6 +16,7 @@ spec:
   template:
     metadata:
       annotations:
+        openshift.io/required-scc: restricted-v2
         kubectl.kubernetes.io/default-container: manager
       labels:
         control-plane: ssp-operator

--- a/data/olm-catalog/ssp-operator.clusterserviceversion.yaml
+++ b/data/olm-catalog/ssp-operator.clusterserviceversion.yaml
@@ -368,6 +368,7 @@ spec:
             metadata:
               annotations:
                 kubectl.kubernetes.io/default-container: manager
+                openshift.io/required-scc: restricted-v2
               labels:
                 control-plane: ssp-operator
                 name: ssp-operator

--- a/internal/common/labels.go
+++ b/internal/common/labels.go
@@ -15,6 +15,10 @@ const (
 	AppKubernetesManagedByValue string = "ssp-operator"
 )
 
+const (
+	RequiredSCCAnnotationValue = "restricted-v2"
+)
+
 type AppComponent string
 
 func (a AppComponent) String() string {

--- a/internal/operands/template-validator/resources.go
+++ b/internal/operands/template-validator/resources.go
@@ -3,6 +3,7 @@ package template_validator
 import (
 	"fmt"
 
+	securityv1 "github.com/openshift/api/security/v1"
 	templatev1 "github.com/openshift/api/template/v1"
 	admission "k8s.io/api/admissionregistration/v1"
 	apps "k8s.io/api/apps/v1"
@@ -15,6 +16,7 @@ import (
 	kubevirt "kubevirt.io/api/core"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 
+	"kubevirt.io/ssp-operator/internal/common"
 	"kubevirt.io/ssp-operator/internal/env"
 	common_templates "kubevirt.io/ssp-operator/internal/operands/common-templates"
 	metrics "kubevirt.io/ssp-operator/internal/operands/metrics"
@@ -160,6 +162,9 @@ func newDeployment(namespace string, replicas int32, image string) *apps.Deploym
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      DeploymentName,
 			Namespace: namespace,
+			Annotations: map[string]string{
+				securityv1.RequiredSCCAnnotation: common.RequiredSCCAnnotationValue,
+			},
 			Labels: map[string]string{
 				"name": DeploymentName,
 			},
@@ -171,7 +176,10 @@ func newDeployment(namespace string, replicas int32, image string) *apps.Deploym
 			},
 			Template: core.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:   VirtTemplateValidator,
+					Name: VirtTemplateValidator,
+					Annotations: map[string]string{
+						securityv1.RequiredSCCAnnotation: common.RequiredSCCAnnotationValue,
+					},
 					Labels: podLabels,
 				},
 				Spec: core.PodSpec{

--- a/internal/operands/vm-console-proxy/reconcile.go
+++ b/internal/operands/vm-console-proxy/reconcile.go
@@ -6,6 +6,7 @@ import (
 
 	ocpv1 "github.com/openshift/api/config/v1"
 	routev1 "github.com/openshift/api/route/v1"
+	securityv1 "github.com/openshift/api/security/v1"
 	"github.com/openshift/library-go/pkg/crypto"
 	apps "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
@@ -347,6 +348,8 @@ func reconcileDeployment(deployment apps.Deployment) common.ReconcileFunc {
 	return func(request *common.Request) (common.ReconcileResult, error) {
 		deployment.Namespace = request.Instance.Namespace
 		deployment.Spec.Template.Spec.Containers[0].Image = getVmConsoleProxyImage()
+		metav1.SetMetaDataAnnotation(&deployment.ObjectMeta, securityv1.RequiredSCCAnnotation, common.RequiredSCCAnnotationValue)
+		metav1.SetMetaDataAnnotation(&deployment.Spec.Template.ObjectMeta, securityv1.RequiredSCCAnnotation, common.RequiredSCCAnnotationValue)
 		common.AddAppLabels(request.Instance, operandName, operandComponent, &deployment.Spec.Template.ObjectMeta)
 		return common.CreateOrUpdate(request).
 			NamespacedResource(&deployment).

--- a/internal/operands/vm-console-proxy/reconcile_test.go
+++ b/internal/operands/vm-console-proxy/reconcile_test.go
@@ -7,6 +7,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	securityv1 "github.com/openshift/api/security/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 
 	ocpv1 "github.com/openshift/api/config/v1"
@@ -353,6 +354,18 @@ var _ = Describe("VM Console Proxy Operand", func() {
 		ExpectResourceNotExists(bundle.Service, request)
 		ExpectResourceNotExists(bundle.Deployment, request)
 		ExpectResourceNotExists(bundle.ApiService, request)
+	})
+
+	It("should add openshift.io/required-scc annotation to deployment", func() {
+		_, err := operand.Reconcile(&request)
+		Expect(err).ToNot(HaveOccurred())
+
+		key := client.ObjectKeyFromObject(bundle.Deployment)
+		deployment := &apps.Deployment{}
+		Expect(request.Client.Get(request.Context, key, deployment)).To(Succeed())
+
+		Expect(deployment.Annotations).To(HaveKeyWithValue(securityv1.RequiredSCCAnnotation, common.RequiredSCCAnnotationValue))
+		Expect(deployment.Spec.Template.Annotations).To(HaveKeyWithValue(securityv1.RequiredSCCAnnotation, common.RequiredSCCAnnotationValue))
 	})
 })
 

--- a/tests/scc_annotation_test.go
+++ b/tests/scc_annotation_test.go
@@ -1,0 +1,39 @@
+package tests
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	securityv1 "github.com/openshift/api/security/v1"
+	apps "k8s.io/api/apps/v1"
+	core "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"kubevirt.io/ssp-operator/internal/common"
+)
+
+var _ = Describe("Required SCC annotation", func() {
+	It("[test_id:TODO] SSP pods should have 'openshift.io/required-scc' annotation", func() {
+		deployment := &apps.Deployment{}
+		Expect(apiClient.Get(ctx, types.NamespacedName{
+			Name:      strategy.GetSSPDeploymentName(),
+			Namespace: strategy.GetSSPDeploymentNameSpace(),
+		}, deployment)).To(Succeed())
+
+		selector, err := metav1.LabelSelectorAsSelector(deployment.Spec.Selector)
+		Expect(err).ToNot(HaveOccurred())
+
+		pods := &core.PodList{}
+		Expect(apiClient.List(ctx, pods, client.MatchingLabelsSelector{Selector: selector})).To(Succeed())
+		Expect(pods.Items).ToNot(BeEmpty())
+
+		for _, pod := range pods.Items {
+			Expect(pod.Annotations).To(HaveKeyWithValue(securityv1.RequiredSCCAnnotation, common.RequiredSCCAnnotationValue),
+				"SSP pod %s/%s does not have required annotation",
+				pod.Namespace, pod.Name,
+			)
+		}
+	})
+})


### PR DESCRIPTION
**What this PR does / why we need it**:
The annotation pins required SCC.

The OpenShift API dictates that a workload can require an SCC by using the annotation:
https://docs.openshift.com/container-platform/4.17/authentication/managing-security-context-constraints.html#security-context-constraints-requiring_configuring-internal-oauth

`required-scc` prevents different SCCs from being auto-selected by pods. The auto selection can fail in multiple ways: not enough permissions, changes of UID. When combined with pod security admission (on in new clusters in 4.19), this can result in SCCs being selected based on RBAC permissions that violate PSA and results in pods not running.

**Which issue(s) this PR fixes**: 
Fixes: https://issues.redhat.com/browse/CNV-56031

**Special notes for your reviewer**:

**Release note**:
```release-note
None
```
