### PR TITLE
[release-v0.21] api: set v1beta1 version to not be served

### DIFF
--- a/api/v1beta1/ssp_types.go
+++ b/api/v1beta1/ssp_types.go
@@ -149,6 +149,7 @@ type SSPStatus struct {
 // +kubebuilder:deprecatedversion:warning="ssp.kubevirt.io/v1beta1 ssp is deprecated"
 // SSP is the Schema for the ssps API
 // +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase"
+// +kubebuilder:unservedversion
 type SSP struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/config/crd/bases/ssp.kubevirt.io_ssps.yaml
+++ b/config/crd/bases/ssp.kubevirt.io_ssps.yaml
@@ -3265,7 +3265,7 @@ spec:
                 type: string
             type: object
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}

--- a/data/crd/ssp.kubevirt.io_ssps.yaml
+++ b/data/crd/ssp.kubevirt.io_ssps.yaml
@@ -3267,7 +3267,7 @@ spec:
                 type: string
             type: object
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}

--- a/data/olm-catalog/ssp-operator.clusterserviceversion.yaml
+++ b/data/olm-catalog/ssp-operator.clusterserviceversion.yaml
@@ -39,9 +39,6 @@ spec:
     enabled: false
   customresourcedefinitions:
     owned:
-    - kind: SSP
-      name: ssps.ssp.kubevirt.io
-      version: v1beta1
     - description: SSP is the Schema for the ssps API
       displayName: SSP
       kind: SSP

--- a/tests/webhook_test.go
+++ b/tests/webhook_test.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	sspv1beta1 "kubevirt.io/ssp-operator/api/v1beta1"
@@ -142,7 +143,7 @@ var _ = Describe("Validation webhook", func() {
 				Expect(err).To(MatchError(ContainSubstring("missing name in DataImportCronTemplate")))
 			})
 
-			It("[test_id:TODO] should accept v1beta1 SSP object", func() {
+			It("[test_id:TODO] should not accept v1beta1 SSP object", func() {
 				ssp := &sspv1beta1.SSP{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      newSsp.GetName(),
@@ -155,7 +156,8 @@ var _ = Describe("Validation webhook", func() {
 					},
 				}
 
-				Expect(apiClient.Create(ctx, ssp, client.DryRunAll)).To(Succeed())
+				Expect(apiClient.Create(ctx, ssp, client.DryRunAll)).
+					To(MatchError(meta.IsNoMatchError, "meta.IsNoMatchError"))
 			})
 		})
 	})

--- a/vendor/kubevirt.io/ssp-operator/api/v1beta1/ssp_types.go
+++ b/vendor/kubevirt.io/ssp-operator/api/v1beta1/ssp_types.go
@@ -149,6 +149,7 @@ type SSPStatus struct {
 // +kubebuilder:deprecatedversion:warning="ssp.kubevirt.io/v1beta1 ssp is deprecated"
 // SSP is the Schema for the ssps API
 // +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase"
+// +kubebuilder:unservedversion
 type SSP struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
**What this PR does / why we need it**:
This allows the OLM to remove the version when updating to the next release v0.22.

Issue: https://issues.redhat.com/browse/CNV-57082

**Release note**:
```release-note
Set the API version v1beta1 as not served.
```
