### PR TITLE
chore(golangci-lint): Bump golangci-lint 1.64.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -319,7 +319,7 @@ kubevirt-sync:
 	KUSTOMIZE=$(KUSTOMIZE) ./hack/kubevirt.sh sync
 
 GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
-GOLANGCI_LINT_VERSION ?= v1.62.2
+GOLANGCI_LINT_VERSION ?= v1.64.6
 
 .PHONY: lint
 lint:


### PR DESCRIPTION
```release-note
None
```
