### PR TITLE
[release-v0.21] chore: update vm-console-proxy manifests to v0.6.2

### DIFF
--- a/data/vm-console-proxy-bundle/vm-console-proxy.yaml
+++ b/data/vm-console-proxy-bundle/vm-console-proxy.yaml
@@ -156,7 +156,7 @@ spec:
       - args: []
         command:
         - /console
-        image: quay.io/kubevirt/vm-console-proxy:v0.6.1
+        image: quay.io/kubevirt/vm-console-proxy:v0.6.2
         imagePullPolicy: Always
         name: console
         ports:

--- a/internal/operands/vm-console-proxy/defaults.go
+++ b/internal/operands/vm-console-proxy/defaults.go
@@ -3,6 +3,6 @@ package vm_console_proxy
 // This file is updated by GitHub action defined in .github/workflows/release-vm-console-proxy.yaml
 
 const (
-	defaultVmConsoleProxyImageTag = "v0.6.1"
+	defaultVmConsoleProxyImageTag = "v0.6.2"
 	defaultVmConsoleProxyImage    = "quay.io/kubevirt/vm-console-proxy:" + defaultVmConsoleProxyImageTag
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
Update vm-console-proxy manifests to version `v0.6.2`.

**Release note**:
```release-note
Update vm-console-proxy-bundle to v0.6.2
```