### PR TITLE
feat: Add common templates for heterogeneous clusters

### DIFF
--- a/internal/architecture/architecture.go
+++ b/internal/architecture/architecture.go
@@ -1,0 +1,32 @@
+package architecture
+
+import "fmt"
+
+type Arch string
+
+const (
+	AMD64 Arch = "amd64"
+	ARM64 Arch = "arm64"
+	S390X Arch = "s390x"
+)
+
+func ToArch(arch string) (Arch, error) {
+	switch arch {
+	case string(AMD64):
+		return AMD64, nil
+	case string(ARM64):
+		return ARM64, nil
+	case string(S390X):
+		return S390X, nil
+	default:
+		return "", fmt.Errorf("unknown architecture: %s", arch)
+	}
+}
+
+func ToArchOrPanic(arch string) Arch {
+	result, err := ToArch(arch)
+	if err != nil {
+		panic(err)
+	}
+	return result
+}

--- a/internal/controllers/setup.go
+++ b/internal/controllers/setup.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 
 	"github.com/go-logr/logr"
 	v1 "github.com/openshift/api/config/v1"
@@ -48,10 +49,7 @@ func CreateControllers(ctx context.Context, apiReader client.Reader) ([]Controll
 		return nil, fmt.Errorf("failed to check if running on openshift: %w", err)
 	}
 
-	templatesBundleFile, err := template_bundle.RetrieveCommonTemplatesBundleFile(templateBundleDir)
-	if err != nil {
-		return nil, err
-	}
+	templatesBundleFile := filepath.Join(templateBundleDir, fmt.Sprintf("common-templates-%s.yaml", common_templates.Version))
 	templatesBundle, err := template_bundle.ReadBundle(templatesBundleFile)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read template bundle: %w", err)

--- a/internal/operands/common-templates/architecture.go
+++ b/internal/operands/common-templates/architecture.go
@@ -1,0 +1,21 @@
+package common_templates
+
+import (
+	templatev1 "github.com/openshift/api/template/v1"
+
+	"kubevirt.io/ssp-operator/internal/architecture"
+)
+
+func GetTemplateArch(template *templatev1.Template) (architecture.Arch, error) {
+	templateArchLabel := template.Labels[TemplateArchitectureLabel]
+	if templateArchLabel == "" {
+		return TemplateDefaultArchitecture, nil
+	}
+
+	arch, err := architecture.ToArch(templateArchLabel)
+	if err != nil {
+		return "", err
+	}
+
+	return arch, nil
+}

--- a/internal/operands/common-templates/architecture_test.go
+++ b/internal/operands/common-templates/architecture_test.go
@@ -1,0 +1,48 @@
+package common_templates
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	templatev1 "github.com/openshift/api/template/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"kubevirt.io/ssp-operator/internal/architecture"
+)
+
+var _ = Describe("GetTemplateArch()", func() {
+	It("should read architecture from label", func() {
+		const testArch = architecture.ARM64
+		template := &templatev1.Template{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test",
+				Labels: map[string]string{
+					TemplateArchitectureLabel: string(testArch),
+				},
+			},
+		}
+		Expect(GetTemplateArch(template)).To(Equal(testArch))
+	})
+
+	It("should use default architecture if label is missing", func() {
+		template := &templatev1.Template{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test",
+			},
+		}
+		Expect(GetTemplateArch(template)).To(Equal(TemplateDefaultArchitecture))
+	})
+
+	It("should fail, if architecture value is not known", func() {
+		template := &templatev1.Template{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test",
+				Labels: map[string]string{
+					TemplateArchitectureLabel: "unknown-arch",
+				},
+			},
+		}
+		_, err := GetTemplateArch(template)
+		Expect(err).To(MatchError(ContainSubstring("unknown architecture: unknown-arch")))
+	})
+})

--- a/internal/operands/common-templates/common_templates_suite_test.go
+++ b/internal/operands/common-templates/common_templates_suite_test.go
@@ -1,0 +1,13 @@
+package common_templates
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestTemplates(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Common Templates Suite")
+}

--- a/internal/operands/common-templates/constants.go
+++ b/internal/operands/common-templates/constants.go
@@ -1,9 +1,13 @@
 package common_templates
 
