### PR TITLE
[release-v0.22]  chore: update vm-console-proxy manifests to v0.8.1

### DIFF
--- a/data/vm-console-proxy-bundle/vm-console-proxy.yaml
+++ b/data/vm-console-proxy-bundle/vm-console-proxy.yaml
@@ -154,7 +154,7 @@ spec:
       - args: []
         command:
         - /console
-        image: quay.io/kubevirt/vm-console-proxy:v0.7.0
+        image: quay.io/kubevirt/vm-console-proxy:v0.8.1
         imagePullPolicy: Always
         name: console
         ports:

--- a/internal/operands/vm-console-proxy/defaults.go
+++ b/internal/operands/vm-console-proxy/defaults.go
@@ -3,6 +3,6 @@ package vm_console_proxy
 // This file is updated by GitHub action defined in .github/workflows/release-vm-console-proxy.yaml
 
 const (
-	defaultVmConsoleProxyImageTag = "v0.7.0"
+	defaultVmConsoleProxyImageTag = "v0.8.1"
 	defaultVmConsoleProxyImage    = "quay.io/kubevirt/vm-console-proxy:" + defaultVmConsoleProxyImageTag
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
Update vm-console-proxy manifests to version `v0.8.1`.

**Release note**:
```release-note
Update vm-console-proxy-bundle to v0.8.1
```