### PR TITLE
tests: fix: Incorrect Eventually block in expectRestoreAfterUpdate()

### DIFF
--- a/tests/tests_common_test.go
+++ b/tests/tests_common_test.go
@@ -195,8 +195,8 @@ func expectRestoreAfterUpdate(res *testResource) {
 
 	Eventually(func(g Gomega) {
 		found := res.NewResource()
-		Expect(apiClient.Get(ctx, res.GetKey(), found)).ToNot(HaveOccurred())
-		Expect(found).To(EqualResource(res, original))
+		g.Expect(apiClient.Get(ctx, res.GetKey(), found)).ToNot(HaveOccurred())
+		g.Expect(found).To(EqualResource(res, original))
 	}, env.ShortTimeout(), time.Second).Should(Succeed())
 }
 


### PR DESCRIPTION

**What this PR does / why we need it**:
The eventually block used global `Gomega` instance, so any failures in `Expect()` failed the whole block, instead of retrying.

**Special notes for your reviewer**:
Previous PR: https://github.com/kubevirt/ssp-operator/pull/1329

**Release note**:
```release-note
None
```
