### PR TITLE
api: deprecate v1beta2 and use v1beta3

### DIFF
--- a/api/v1beta2/ssp_types.go
+++ b/api/v1beta2/ssp_types.go
@@ -164,8 +164,8 @@ type SSPStatus struct {
 //
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:storageversion
 // +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase"
+// +kubebuilder:deprecatedversion:warning="SSP v1beta2 is deprecated and will not be updated with new functionality. It will stop being served in the next version."
 type SSP struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1beta3/ssp_types.go
+++ b/api/v1beta3/ssp_types.go
@@ -96,6 +96,7 @@ type SSPStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase"
 
 // SSP is the Schema for the ssps API

--- a/config/crd/bases/ssp.kubevirt.io_ssps.yaml
+++ b/config/crd/bases/ssp.kubevirt.io_ssps.yaml
@@ -18,6 +18,9 @@ spec:
     - jsonPath: .status.phase
       name: Phase
       type: string
+    deprecated: true
+    deprecationWarning: SSP v1beta2 is deprecated and will not be updated with new
+      functionality. It will stop being served in the next version.
     name: v1beta2
     schema:
       openAPIV3Schema:
@@ -2185,7 +2188,7 @@ spec:
             type: object
         type: object
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}
   - additionalPrinterColumns:
@@ -4302,6 +4305,6 @@ spec:
             type: object
         type: object
     served: true
-    storage: false
+    storage: true
     subresources:
       status: {}

--- a/data/crd/ssp.kubevirt.io_ssps.yaml
+++ b/data/crd/ssp.kubevirt.io_ssps.yaml
@@ -20,6 +20,9 @@ spec:
     - jsonPath: .status.phase
       name: Phase
       type: string
+    deprecated: true
+    deprecationWarning: SSP v1beta2 is deprecated and will not be updated with new
+      functionality. It will stop being served in the next version.
     name: v1beta2
     schema:
       openAPIV3Schema:
@@ -2187,7 +2190,7 @@ spec:
             type: object
         type: object
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}
   - additionalPrinterColumns:
@@ -4304,7 +4307,7 @@ spec:
             type: object
         type: object
     served: true
-    storage: false
+    storage: true
     subresources:
       status: {}
 status:

