### PR TITLE
[release-v0.18] tests: Set DICT RetentionPolicy to None

### DIFF
--- a/tests/dataSources_test.go
+++ b/tests/dataSources_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"fmt"
 	"reflect"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -28,7 +29,9 @@ var _ = Describe("DataSources", func() {
 	// The name must be one of the DataSources needed by common templates
 	const dataSourceName = "fedora"
 
-	const cdiLabel = "cdi.kubevirt.io/dataImportCron"
+	const cdiLabelPrefix = "cdi.kubevirt.io"
+	const cdiLabel = cdiLabelPrefix + "/dataImportCron"
+	const cdiCleanupLabel = cdiLabel + ".cleanup"
 
 	var (
 		expectedLabels map[string]string
@@ -752,6 +755,7 @@ var _ = Describe("DataSources", func() {
 			})
 			waitUntilDeployed()
 
+			retentionPolicyNone := cdiv1beta1.DataImportCronRetainNone
 			cronTemplate = ssp.DataImportCronTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        cronName,
@@ -760,6 +764,7 @@ var _ = Describe("DataSources", func() {
 				Spec: cdiv1beta1.DataImportCronSpec{
 					Schedule:          cronSchedule,
 					ManagedDataSource: dataSourceName,
+					RetentionPolicy:   &retentionPolicyNone,
 					Template: cdiv1beta1.DataVolume{
 						Spec: cdiv1beta1.DataVolumeSpec{
 							Source: &cdiv1beta1.DataVolumeSource{
@@ -1092,6 +1097,11 @@ var _ = Describe("DataSources", func() {
 						if ds.GetLabels() == nil {
 							ds.SetLabels(map[string]string{})
 						}
+						// Removing cleanup label, otherwise the DS would be removed by CDI and the following tests would fail.
+						// This is to remove side effects between tests. When the DIC is removed in one of the AfterEach() blocks,
+						// CDI adds this label to the DS.
+						delete(ds.GetLabels(), cdiCleanupLabel)
+
 						ds.GetLabels()[cdiLabel] = "test-value"
 
 						return apiClient.Update(ctx, ds)
@@ -1102,7 +1112,11 @@ var _ = Describe("DataSources", func() {
 					Eventually(func() error {
 						ds := &cdiv1beta1.DataSource{}
 						Expect(apiClient.Get(ctx, dataSource.GetKey(), ds))
-						delete(ds.GetLabels(), cdiLabel)
+						for key := range ds.GetLabels() {
+							if strings.HasPrefix(key, cdiLabelPrefix) {
+								delete(ds.GetLabels(), key)
+							}
+						}
 						return apiClient.Update(ctx, ds)
 					}, env.ShortTimeout(), time.Second).Should(Succeed())
 				})
@@ -1216,6 +1230,7 @@ var _ = Describe("DataSources", func() {
 			})
 
 			It("[test_id:7453] should keep DataImportCron if not owned by operator", func() {
+				retentionPolicyNone := cdiv1beta1.DataImportCronRetainNone
 				cron = &cdiv1beta1.DataImportCron{
 					ObjectMeta: metav1.ObjectMeta{
 						GenerateName: "test-not-in-ssp",
@@ -1225,6 +1240,7 @@ var _ = Describe("DataSources", func() {
 					Spec: cdiv1beta1.DataImportCronSpec{
 						Schedule:          cronSchedule,
 						ManagedDataSource: "test-not-in-ssp",
+						RetentionPolicy:   &retentionPolicyNone,
 						Template: cdiv1beta1.DataVolume{
 							Spec: cdiv1beta1.DataVolumeSpec{
 								Source: &cdiv1beta1.DataVolumeSource{


### PR DESCRIPTION
Manual cherry-pick of https://github.com/kubevirt/ssp-operator/pull/1240 .
Package `k8s.io/utils/ptr` is not in this version, so I've used a pointer to variable.

**What this PR does / why we need it**:
The default retention policy is `All`, which means that DataSource is not removed when DataImportCron is removed. This caused cluster health check to fail.

**Release note**:
```release-note
None
```
