### PR TITLE
deps: update vm-console-proxy manifests to v0.8.0

### DIFF
--- a/data/vm-console-proxy-bundle/vm-console-proxy.yaml
+++ b/data/vm-console-proxy-bundle/vm-console-proxy.yaml
@@ -154,7 +154,7 @@ spec:
       - args: []
         command:
         - /console
-        image: quay.io/kubevirt/vm-console-proxy:v0.7.0
+        image: quay.io/kubevirt/vm-console-proxy:v0.8.0
         imagePullPolicy: Always
         name: console
         ports:

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	kubevirt.io/containerized-data-importer-api v1.61.2
 	kubevirt.io/controller-lifecycle-operator-sdk/api v0.2.4
 	kubevirt.io/ssp-operator/api v0.0.0
-	kubevirt.io/vm-console-proxy/api v0.7.0
+	kubevirt.io/vm-console-proxy/api v0.8.0
 	sigs.k8s.io/controller-runtime v0.20.4
 	sigs.k8s.io/yaml v1.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -453,8 +453,8 @@ kubevirt.io/containerized-data-importer-api v1.61.2 h1:KdQOC6C/w9tfv3FR30UWlDFAf
 kubevirt.io/containerized-data-importer-api v1.61.2/go.mod h1:SDJjLGhbPyayDqAqawcGmVNapBp0KodOQvhKPLVGCQU=
 kubevirt.io/controller-lifecycle-operator-sdk/api v0.2.4 h1:fZYvD3/Vnitfkx6IJxjLAk8ugnZQ7CXVYcRfkSKmuZY=
 kubevirt.io/controller-lifecycle-operator-sdk/api v0.2.4/go.mod h1:018lASpFYBsYN6XwmA2TIrPCx6e0gviTd/ZNtSitKgc=
-kubevirt.io/vm-console-proxy/api v0.7.0 h1:yhzTtywJDqDx3ddIDhuMmN9O19EdGZS0NDqtGwEwk9c=
-kubevirt.io/vm-console-proxy/api v0.7.0/go.mod h1:7q967W73c6/Iczl3xJkOjQOASAJ2wXBTEbCbiqD9bXE=
+kubevirt.io/vm-console-proxy/api v0.8.0 h1:PIE3PuV9yk9eEVWFx/YbpV5Cr/2zGUrwFXwllz63VI0=
+kubevirt.io/vm-console-proxy/api v0.8.0/go.mod h1:m2Uxp9QNyYDAur8hLt9sSv9dimobqp1qeWfkt23GD9U=
 sigs.k8s.io/controller-runtime v0.20.4 h1:X3c+Odnxz+iPTRobG4tp092+CvBU9UK0t/bRf+n0DGU=
 sigs.k8s.io/controller-runtime v0.20.4/go.mod h1:xg2XB0K5ShQzAgsoujxuKN4LNXR2LfwwHsPj7Iaw+XY=
 sigs.k8s.io/json v0.0.0-20211020170558-c049b76a60c6/go.mod h1:p4QtZmO4uMYipTQNzagwnNoseA6OxSUutVw05NhYDRs=

--- a/internal/operands/vm-console-proxy/defaults.go
+++ b/internal/operands/vm-console-proxy/defaults.go
@@ -3,6 +3,6 @@ package vm_console_proxy
 // This file is updated by GitHub action defined in .github/workflows/release-vm-console-proxy.yaml
 
 const (
-	defaultVmConsoleProxyImageTag = "v0.7.0"
+	defaultVmConsoleProxyImageTag = "v0.8.0"
 	defaultVmConsoleProxyImage    = "quay.io/kubevirt/vm-console-proxy:" + defaultVmConsoleProxyImageTag
 )

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -881,7 +881,7 @@ kubevirt.io/controller-lifecycle-operator-sdk/api
 ## explicit; go 1.23.2
 kubevirt.io/ssp-operator/api/v1beta2
 kubevirt.io/ssp-operator/api/v1beta3
-# kubevirt.io/vm-console-proxy/api v0.7.0
+# kubevirt.io/vm-console-proxy/api v0.8.0
 ## explicit; go 1.22.4
 kubevirt.io/vm-console-proxy/api/v1
 # sigs.k8s.io/controller-runtime v0.20.4


### PR DESCRIPTION
**What this PR does / why we need it**:
Update `vm-console-proxy` manifests to version `v0.8.0`.

**Release note**:
```release-note
None
```
