### PR TITLE
chore: webhook: Move placement validation to the end

### DIFF
--- a/webhooks/ssp_webhook.go
+++ b/webhooks/ssp_webhook.go
@@ -104,12 +104,12 @@ func (s *sspValidator) ValidateDelete(_ context.Context, _ runtime.Object) (admi
 }
 
 func (s *sspValidator) validateSspObject(ctx context.Context, ssp *sspv1beta2.SSP) (admission.Warnings, error) {
-	if err := s.validatePlacement(ctx, ssp); err != nil {
-		return nil, fmt.Errorf("placement api validation error: %w", err)
-	}
-
 	if err := validateDataImportCronTemplates(ssp); err != nil {
 		return nil, fmt.Errorf("dataImportCronTemplates validation error: %w", err)
+	}
+
+	if err := s.validatePlacement(ctx, ssp); err != nil {
+		return nil, fmt.Errorf("placement api validation error: %w", err)
 	}
 
 	return nil, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Placement validation calls API server, so it is better to do it last, when we are sure that the SSP object is correct.

**Release note**:
```release-note
None
```