+import "kubevirt.io/ssp-operator/internal/architecture"
+
 const (
 	TemplateVersionLabel         = "template.kubevirt.io/version"
 	TemplateTypeLabel            = "template.kubevirt.io/type"
 	TemplateTypeLabelBaseValue   = "base"
+	TemplateArchitectureLabel    = "template.kubevirt.io/architecture"
+	TemplateDefaultArchitecture  = architecture.AMD64
 	TemplateOsLabelPrefix        = "os.template.kubevirt.io/"
 	TemplateFlavorLabelPrefix    = "flavor.template.kubevirt.io/"
 	TemplateWorkloadLabelPrefix  = "workload.template.kubevirt.io/"

--- a/internal/operands/common-templates/reconcile.go
+++ b/internal/operands/common-templates/reconcile.go
@@ -179,7 +179,7 @@ func (c *commonTemplates) reconcileOlderTemplates(request *common.Request) ([]co
 		return nil, err
 	}
 
-	templatesVersion, err := semver.ParseTolerant(Version)
+	latestTemplateVersion, err := semver.ParseTolerant(Version)
 	if err != nil {
 		return nil, err
 	}
@@ -192,11 +192,11 @@ func (c *commonTemplates) reconcileOlderTemplates(request *common.Request) ([]co
 			continue
 		}
 
-		// if template has higher version than is defined in ssp operator, keep it as it is. If parsing
-		// of template version fails, continue with adding deprecated label
+		// If template has lower version, than what is defined in ssp operator, deprecate it.
+		// Deprecate also, if version label cannot be parsed.
 		if template.Labels[TemplateVersionLabel] != "" {
-			v, err := semver.ParseTolerant(template.Labels[TemplateVersionLabel])
-			if err == nil && templatesVersion.Compare(v) == -1 {
+			version, err := semver.ParseTolerant(template.Labels[TemplateVersionLabel])
+			if err == nil && latestTemplateVersion.Compare(version) != 1 {
 				continue
 			}
 		}

--- a/internal/operands/data-sources/reconcile.go
+++ b/internal/operands/data-sources/reconcile.go
@@ -62,7 +62,12 @@ type dataSources struct {
 
 var _ operands.Operand = &dataSources{}
 
-func New(sources []cdiv1beta1.DataSource) operands.Operand {
+func New(sourceNames []string) operands.Operand {
+	sources := make([]cdiv1beta1.DataSource, 0, len(sourceNames))
+	for _, name := range sourceNames {
+		sources = append(sources, newDataSource(name))
+	}
+
 	return &dataSources{
 		sources: sources,
 	}

--- a/internal/operands/data-sources/reconcile_test.go
+++ b/internal/operands/data-sources/reconcile_test.go
@@ -42,7 +42,11 @@ var _ = Describe("Data-Sources operand", func() {
 	BeforeEach(func() {
 		testDataSources = getDataSources()
 
-		operand = New(testDataSources)
+		var dsNames []string
+		for _, ds := range testDataSources {
+			dsNames = append(dsNames, ds.Name)
+		}
+		operand = New(dsNames)
 
 		client := fake.NewClientBuilder().WithScheme(common.Scheme).Build()
 		request = common.Request{

--- a/internal/operands/data-sources/resource.go
+++ b/internal/operands/data-sources/resource.go
@@ -5,12 +5,31 @@ import (
 	rbac "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	cdiv1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+
+	"kubevirt.io/ssp-operator/internal"
 )
 
 const (
 	ViewRoleName        = "os-images.kubevirt.io:view"
 	EditClusterRoleName = "os-images.kubevirt.io:edit"
 )
+
+func newDataSource(name string) cdiv1beta1.DataSource {
+	return cdiv1beta1.DataSource{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: internal.GoldenImagesNamespace,
+		},
+		Spec: cdiv1beta1.DataSourceSpec{
+			Source: cdiv1beta1.DataSourceSource{
+				PVC: &cdiv1beta1.DataVolumeSourcePVC{
+					Name:      name,
+					Namespace: internal.GoldenImagesNamespace,
+				},
+			},
+		},
+	}
+}
 
 func newGoldenImagesNS(namespace string) *core.Namespace {
 	return &core.Namespace{

--- a/internal/template-bundle/bundle_test.go
+++ b/internal/template-bundle/bundle_test.go
@@ -1,15 +1,11 @@
 package template_bundle
 
 import (
-	"fmt"
-	"os"
-	"path/filepath"
 	"runtime"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	common_templates "kubevirt.io/ssp-operator/internal/operands/common-templates"
 )
 
 func retrieveSuffix() string {
@@ -23,11 +19,8 @@ func retrieveSuffix() string {
 
 var _ = Describe("Template bundle", Ordered, func() {
 	var (
-		testBundle          Bundle
-		nameSuffix          string
-		tmpDir              string
-		archIndependentFile string
-		archDependentFile   string
+		testBundle Bundle
+		nameSuffix string
 	)
 
 	BeforeAll(func() {
@@ -35,12 +28,6 @@ var _ = Describe("Template bundle", Ordered, func() {
 		testBundle, err = ReadBundle("template-bundle-test.yaml")
 		Expect(err).ToNot(HaveOccurred())
 		nameSuffix = retrieveSuffix()
-	})
-
-	BeforeEach(func() {
-		tmpDir = GinkgoT().TempDir()
-		archIndependentFile = filepath.Join(tmpDir, fmt.Sprintf("common-templates-%s.yaml", common_templates.Version))
-		archDependentFile = filepath.Join(tmpDir, fmt.Sprintf("common-templates-%s-%s.yaml", runtime.GOARCH, common_templates.Version))
 	})
 
 	It("should correctly read templates", func() {
@@ -89,36 +76,6 @@ var _ = Describe("Template bundle", Ordered, func() {
 		Expect(ds2.Spec.Source.PVC.Namespace).To(Equal("kubevirt-os-images"))
 	})
 
-	It("should throw an error retrieving the bundle file", func() {
-		_, err := RetrieveCommonTemplatesBundleFile(tmpDir)
-		Expect(err).To(MatchError(ContainSubstring("failed to find common-templates bundles, none of the files were found")))
-	})
-
-	It("should retrieve the bundle arch independent file", func() {
-		err := os.WriteFile(archIndependentFile, []byte(""), 0644)
-		Expect(err).ToNot(HaveOccurred())
-		commonTemplatesBundleFile, err := RetrieveCommonTemplatesBundleFile(tmpDir)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(commonTemplatesBundleFile).To(Equal(archIndependentFile))
-	})
-
-	It("should retrieve the bundle arch dependent file", func() {
-		err := os.WriteFile(archDependentFile, []byte(""), 0644)
-		Expect(err).ToNot(HaveOccurred())
-		commonTemplatesBundleFile, err := RetrieveCommonTemplatesBundleFile(tmpDir)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(commonTemplatesBundleFile).To(Equal(archDependentFile))
-	})
-
-	It("should retrieve the bundle arch dependent file when the generic one also exists", func() {
-		err := os.WriteFile(archIndependentFile, []byte(""), 0644)
-		Expect(err).ToNot(HaveOccurred())
-		err = os.WriteFile(archDependentFile, []byte(""), 0644)
-		Expect(err).ToNot(HaveOccurred())
-		commonTemplatesBundleFile, err := RetrieveCommonTemplatesBundleFile(tmpDir)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(commonTemplatesBundleFile).To(Equal(archDependentFile))
-	})
 })
 
 func TestTemplateBundle(t *testing.T) {

--- a/internal/template-bundle/bundle_test.go
+++ b/internal/template-bundle/bundle_test.go
@@ -6,6 +6,13 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	templatev1 "github.com/openshift/api/template/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/json"
+	kubevirtv1 "kubevirt.io/api/core/v1"
+	cdiv1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 )
 
 func retrieveSuffix() string {
@@ -17,65 +24,105 @@ func retrieveSuffix() string {
 	}
 }
 
-var _ = Describe("Template bundle", Ordered, func() {
-	var (
-		testBundle Bundle
-		nameSuffix string
-	)
-
-	BeforeAll(func() {
-		var err error
-		testBundle, err = ReadBundle("template-bundle-test.yaml")
+var _ = Describe("Template bundle", func() {
+	It("ReadTemplates() should correctly read templates", func() {
+		testTemplates, err := ReadTemplates("template-bundle-test.yaml")
 		Expect(err).ToNot(HaveOccurred())
-		nameSuffix = retrieveSuffix()
-	})
 
-	It("should correctly read templates", func() {
-		templates := testBundle.Templates
-		Expect(templates).To(HaveLen(4))
+		nameSuffix := retrieveSuffix()
+
+		Expect(testTemplates).To(HaveLen(4))
 		{
-			templ := templates[0]
+			templ := testTemplates[0]
 			Expect(templ.Name).To(Equal("centos-stream8-server-medium" + nameSuffix))
 			Expect(templ.Annotations).To(HaveKey("name.os.template.kubevirt.io/centos-stream8"))
 			Expect(templ.Objects).To(HaveLen(1))
 		}
 		{
-			templ := templates[1]
+			templ := testTemplates[1]
 			Expect(templ.Name).To(Equal("centos-stream8-desktop-large" + nameSuffix))
 			Expect(templ.Annotations).To(HaveKey("name.os.template.kubevirt.io/centos-stream8"))
 			Expect(templ.Objects).To(HaveLen(1))
 		}
 		{
-			templ := templates[2]
+			templ := testTemplates[2]
 			Expect(templ.Name).To(Equal("windows10-desktop-medium" + nameSuffix))
 			Expect(templ.Annotations).To(HaveKey("name.os.template.kubevirt.io/win10"))
 			Expect(templ.Objects).To(HaveLen(1))
 		}
 		{
-			templ := templates[3]
+			templ := testTemplates[3]
 			Expect(templ.Name).To(Equal("rhel8-saphana-tiny" + nameSuffix))
 			Expect(templ.Annotations).To(HaveKey("name.os.template.kubevirt.io/rhel8.4"))
 			Expect(templ.Objects).To(HaveLen(1))
 		}
 	})
 
-	It("should create DataSources", func() {
-		dataSources := testBundle.DataSources
-		Expect(dataSources).To(HaveLen(2))
+	Context("CollectDataSourceNames", func() {
+		It("should collect DataSource names", func() {
+			// The template object is not strictly a VirtualMachine, because it can contain
+			// string variables in fields that don't have string type. But for this test code,
+			// we don't use any such variables.
+			testVmTemplate := &kubevirtv1.VirtualMachine{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "VirtualMachine",
+					APIVersion: kubevirtv1.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec: kubevirtv1.VirtualMachineSpec{
+					DataVolumeTemplates: []kubevirtv1.DataVolumeTemplateSpec{{
+						Spec: cdiv1beta1.DataVolumeSpec{
+							SourceRef: &cdiv1beta1.DataVolumeSourceRef{},
+						},
+					}},
+				},
+			}
 
-		ds1 := dataSources[0]
-		Expect(ds1.Name).To(Equal("centos-stream8"))
-		Expect(ds1.Namespace).To(Equal("kubevirt-os-images"))
-		Expect(ds1.Spec.Source.PVC.Name).To(Equal("centos-stream8"))
-		Expect(ds1.Spec.Source.PVC.Namespace).To(Equal("kubevirt-os-images"))
+			testTemplates := []templatev1.Template{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "centos-stream8-server-medium",
+				},
+				Objects: []k8sruntime.RawExtension{{
+					Object: testVmTemplate,
+				}},
+				Parameters: []templatev1.Parameter{{
+					Name:  "DATA_SOURCE_NAME",
+					Value: "centos-stream8",
+				}, {
+					Name:  "DATA_SOURCE_NAMESPACE",
+					Value: "kubevirt-os-images",
+				}},
+			}, {
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "windows10-desktop-medium",
+				},
+				Objects: []k8sruntime.RawExtension{{
+					Object: testVmTemplate,
+				}},
+				Parameters: []templatev1.Parameter{{
+					Name:  "DATA_SOURCE_NAME",
+					Value: "win10",
+				}, {
+					Name:  "DATA_SOURCE_NAMESPACE",
+					Value: "kubevirt-os-images",
+				}},
+			}}
 
-		ds2 := dataSources[1]
-		Expect(ds2.Name).To(Equal("win10"))
-		Expect(ds2.Namespace).To(Equal("kubevirt-os-images"))
-		Expect(ds2.Spec.Source.PVC.Name).To(Equal("win10"))
-		Expect(ds2.Spec.Source.PVC.Namespace).To(Equal("kubevirt-os-images"))
+			for i := range testTemplates {
+				for j := range testTemplates[i].Objects {
+					object := &testTemplates[i].Objects[j]
+					var err error
+					object.Raw, err = json.Marshal(object.Object)
+					Expect(err).ToNot(HaveOccurred())
+				}
+			}
+
+			dataSourceNames, err := CollectDataSourceNames(testTemplates)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(dataSourceNames).To(ConsistOf("centos-stream8", "win10"))
+		})
 	})
-
 })
 
 func TestTemplateBundle(t *testing.T) {

--- a/internal/template-bundle/bundle_test.go
+++ b/internal/template-bundle/bundle_test.go
@@ -1,11 +1,11 @@
 package template_bundle
 
 import (
-	"runtime"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"kubevirt.io/ssp-operator/internal/architecture"
 
 	templatev1 "github.com/openshift/api/template/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -15,50 +15,64 @@ import (
 	cdiv1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 )
 
-func retrieveSuffix() string {
-	switch runtime.GOARCH {
-	case "s390x":
-		return "-s390x"
-	default:
-		return ""
-	}
-}
-
 var _ = Describe("Template bundle", func() {
 	It("ReadTemplates() should correctly read templates", func() {
 		testTemplates, err := ReadTemplates("template-bundle-test.yaml")
 		Expect(err).ToNot(HaveOccurred())
 
-		nameSuffix := retrieveSuffix()
-
-		Expect(testTemplates).To(HaveLen(4))
+		Expect(testTemplates).To(HaveLen(8))
 		{
 			templ := testTemplates[0]
-			Expect(templ.Name).To(Equal("centos-stream8-server-medium" + nameSuffix))
+			Expect(templ.Name).To(Equal("centos-stream8-server-medium"))
 			Expect(templ.Annotations).To(HaveKey("name.os.template.kubevirt.io/centos-stream8"))
 			Expect(templ.Objects).To(HaveLen(1))
 		}
 		{
 			templ := testTemplates[1]
-			Expect(templ.Name).To(Equal("centos-stream8-desktop-large" + nameSuffix))
+			Expect(templ.Name).To(Equal("centos-stream8-desktop-large"))
 			Expect(templ.Annotations).To(HaveKey("name.os.template.kubevirt.io/centos-stream8"))
 			Expect(templ.Objects).To(HaveLen(1))
 		}
 		{
 			templ := testTemplates[2]
-			Expect(templ.Name).To(Equal("windows10-desktop-medium" + nameSuffix))
+			Expect(templ.Name).To(Equal("windows10-desktop-medium"))
 			Expect(templ.Annotations).To(HaveKey("name.os.template.kubevirt.io/win10"))
 			Expect(templ.Objects).To(HaveLen(1))
 		}
 		{
 			templ := testTemplates[3]
-			Expect(templ.Name).To(Equal("rhel8-saphana-tiny" + nameSuffix))
+			Expect(templ.Name).To(Equal("rhel8-saphana-tiny"))
+			Expect(templ.Annotations).To(HaveKey("name.os.template.kubevirt.io/rhel8.4"))
+			Expect(templ.Objects).To(HaveLen(1))
+		}
+
+		{
+			templ := testTemplates[4]
+			Expect(templ.Name).To(Equal("centos-stream8-server-medium-" + string(architecture.S390X)))
+			Expect(templ.Annotations).To(HaveKey("name.os.template.kubevirt.io/centos-stream8"))
+			Expect(templ.Objects).To(HaveLen(1))
+		}
+		{
+			templ := testTemplates[5]
+			Expect(templ.Name).To(Equal("centos-stream8-desktop-large-" + string(architecture.S390X)))
+			Expect(templ.Annotations).To(HaveKey("name.os.template.kubevirt.io/centos-stream8"))
+			Expect(templ.Objects).To(HaveLen(1))
+		}
+		{
+			templ := testTemplates[6]
+			Expect(templ.Name).To(Equal("windows10-desktop-medium-" + string(architecture.S390X)))
+			Expect(templ.Annotations).To(HaveKey("name.os.template.kubevirt.io/win10"))
+			Expect(templ.Objects).To(HaveLen(1))
+		}
+		{
+			templ := testTemplates[7]
+			Expect(templ.Name).To(Equal("rhel8-saphana-tiny-" + string(architecture.S390X)))
 			Expect(templ.Annotations).To(HaveKey("name.os.template.kubevirt.io/rhel8.4"))
 			Expect(templ.Objects).To(HaveLen(1))
 		}
 	})
 
-	Context("CollectDataSourceNames", func() {
+	Context("CollectDataSources", func() {
 		It("should collect DataSource names", func() {
 			// The template object is not strictly a VirtualMachine, because it can contain
 			// string variables in fields that don't have string type. But for this test code,
@@ -78,6 +92,11 @@ var _ = Describe("Template bundle", func() {
 				},
 			}
 
+			const (
+				centosDsName  = "centos-stream8"
+				windowsDsName = "win10"
+			)
+
 			testTemplates := []templatev1.Template{{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "centos-stream8-server-medium",
@@ -87,7 +106,7 @@ var _ = Describe("Template bundle", func() {
 				}},
 				Parameters: []templatev1.Parameter{{
 					Name:  "DATA_SOURCE_NAME",
-					Value: "centos-stream8",
+					Value: centosDsName,
 				}, {
 					Name:  "DATA_SOURCE_NAMESPACE",
 					Value: "kubevirt-os-images",
@@ -101,7 +120,7 @@ var _ = Describe("Template bundle", func() {
 				}},
 				Parameters: []templatev1.Parameter{{
 					Name:  "DATA_SOURCE_NAME",
-					Value: "win10",
+					Value: windowsDsName,
 				}, {
 					Name:  "DATA_SOURCE_NAMESPACE",
 					Value: "kubevirt-os-images",
@@ -117,10 +136,11 @@ var _ = Describe("Template bundle", func() {
 				}
 			}
 
-			dataSourceNames, err := CollectDataSourceNames(testTemplates)
+			dataSourceCollection, err := CollectDataSources(testTemplates)
 			Expect(err).ToNot(HaveOccurred())
 
-			Expect(dataSourceNames).To(ConsistOf("centos-stream8", "win10"))
+			Expect(dataSourceCollection.Names()).To(ContainElement(centosDsName))
+			Expect(dataSourceCollection.Names()).To(ContainElement(windowsDsName))
 		})
 	})
 })

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -483,6 +483,7 @@ func getSsp() *sspv1beta3.SSP {
 	key := client.ObjectKey{Name: strategy.GetName(), Namespace: strategy.GetNamespace()}
 	foundSsp := &sspv1beta3.SSP{}
 	Expect(apiClient.Get(ctx, key, foundSsp)).ToNot(HaveOccurred())
+	foundSsp.SetGroupVersionKind(sspv1beta3.GroupVersion.WithKind("SSP"))
 	return foundSsp
 }
 

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -10,6 +10,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"kubevirt.io/ssp-operator/internal/architecture"
 
 	osconfv1 "github.com/openshift/api/config/v1"
 	routev1 "github.com/openshift/api/route/v1"
@@ -52,10 +53,7 @@ var (
 )
 
 const (
-	amd64   = "amd64"
-	s390x   = "s390x"
 	arm     = "arm"
-	arm64   = "arm64"
 	aarch64 = "aarch64"
 )
 
@@ -607,25 +605,31 @@ func retrieveNodeArchitecture() string {
 	Expect(err).NotTo(HaveOccurred(), "Failed to list nodes")
 	nodes := nodeList.Items
 	Expect(nodes).NotTo(BeEmpty(), "No nodes found")
-	architecture := nodes[0].Status.NodeInfo.Architecture
-	Expect(architecture).To(BeElementOf([]string{s390x, amd64, arm, arm64, aarch64}), "Unsupported architecture")
-	return architecture
+	arch := nodes[0].Status.NodeInfo.Architecture
+	Expect(arch).To(BeElementOf([]string{
+		string(architecture.S390X),
+		string(architecture.AMD64),
+		arm,
+		string(architecture.ARM64),
+		aarch64}), "Unsupported architecture")
+
+	return arch
 }
 
-func retrieveQemuMachineType(architecture string) string {
-	switch architecture {
-	case amd64:
+func retrieveQemuMachineType(arch string) string {
+	switch arch {
+	case string(architecture.AMD64):
 		return "q35"
-	case s390x:
+	case string(architecture.S390X):
 		return "s390-ccw-virtio"
 	default:
 		return "virt"
 	}
 }
 
-func retrieveTemplatesSuffix(architecture string) string {
-	if architecture == amd64 {
+func retrieveTemplatesSuffix(arch string) string {
+	if arch == string(architecture.AMD64) {
 		return ""
 	}
-	return "-" + architecture
+	return "-" + arch
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Added logic to create common templates for multiple architectures.

**Which issue(s) this PR fixes**: 
Implements a part of the SSP work of: https://github.com/kubevirt/enhancements/pull/49

Jira: https://issues.redhat.com/browse/CNV-61575


**Release note**:
```release-note
Added logic to create common templates for multiple architectures.
```
