### PR TITLE
fix: Add delete permission to PrometheusRules and ServiceMonitors

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -153,6 +153,7 @@ rules:
   - servicemonitors
   verbs:
   - create
+  - delete
   - list
   - update
   - watch

--- a/data/olm-catalog/ssp-operator.clusterserviceversion.yaml
+++ b/data/olm-catalog/ssp-operator.clusterserviceversion.yaml
@@ -221,6 +221,7 @@ spec:
           - servicemonitors
           verbs:
           - create
+          - delete
           - list
           - update
           - watch

--- a/internal/operands/data-sources/reconcile.go
+++ b/internal/operands/data-sources/reconcile.go
@@ -17,7 +17,6 @@ import (
 )
 
 // Define RBAC rules needed by this operand:
-// Define RBAC rules needed by this operand:
 // +kubebuilder:rbac:groups=core,resources=namespaces,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;roles;rolebindings,verbs=list;watch;create;update;delete
 // +kubebuilder:rbac:groups=cdi.kubevirt.io,resources=datasources,verbs=get;list;watch;create;update;patch;delete

--- a/internal/operands/metrics/reconcile.go
+++ b/internal/operands/metrics/reconcile.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Define RBAC rules needed by this operand:
-// +kubebuilder:rbac:groups=monitoring.coreos.com,resources=prometheusrules;servicemonitors,verbs=list;watch;create;update
+// +kubebuilder:rbac:groups=monitoring.coreos.com,resources=prometheusrules;servicemonitors,verbs=list;watch;create;update;delete
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings,verbs=list;watch;create;update;delete
 // +kubebuilder:rbac:groups="",resources=pods;endpoints,verbs=get;list;watch
 


### PR DESCRIPTION
**What this PR does / why we need it**:
These objects are created and owned by ssp-operator, so it needs to have permission to delete them.
Otherwise their creation fails with an error like this:

```
servicemonitors.monitoring.coreos.com "prometheus-k8s-rules-cnv" is forbidden: cannot set an ownerRef on a resource you can't delete:
```

**Release note**:
```release-note
None
```
