### PR TITLE
fix: vm_controller: Don't fail if PVC or PV does not exist

### DIFF
--- a/internal/controllers/vm_controller.go
+++ b/internal/controllers/vm_controller.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -77,7 +78,7 @@ func (v *vmController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Re
 		return ctrl.Result{
 			Requeue:      true,
 			RequeueAfter: 5 * time.Second,
-		}, err
+		}, fmt.Errorf("could not find VM %s/%s: %w", req.Namespace, req.Name, err)
 	}
 
 	if vm.Status.PrintableStatus == kubevirtv1.VirtualMachineStatusProvisioning {
@@ -89,9 +90,11 @@ func (v *vmController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Re
 	if err := v.setVmVolumesMetrics(ctx, &vm); err != nil {
 		v.log.Error(err, "Could not set vm volumes metrics", "vm", req.NamespacedName)
 		return ctrl.Result{
-			Requeue:      true,
-			RequeueAfter: 5 * time.Second,
-		}, err
+				Requeue:      true,
+				RequeueAfter: 5 * time.Second,
+			}, fmt.Errorf("could not set vm volumes metrics for %s/%s: %w",
+				req.Namespace, req.Name, err,
+			)
 	}
 
 	return ctrl.Result{}, nil
@@ -103,8 +106,6 @@ func getVmCrd() string {
 }
 
 func (v *vmController) setVmVolumesMetrics(ctx context.Context, vm *kubevirtv1.VirtualMachine) error {
-	var result error
-
 	for _, volume := range vm.Spec.Template.Spec.Volumes {
 		volumeName := ""
 		if volume.DataVolume != nil {
@@ -115,43 +116,27 @@ func (v *vmController) setVmVolumesMetrics(ctx context.Context, vm *kubevirtv1.V
 			continue
 		}
 
-		pvc, err := v.getPVC(ctx, vm, volumeName)
+		pvc := &corev1.PersistentVolumeClaim{}
+		err := v.client.Get(ctx,
+			client.ObjectKey{
+				Namespace: vm.Namespace,
+				Name:      volumeName,
+			}, pvc)
 		if err != nil {
 			return err
 		}
-		pv, err := v.getPV(ctx, vm, pvc)
+
+		pv := &corev1.PersistentVolume{}
+		err = v.client.Get(ctx,
+			client.ObjectKey{
+				Namespace: vm.Namespace,
+				Name:      pvc.Spec.VolumeName,
+			}, pv)
 		if err != nil {
 			return err
 		}
 
 		metrics.SetVmWithVolume(vm, pvc, pv)
 	}
-
-	return result
-}
-
-func (v *vmController) getPVC(ctx context.Context, vm *kubevirtv1.VirtualMachine, name string) (*corev1.PersistentVolumeClaim, error) {
-	pvc := &corev1.PersistentVolumeClaim{}
-	err := v.client.Get(
-		ctx,
-		client.ObjectKey{
-			Namespace: vm.Namespace,
-			Name:      name,
-		},
-		pvc,
-	)
-	return pvc, err
-}
-
-func (v *vmController) getPV(ctx context.Context, vm *kubevirtv1.VirtualMachine, pvc *corev1.PersistentVolumeClaim) (*corev1.PersistentVolume, error) {
-	pv := &corev1.PersistentVolume{}
-	err := v.client.Get(
-		ctx,
-		client.ObjectKey{
-			Namespace: vm.Namespace,
-			Name:      pvc.Spec.VolumeName,
-		},
-		pv,
-	)
-	return pv, err
+	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
`vm_controller` does not show error if PVC or PV do not exist.
This can happen, if the VM is newly created and the PVC and PV were not yet created.

Fixes: https://issues.redhat.com/browse/CNV-35800
Fixes: https://issues.redhat.com/browse/CNV-35801

**Release note**:
```release-note
None
```