--- a/internal/common/labels.go
+++ b/internal/common/labels.go
@@ -2,7 +2,7 @@ package common
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	ssp "kubevirt.io/ssp-operator/api/v1beta2"
+	ssp "kubevirt.io/ssp-operator/api/v1beta3"
 )
 
 const (

--- a/internal/common/labels_test.go
+++ b/internal/common/labels_test.go
@@ -3,10 +3,11 @@ package common
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	ssp "kubevirt.io/ssp-operator/api/v1beta2"
+	ssp "kubevirt.io/ssp-operator/api/v1beta3"
 )
 
 var _ = Describe("AddAppLabels", func() {

--- a/internal/common/owner_test.go
+++ b/internal/common/owner_test.go
@@ -8,7 +8,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	ssp "kubevirt.io/ssp-operator/api/v1beta2"
+	ssp "kubevirt.io/ssp-operator/api/v1beta3"
 )
 
 var _ = Describe("Owner", func() {

--- a/internal/common/request.go
+++ b/internal/common/request.go
@@ -8,7 +8,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	ssp "kubevirt.io/ssp-operator/api/v1beta2"
+	ssp "kubevirt.io/ssp-operator/api/v1beta3"
 	crd_watch "kubevirt.io/ssp-operator/internal/crd-watch"
 )
 

--- a/internal/common/resource_test.go
+++ b/internal/common/resource_test.go
@@ -18,7 +18,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	ssp "kubevirt.io/ssp-operator/api/v1beta2"
+	ssp "kubevirt.io/ssp-operator/api/v1beta3"
 )
 
 var log = logf.Log.WithName("common_operand_package")

--- a/internal/controller/predicates/predicates_test.go
+++ b/internal/controller/predicates/predicates_test.go
@@ -10,7 +10,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 
-	ssp "kubevirt.io/ssp-operator/api/v1beta2"
+	ssp "kubevirt.io/ssp-operator/api/v1beta3"
 )
 
 var _ = Describe("SpecChangedPredicate", func() {

--- a/internal/controllers/ssp_controller.go
+++ b/internal/controllers/ssp_controller.go
@@ -43,7 +43,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	ssp "kubevirt.io/ssp-operator/api/v1beta2"
+	ssp "kubevirt.io/ssp-operator/api/v1beta3"
 	"kubevirt.io/ssp-operator/internal/common"
 	handler_hook "kubevirt.io/ssp-operator/internal/controller/handler-hook"
 	"kubevirt.io/ssp-operator/internal/controller/predicates"

--- a/internal/controllers/webhook_controller.go
+++ b/internal/controllers/webhook_controller.go
@@ -13,7 +13,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	sspv1beta2 "kubevirt.io/ssp-operator/api/v1beta2"
+	ssp "kubevirt.io/ssp-operator/api/v1beta3"
 )
 
 const (
@@ -99,7 +99,7 @@ func updateWebhookConfiguration(webhookConfig *admissionv1.ValidatingWebhookConf
 		// Check if the webhook reacts to SSP resource.
 		var hasSspRule bool
 		for _, rule := range webhook.Rules {
-			if slices.Contains(rule.APIGroups, sspv1beta2.GroupVersion.Group) {
+			if slices.Contains(rule.APIGroups, ssp.GroupVersion.Group) {
 				hasSspRule = true
 				break
 			}

--- a/internal/controllers/webhook_controller_test.go
+++ b/internal/controllers/webhook_controller_test.go
@@ -14,7 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	sspv1beta2 "kubevirt.io/ssp-operator/api/v1beta2"
+	ssp "kubevirt.io/ssp-operator/api/v1beta3"
 	"kubevirt.io/ssp-operator/internal/common"
 )
 
@@ -46,8 +46,8 @@ var _ = Describe("Webhook controller", func() {
 				},
 				Rules: []admissionv1.RuleWithOperations{{
 					Rule: admissionv1.Rule{
-						APIGroups:   []string{sspv1beta2.GroupVersion.Group},
-						APIVersions: []string{sspv1beta2.GroupVersion.Version},
+						APIGroups:   []string{ssp.GroupVersion.Group},
+						APIVersions: []string{ssp.GroupVersion.Version},
 						Resources:   []string{"ssps"},
 					},
 					Operations: []admissionv1.OperationType{

--- a/internal/operands/common-templates/reconcile_test.go
+++ b/internal/operands/common-templates/reconcile_test.go
@@ -18,7 +18,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	ssp "kubevirt.io/ssp-operator/api/v1beta2"
+	ssp "kubevirt.io/ssp-operator/api/v1beta3"
 	"kubevirt.io/ssp-operator/internal/common"
 	"kubevirt.io/ssp-operator/internal/env"
 	"kubevirt.io/ssp-operator/internal/operands"

--- a/internal/operands/data-sources/reconcile.go
+++ b/internal/operands/data-sources/reconcile.go
@@ -10,7 +10,7 @@ import (
 	cdiv1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	ssp "kubevirt.io/ssp-operator/api/v1beta2"
+	ssp "kubevirt.io/ssp-operator/api/v1beta3"
 	"kubevirt.io/ssp-operator/internal"
 	"kubevirt.io/ssp-operator/internal/common"
 	"kubevirt.io/ssp-operator/internal/operands"

--- a/internal/operands/data-sources/reconcile_test.go
+++ b/internal/operands/data-sources/reconcile_test.go
@@ -17,7 +17,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	ssp "kubevirt.io/ssp-operator/api/v1beta2"
+	ssp "kubevirt.io/ssp-operator/api/v1beta3"
 	"kubevirt.io/ssp-operator/internal"
 	"kubevirt.io/ssp-operator/internal/common"
 	"kubevirt.io/ssp-operator/internal/operands"

--- a/internal/operands/metrics/reconcile_test.go
+++ b/internal/operands/metrics/reconcile_test.go
@@ -16,7 +16,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	ssp "kubevirt.io/ssp-operator/api/v1beta2"
+	ssp "kubevirt.io/ssp-operator/api/v1beta3"
 	"kubevirt.io/ssp-operator/internal/common"
 	"kubevirt.io/ssp-operator/pkg/monitoring/rules"
 )

--- a/internal/operands/template-validator/reconcile.go
+++ b/internal/operands/template-validator/reconcile.go
@@ -7,9 +7,9 @@ import (
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	rbac "k8s.io/api/rbac/v1"
-	ssp "kubevirt.io/ssp-operator/api/v1beta2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	ssp "kubevirt.io/ssp-operator/api/v1beta3"
 	"kubevirt.io/ssp-operator/internal/common"
 	"kubevirt.io/ssp-operator/internal/operands"
 )

--- a/internal/operands/template-validator/reconcile_test.go
+++ b/internal/operands/template-validator/reconcile_test.go
@@ -21,7 +21,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	ssp "kubevirt.io/ssp-operator/api/v1beta2"
+	ssp "kubevirt.io/ssp-operator/api/v1beta3"
 	"kubevirt.io/ssp-operator/internal/common"
 	. "kubevirt.io/ssp-operator/internal/test-utils"
 )

--- a/internal/operands/vm-console-proxy/reconcile_test.go
+++ b/internal/operands/vm-console-proxy/reconcile_test.go
@@ -31,7 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/yaml"
 
-	ssp "kubevirt.io/ssp-operator/api/v1beta2"
+	ssp "kubevirt.io/ssp-operator/api/v1beta3"
 	"kubevirt.io/ssp-operator/internal/common"
 	"kubevirt.io/ssp-operator/internal/env"
 	"kubevirt.io/ssp-operator/internal/operands"

--- a/internal/operands/vm-delete-protection/reconcile_test.go
+++ b/internal/operands/vm-delete-protection/reconcile_test.go
@@ -15,7 +15,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	ssp "kubevirt.io/ssp-operator/api/v1beta2"
+	ssp "kubevirt.io/ssp-operator/api/v1beta3"
 	"kubevirt.io/ssp-operator/internal/common"
 	. "kubevirt.io/ssp-operator/internal/test-utils"
 )

--- a/main.go
+++ b/main.go
@@ -43,7 +43,7 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
-	ssp "kubevirt.io/ssp-operator/api/v1beta2"
+	ssp "kubevirt.io/ssp-operator/api/v1beta3"
 	"kubevirt.io/ssp-operator/internal/common"
 	"kubevirt.io/ssp-operator/internal/controllers"
 	sspMetrics "kubevirt.io/ssp-operator/pkg/monitoring/metrics/ssp-operator"

--- a/tests/cleanup_test.go
+++ b/tests/cleanup_test.go
@@ -9,7 +9,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 
-	ssp "kubevirt.io/ssp-operator/api/v1beta2"
+	ssp "kubevirt.io/ssp-operator/api/v1beta3"
 	"kubevirt.io/ssp-operator/internal/common"
 	"kubevirt.io/ssp-operator/internal/operands"
 	common_templates "kubevirt.io/ssp-operator/internal/operands/common-templates"

--- a/tests/commonTemplates_test.go
+++ b/tests/commonTemplates_test.go
@@ -13,7 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	ssp "kubevirt.io/ssp-operator/api/v1beta2"
+	ssp "kubevirt.io/ssp-operator/api/v1beta3"
 	"kubevirt.io/ssp-operator/internal/common"
 	commonTemplates "kubevirt.io/ssp-operator/internal/operands/common-templates"
 	"kubevirt.io/ssp-operator/tests/env"

--- a/tests/crypto_policy_test.go
+++ b/tests/crypto_policy_test.go
@@ -18,7 +18,7 @@ import (
 	apiregv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	ssp "kubevirt.io/ssp-operator/api/v1beta2"
+	ssp "kubevirt.io/ssp-operator/api/v1beta3"
 	"kubevirt.io/ssp-operator/internal/common"
 	template_validator "kubevirt.io/ssp-operator/internal/operands/template-validator"
 	"kubevirt.io/ssp-operator/tests/env"

--- a/tests/dataSources_test.go
+++ b/tests/dataSources_test.go
@@ -19,7 +19,7 @@ import (
 	cdiv1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	ssp "kubevirt.io/ssp-operator/api/v1beta2"
+	ssp "kubevirt.io/ssp-operator/api/v1beta3"
 	"kubevirt.io/ssp-operator/internal"
 	"kubevirt.io/ssp-operator/internal/common"
 	data_sources "kubevirt.io/ssp-operator/internal/operands/data-sources"

--- a/tests/misc_test.go
+++ b/tests/misc_test.go
@@ -23,7 +23,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	ssp "kubevirt.io/ssp-operator/api/v1beta2"
+	ssp "kubevirt.io/ssp-operator/api/v1beta3"
 	validator "kubevirt.io/ssp-operator/internal/operands/template-validator"
 	"kubevirt.io/ssp-operator/tests/env"
 )

--- a/tests/monitoring_test.go
+++ b/tests/monitoring_test.go
@@ -30,7 +30,7 @@ import (
 	kubevirtv1 "kubevirt.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	ssp "kubevirt.io/ssp-operator/api/v1beta2"
+	ssp "kubevirt.io/ssp-operator/api/v1beta3"
 	"kubevirt.io/ssp-operator/internal/operands/metrics"
 	"kubevirt.io/ssp-operator/pkg/monitoring/rules/recordingrules"
 	"kubevirt.io/ssp-operator/tests/env"

--- a/tests/single_node_test.go
+++ b/tests/single_node_test.go
@@ -3,10 +3,11 @@ package tests
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"kubevirt.io/ssp-operator/tests/env"
 
 	"kubevirt.io/controller-lifecycle-operator-sdk/api"
-	ssp "kubevirt.io/ssp-operator/api/v1beta2"
+
+	ssp "kubevirt.io/ssp-operator/api/v1beta3"
+	"kubevirt.io/ssp-operator/tests/env"
 )
 
 var _ = Describe("Single Node Topology", func() {

--- a/tests/tests_common_test.go
+++ b/tests/tests_common_test.go
@@ -23,7 +23,7 @@ import (
 	"kubevirt.io/controller-lifecycle-operator-sdk/api"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	ssp "kubevirt.io/ssp-operator/api/v1beta2"
+	ssp "kubevirt.io/ssp-operator/api/v1beta3"
 	"kubevirt.io/ssp-operator/internal/operands/metrics"
 	"kubevirt.io/ssp-operator/tests/env"
 )

--- a/tests/validator_test.go
+++ b/tests/validator_test.go
@@ -28,7 +28,7 @@ import (
 	lifecycleapi "kubevirt.io/controller-lifecycle-operator-sdk/api"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	ssp "kubevirt.io/ssp-operator/api/v1beta2"
+	ssp "kubevirt.io/ssp-operator/api/v1beta3"
 	"kubevirt.io/ssp-operator/internal/common"
 	validator "kubevirt.io/ssp-operator/internal/operands/template-validator"
 	"kubevirt.io/ssp-operator/internal/template-validator/labels"

--- a/tests/vm_console_proxy_test.go
+++ b/tests/vm_console_proxy_test.go
@@ -21,7 +21,7 @@ import (
 	"k8s.io/utils/ptr"
 	kubevirtcorev1 "kubevirt.io/api/core/v1"
 
-	ssp "kubevirt.io/ssp-operator/api/v1beta2"
+	ssp "kubevirt.io/ssp-operator/api/v1beta3"
 	"kubevirt.io/ssp-operator/tests/env"
 )
 

--- a/tests/watcher.go
+++ b/tests/watcher.go
@@ -13,7 +13,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
 
-	ssp "kubevirt.io/ssp-operator/api/v1beta2"
+	ssp "kubevirt.io/ssp-operator/api/v1beta3"
 )
 
 type SspWatch interface {

--- a/tests/webhook_controller_test.go
+++ b/tests/webhook_controller_test.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	sspv1beta2 "kubevirt.io/ssp-operator/api/v1beta2"
+	ssp "kubevirt.io/ssp-operator/api/v1beta3"
 	"kubevirt.io/ssp-operator/internal/controllers"
 	"kubevirt.io/ssp-operator/tests/env"
 )
@@ -39,8 +39,8 @@ var _ = Describe("Webhook controller", func() {
 					// Using "Delete" so it does not conflict with existing SSP webhook
 					Operations: []admissionv1.OperationType{admissionv1.Delete},
 					Rule: admissionv1.Rule{
-						APIGroups:   []string{sspv1beta2.GroupVersion.Group},
-						APIVersions: []string{sspv1beta2.GroupVersion.Version},
+						APIGroups:   []string{ssp.GroupVersion.Group},
+						APIVersions: []string{ssp.GroupVersion.Version},
 						Resources:   []string{"ssps"},
 					},
 				}},

--- a/tests/webhook_test.go
+++ b/tests/webhook_test.go
@@ -70,8 +70,8 @@ var _ = Describe("Validation webhook", func() {
 	})
 
 	Context("creation", func() {
-		It("[test_id:5242] should fail to create a second v1beta2.SSP CR", func() {
-			foundSsp := getSsp()
+		It("[test_id:5242] [v1beta2] should fail to create a second SSP CR", func() {
+			foundSsp := getSspV1Beta2()
 			ssp2 := foundSsp.DeepCopy()
 			ssp2.ObjectMeta = v1.ObjectMeta{
 				Name:      "test-ssp2",
@@ -86,8 +86,8 @@ var _ = Describe("Validation webhook", func() {
 			)))
 		})
 
-		It("[test_id:TODO] should fail to create a second v1beta3.SSP CR", func() {
-			foundSsp := getSspV1Beta3()
+		It("[test_id:TODO] [v1beta3] should fail to create a second SSP CR", func() {
+			foundSsp := getSsp()
 			ssp2 := foundSsp.DeepCopy()
 			ssp2.ObjectMeta = v1.ObjectMeta{
 				Name:      "test-ssp2",
@@ -111,8 +111,8 @@ var _ = Describe("Validation webhook", func() {
 			BeforeEach(func() {
 				strategy.SkipSspUpdateTestsIfNeeded()
 
+				newSspV1Beta2 = getSspV1Beta2()
 				foundSsp := getSsp()
-				newSspV1Beta3 = getSspV1Beta3()
 
 				Expect(apiClient.Delete(ctx, foundSsp)).ToNot(HaveOccurred())
 				waitForDeletion(client.ObjectKey{Name: foundSsp.GetName(), Namespace: foundSsp.GetNamespace()}, &sspv1beta2.SSP{})
@@ -122,7 +122,7 @@ var _ = Describe("Validation webhook", func() {
 					Namespace: foundSsp.GetNamespace(),
 				}
 
-				newSspV1Beta2 = foundSsp
+				newSspV1Beta3 = foundSsp
 			})
 
 			AfterEach(func() {
@@ -130,7 +130,7 @@ var _ = Describe("Validation webhook", func() {
 			})
 
 			Context("Placement API validation", func() {
-				It("[test_id:5988]should succeed with valid template-validator placement fields", func() {
+				It("[test_id:5988] [v1beta2] should succeed with valid template-validator placement fields", func() {
 					newSspV1Beta2.Spec.TemplateValidator = &sspv1beta2.TemplateValidator{
 						Placement: &placementAPIValidationValidPlacement,
 					}
@@ -148,7 +148,7 @@ var _ = Describe("Validation webhook", func() {
 						"failed to create SSP CR with valid template-validator placement fields")
 				})
 
-				It("[test_id:5987]should fail with invalid template-validator placement fields", func() {
+				It("[test_id:5987] [v1beta2] should fail with invalid template-validator placement fields", func() {
 					newSspV1Beta2.Spec.TemplateValidator = &sspv1beta2.TemplateValidator{
 						Placement: &placementAPIValidationInvalidPlacement,
 					}
@@ -167,7 +167,7 @@ var _ = Describe("Validation webhook", func() {
 				})
 			})
 
-			It("[test_id:TODO] should fail when DataImportCronTemplate does not have a name", func() {
+			It("[test_id:TODO] [v1beta2] should fail when DataImportCronTemplate does not have a name", func() {
 				newSspV1Beta2.Spec.CommonTemplates.DataImportCronTemplates = []sspv1beta2.DataImportCronTemplate{{
 					ObjectMeta: metav1.ObjectMeta{Name: ""},
 				}}
@@ -195,9 +195,9 @@ var _ = Describe("Validation webhook", func() {
 		})
 
 		Context("Placement API validation", func() {
-			It("[test_id:5990]should succeed with valid template-validator placement fields", func() {
+			It("[test_id:5990] [v1beta2] should succeed with valid template-validator placement fields", func() {
 				Eventually(func() error {
-					foundSsp := getSsp()
+					foundSsp := getSspV1Beta2()
 					foundSsp.Spec.TemplateValidator = &sspv1beta2.TemplateValidator{
 						Placement: &placementAPIValidationValidPlacement,
 					}
@@ -207,7 +207,7 @@ var _ = Describe("Validation webhook", func() {
 
 			It("[test_id:5990] [v1beta3] should succeed with valid template-validator placement fields", func() {
 				Eventually(func() error {
-					foundSsp := getSspV1Beta3()
+					foundSsp := getSsp()
 					foundSsp.Spec.TemplateValidator = &sspv1beta3.TemplateValidator{
 						Placement: &placementAPIValidationValidPlacement,
 					}
@@ -215,9 +215,9 @@ var _ = Describe("Validation webhook", func() {
 				}, 20*time.Second, time.Second).ShouldNot(HaveOccurred(), "failed to update SSP CR with valid template-validator placement fields")
 			})
 
-			It("[test_id:5989]should fail with invalid template-validator placement fields", func() {
+			It("[test_id:5989] [v1beta2] should fail with invalid template-validator placement fields", func() {
 				Eventually(func() v1.StatusReason {
-					foundSsp := getSsp()
+					foundSsp := getSspV1Beta2()
 					foundSsp.Spec.TemplateValidator = &sspv1beta2.TemplateValidator{
 						Placement: &placementAPIValidationInvalidPlacement,
 					}
@@ -228,7 +228,7 @@ var _ = Describe("Validation webhook", func() {
 
 			It("[test_id:5989] [v1beta3] should fail with invalid template-validator placement fields", func() {
 				Eventually(func() v1.StatusReason {
-					foundSsp := getSspV1Beta3()
+					foundSsp := getSsp()
 					foundSsp.Spec.TemplateValidator = &sspv1beta3.TemplateValidator{
 						Placement: &placementAPIValidationInvalidPlacement,
 					}
@@ -238,9 +238,9 @@ var _ = Describe("Validation webhook", func() {
 			})
 		})
 
-		It("[test_id:TODO] should fail when DataImportCronTemplate does not have a name", func() {
+		It("[test_id:TODO] [v1beta2] should fail when DataImportCronTemplate does not have a name", func() {
 			Eventually(func() error {
-				foundSsp := getSsp()
+				foundSsp := getSspV1Beta2()
 				foundSsp.Spec.CommonTemplates.DataImportCronTemplates = []sspv1beta2.DataImportCronTemplate{{
 					ObjectMeta: metav1.ObjectMeta{Name: ""},
 				}}
@@ -250,7 +250,7 @@ var _ = Describe("Validation webhook", func() {
 
 		It("[test_id:TODO] [v1beta3] should fail when DataImportCronTemplate does not have a name", func() {
 			Eventually(func() error {
-				foundSsp := getSspV1Beta3()
+				foundSsp := getSsp()
 				foundSsp.Spec.CommonTemplates.DataImportCronTemplates = []sspv1beta3.DataImportCronTemplate{{
 					ObjectMeta: metav1.ObjectMeta{Name: ""},
 				}}

--- a/vendor/kubevirt.io/ssp-operator/api/v1beta2/ssp_types.go
+++ b/vendor/kubevirt.io/ssp-operator/api/v1beta2/ssp_types.go
@@ -164,8 +164,8 @@ type SSPStatus struct {
 //
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:storageversion
 // +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase"
+// +kubebuilder:deprecatedversion:warning="SSP v1beta2 is deprecated and will not be updated with new functionality. It will stop being served in the next version."
 type SSP struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/vendor/kubevirt.io/ssp-operator/api/v1beta3/ssp_types.go
+++ b/vendor/kubevirt.io/ssp-operator/api/v1beta3/ssp_types.go
@@ -96,6 +96,7 @@ type SSPStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase"
 
 // SSP is the Schema for the ssps API


### PR DESCRIPTION
**What this PR does / why we need it**:
Deprecated `v1beta2` API version.

Changed operator code to use `v1beta3` instead.

**Release note**:
```release-note
None
```
