### PR TITLE
chore: Update webhook code to use SSP v1beta3

### DIFF
--- a/webhooks/convert/convert.go
+++ b/webhooks/convert/convert.go
@@ -7,23 +7,23 @@ import (
 	sspv1beta3 "kubevirt.io/ssp-operator/api/v1beta3"
 )
 
-func ConvertSSP(src *sspv1beta3.SSP) *sspv1beta2.SSP {
-	return &sspv1beta2.SSP{
+func ConvertSSP(src *sspv1beta2.SSP) *sspv1beta3.SSP {
+	return &sspv1beta3.SSP{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       src.Kind,
-			APIVersion: sspv1beta2.GroupVersion.String(),
+			APIVersion: sspv1beta3.GroupVersion.String(),
 		},
 		ObjectMeta: src.ObjectMeta,
-		Spec: sspv1beta2.SSPSpec{
+		Spec: sspv1beta3.SSPSpec{
 			TemplateValidator: convertTemplateValidator(src.Spec.TemplateValidator),
-			CommonTemplates: sspv1beta2.CommonTemplates{
+			CommonTemplates: sspv1beta3.CommonTemplates{
 				Namespace:               src.Spec.CommonTemplates.Namespace,
 				DataImportCronTemplates: convertDataImportCronTemplates(src.Spec.CommonTemplates.DataImportCronTemplates),
 			},
 			TLSSecurityProfile:     src.Spec.TLSSecurityProfile,
 			TokenGenerationService: convertTokenGenerationService(src.Spec.TokenGenerationService),
 		},
-		Status: sspv1beta2.SSPStatus{
+		Status: sspv1beta3.SSPStatus{
 			Status:             src.Status.Status,
 			Paused:             src.Status.Paused,
 			ObservedGeneration: src.Status.ObservedGeneration,
@@ -31,26 +31,26 @@ func ConvertSSP(src *sspv1beta3.SSP) *sspv1beta2.SSP {
 	}
 }
 
-func convertTemplateValidator(src *sspv1beta3.TemplateValidator) *sspv1beta2.TemplateValidator {
+func convertTemplateValidator(src *sspv1beta2.TemplateValidator) *sspv1beta3.TemplateValidator {
 	if src == nil {
 		return nil
 	}
 
-	return &sspv1beta2.TemplateValidator{
+	return &sspv1beta3.TemplateValidator{
 		Replicas:  src.Replicas,
 		Placement: src.Placement,
 	}
 }
 
-func convertDataImportCronTemplates(src []sspv1beta3.DataImportCronTemplate) []sspv1beta2.DataImportCronTemplate {
+func convertDataImportCronTemplates(src []sspv1beta2.DataImportCronTemplate) []sspv1beta3.DataImportCronTemplate {
 	if len(src) == 0 {
 		return nil
 	}
 
-	result := make([]sspv1beta2.DataImportCronTemplate, 0, len(src))
+	result := make([]sspv1beta3.DataImportCronTemplate, 0, len(src))
 	for i := range src {
 		oldTemplate := &src[i]
-		result = append(result, sspv1beta2.DataImportCronTemplate{
+		result = append(result, sspv1beta3.DataImportCronTemplate{
 			ObjectMeta: oldTemplate.ObjectMeta,
 			Spec:       oldTemplate.Spec,
 		})
@@ -59,12 +59,12 @@ func convertDataImportCronTemplates(src []sspv1beta3.DataImportCronTemplate) []s
 	return result
 }
 
-func convertTokenGenerationService(src *sspv1beta3.TokenGenerationService) *sspv1beta2.TokenGenerationService {
+func convertTokenGenerationService(src *sspv1beta2.TokenGenerationService) *sspv1beta3.TokenGenerationService {
 	if src == nil {
 		return nil
 	}
 
-	return &sspv1beta2.TokenGenerationService{
+	return &sspv1beta3.TokenGenerationService{
 		Enabled: src.Enabled,
 	}
 }

--- a/webhooks/ssp_webhook.go
+++ b/webhooks/ssp_webhook.go
@@ -73,7 +73,7 @@ func (s *sspValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (
 		return nil, err
 	}
 
-	var ssps sspv1beta2.SSPList
+	var ssps sspv1beta3.SSPList
 
 	// Check if no other SSP resources are present in the cluster
 	ssplog.Info("validate create", "name", sspObj.Name)
@@ -103,7 +103,7 @@ func (s *sspValidator) ValidateDelete(_ context.Context, _ runtime.Object) (admi
 	return nil, nil
 }
 
-func (s *sspValidator) validateSspObject(ctx context.Context, ssp *sspv1beta2.SSP) (admission.Warnings, error) {
+func (s *sspValidator) validateSspObject(ctx context.Context, ssp *sspv1beta3.SSP) (admission.Warnings, error) {
 	if err := validateDataImportCronTemplates(ssp); err != nil {
 		return nil, fmt.Errorf("dataImportCronTemplates validation error: %w", err)
 	}
@@ -115,7 +115,7 @@ func (s *sspValidator) validateSspObject(ctx context.Context, ssp *sspv1beta2.SS
 	return nil, nil
 }
 
-func (s *sspValidator) validatePlacement(ctx context.Context, ssp *sspv1beta2.SSP) error {
+func (s *sspValidator) validatePlacement(ctx context.Context, ssp *sspv1beta3.SSP) error {
 	if ssp.Spec.TemplateValidator == nil {
 		return nil
 	}
@@ -174,7 +174,7 @@ func (s *sspValidator) validateOperandPlacement(ctx context.Context, namespace s
 }
 
 // TODO: also validate DataImportCronTemplates in general once CDI exposes its own validation
-func validateDataImportCronTemplates(ssp *sspv1beta2.SSP) error {
+func validateDataImportCronTemplates(ssp *sspv1beta3.SSP) error {
 	for _, cron := range ssp.Spec.CommonTemplates.DataImportCronTemplates {
 		if cron.Name == "" {
 			return fmt.Errorf("missing name in DataImportCronTemplate")
@@ -187,11 +187,11 @@ func newSspValidator(clt client.Client) *sspValidator {
 	return &sspValidator{apiClient: clt}
 }
 
-func getSsp(obj runtime.Object) (*sspv1beta2.SSP, error) {
+func getSsp(obj runtime.Object) (*sspv1beta3.SSP, error) {
 	switch sspObj := obj.(type) {
-	case *sspv1beta2.SSP:
-		return sspObj, nil
 	case *sspv1beta3.SSP:
+		return sspObj, nil
+	case *sspv1beta2.SSP:
 		return convert.ConvertSSP(sspObj), nil
 	default:
 		return nil, fmt.Errorf("unexpected type: %T", obj)

--- a/webhooks/ssp_webhook_test.go
+++ b/webhooks/ssp_webhook_test.go
@@ -68,17 +68,17 @@ var _ = Describe("SSP Validation", func() {
 
 	Context("creating SSP CR", func() {
 		BeforeEach(func() {
-			err := apiClient.Create(ctx, &sspv1beta2.SSP{
+			err := apiClient.Create(ctx, &sspv1beta3.SSP{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-ssp",
 					Namespace: "test-ns",
 				},
-				Spec: sspv1beta2.SSPSpec{},
+				Spec: sspv1beta3.SSPSpec{},
 			})
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("should reject v1beta2.SSP when one is already present", func() {
+		It("should reject v1beta2.SSP when v1beta3.SSP is already present", func() {
 			ssp := &sspv1beta2.SSP{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-ssp2",
@@ -91,7 +91,7 @@ var _ = Describe("SSP Validation", func() {
 			Expect(err).To(MatchError(ContainSubstring("creation failed, an SSP CR already exists in namespace test-ns: test-ssp")))
 		})
 
-		It("should reject v1beta3.SSP when v1beta2.SSP is already present", func() {
+		It("should reject v1beta3.SSP when one is already present", func() {
 			ssp := &sspv1beta3.SSP{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-ssp2",


### PR DESCRIPTION
**What this PR does / why we need it**:
Previous PR did not update webhook code: https://github.com/kubevirt/ssp-operator/pull/1405

**Release note**:
```release-note
None
```
