### PR TITLE
Bump Go to 1.23.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ARG TARGET_ARCH
 RUN microdnf install -y make tar gzip which && microdnf clean all
 
 RUN ARCH=$(uname -m | sed 's/x86_64/amd64/') && \
-    curl -L https://go.dev/dl/go1.23.6.linux-${ARCH}.tar.gz -o go.tar.gz && \
+    curl -L https://go.dev/dl/go1.23.8.linux-${ARCH}.tar.gz -o go.tar.gz && \
     tar -C /usr/local -xzf go.tar.gz && \
     rm go.tar.gz
 

--- a/ci-builder/Dockerfile
+++ b/ci-builder/Dockerfile
@@ -1,7 +1,7 @@
 # This Dockerfile is used in openshift CI
 FROM quay.io/fedora/fedora:40
 
-RUN curl -L https://go.dev/dl/go1.23.6.linux-amd64.tar.gz | tar -C /usr/local -xzf -
+RUN curl -L https://go.dev/dl/go1.23.8.linux-amd64.tar.gz | tar -C /usr/local -xzf -
 ENV PATH=$PATH:/usr/local/go/bin
 
 # Install dependencies and tools

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module kubevirt.io/ssp-operator
 
-go 1.23.6
+go 1.23.8
 
 require (
 	github.com/blang/semver/v4 v4.0.0

--- a/validator.Dockerfile
+++ b/validator.Dockerfile
@@ -11,7 +11,7 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal as builder
 ARG TARGET_ARCH
 
 RUN microdnf install -y make tar gzip which && microdnf clean all
-RUN export ARCH=$(uname -m | sed 's/x86_64/amd64/'); curl -L https://go.dev/dl/go1.23.6.linux-${ARCH}.tar.gz | tar -C /usr/local -xzf -
+RUN export ARCH=$(uname -m | sed 's/x86_64/amd64/'); curl -L https://go.dev/dl/go1.23.8.linux-${ARCH}.tar.gz | tar -C /usr/local -xzf -
 ENV PATH=$PATH:/usr/local/go/bin
 
 ARG VERSION=latest


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR addresses CVE-2025-22871 which bumps the Go version to `1.23.8` according to the [Vulnerability Report](https://pkg.go.dev/vuln/GO-2025-3563)

**Which issue(s) this PR fixes**: 
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

Fixes CVE-2025-22871


**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
