### PR TITLE
ci: update base image to use golang 1.24.3

### DIFF
--- a/ci-builder/Dockerfile
+++ b/ci-builder/Dockerfile
@@ -1,7 +1,7 @@
 # This Dockerfile is used in openshift CI
-FROM quay.io/fedora/fedora:40
+FROM quay.io/fedora/fedora:42
 
-RUN curl -L https://go.dev/dl/go1.23.6.linux-amd64.tar.gz | tar -C /usr/local -xzf -
+RUN curl -L https://go.dev/dl/go1.24.3.linux-amd64.tar.gz | tar -C /usr/local -xzf -
 ENV PATH=$PATH:/usr/local/go/bin
 
 # Install dependencies and tools


### PR DESCRIPTION
**What this PR does / why we need it**:
CI base image needs to be updated before we update the rest of code to golang 1.24, because CI uses the image that is merged, not the one in a PR.

**Release note**:
```release-note
None.
```
