### PR TITLE
deps: Update golang and monitoring-linter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ARG TARGET_ARCH
 RUN microdnf install -y make tar gzip which && microdnf clean all
 
 RUN ARCH=$(uname -m | sed 's/x86_64/amd64/') && \
-    curl -L https://go.dev/dl/go1.23.2.linux-${ARCH}.tar.gz -o go.tar.gz && \
+    curl -L https://go.dev/dl/go1.23.6.linux-${ARCH}.tar.gz -o go.tar.gz && \
     tar -C /usr/local -xzf go.tar.gz && \
     rm go.tar.gz
 

--- a/Makefile
+++ b/Makefile
@@ -238,7 +238,7 @@ MONITORING_LINTER ?= $(LOCALBIN)/monitoringlinter
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v4.5.7
 CONTROLLER_TOOLS_VERSION ?= v0.17.1
-MONITORING_LINTER_REVISION ?= e2be790
+MONITORING_LINTER_REVISION ?= v0.0.8
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 .PHONY: kustomize

--- a/ci-builder/Dockerfile
+++ b/ci-builder/Dockerfile
@@ -1,7 +1,7 @@
 # This Dockerfile is used in openshift CI
 FROM quay.io/fedora/fedora:40
 
-RUN curl -L https://go.dev/dl/go1.23.2.linux-amd64.tar.gz | tar -C /usr/local -xzf -
+RUN curl -L https://go.dev/dl/go1.23.6.linux-amd64.tar.gz | tar -C /usr/local -xzf -
 ENV PATH=$PATH:/usr/local/go/bin
 
 # Install dependencies and tools

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module kubevirt.io/ssp-operator
 
-go 1.23.2
+go 1.23.6
 
 require (
 	github.com/blang/semver/v4 v4.0.0

--- a/validator.Dockerfile
+++ b/validator.Dockerfile
@@ -11,7 +11,7 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal as builder
 ARG TARGET_ARCH
 
 RUN microdnf install -y make tar gzip which && microdnf clean all
-RUN export ARCH=$(uname -m | sed 's/x86_64/amd64/'); curl -L https://go.dev/dl/go1.23.2.linux-${ARCH}.tar.gz | tar -C /usr/local -xzf -
+RUN export ARCH=$(uname -m | sed 's/x86_64/amd64/'); curl -L https://go.dev/dl/go1.23.6.linux-${ARCH}.tar.gz | tar -C /usr/local -xzf -
 ENV PATH=$PATH:/usr/local/go/bin
 
 ARG VERSION=latest


### PR DESCRIPTION
**What this PR does / why we need it**:
- Updated golang to version 1.23.6.
- Updated monitoring-linter to version v0.0.8. The previous version without tag stopped working.

**Release note**:
```release-note
None
```
