### PR TITLE
DNM WIP feat: Add network-policy-generator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,11 @@ manager: generate lint fmt vet
 csv-generator: generate lint fmt vet
 	go build -o bin/csv-generator hack/csv-generator.go
 
+# Build network-policy-generator binary
+.PHONY: network-policy-generator
+network-policy-generator: lint fmt vet
+	go build -o bin/network-policy-generator tools/network-policy-generator/*.go
+
 # Run against the configured Kubernetes cluster in ~/.kube/config
 .PHONY: run
 run: generate lint fmt vet manifests

--- a/tools/network-policy-generator/network-policy-generator.go
+++ b/tools/network-policy-generator/network-policy-generator.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/yaml"
+)
+
+func main() {
+	if err := newCmd().Execute(); err != nil {
+		// Ignoring returned error: no reasonable way to handle it.
+		_, _ = fmt.Fprintf(os.Stderr, "%v", err)
+		os.Exit(1)
+	}
+}
+
+func newCmd() *cobra.Command {
+	g := &Generator{}
+	cmd := &cobra.Command{
+		Use:   "network-policy-generator",
+		Short: "network policy generator for ssp operator",
+		Long:  "network-policy-generator generates NetworkPolicies for ssp operator",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			for _, v := range g.Generate() {
+				if err := marshal(v, cmd.OutOrStdout()); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&g.Namespace, "namespace", "kubevirt", "Namespace in which ssp operator will be deployed (for OKD/OCP set to \"openshift-cnv\")")
+	cmd.Flags().StringVar(&g.APINamespace, "api-namespace", "kube-system", "kube-apiserver namespace for the api network policy (for OKD/OCP set to \"openshift-kube-apiserver\")")
+	cmd.Flags().StringVar(&g.APILabelKey, "api-pod-selector-label", "component", "kube-apiserver pod selector label key for the api network policy (for OKD/OCP set to \"app\")")
+	cmd.Flags().StringVar(&g.APILabelValue, "api-pod-selector-value", "kube-apiserver", "kube-apiserver pod selector label value for the api network policy (for OKD/OCP set to \"openshift-kube-apiserver\")")
+	cmd.Flags().Int32Var(&g.APIPort, "api-pod-port", 6443, "kube-apiserver pod port value for the api network policy")
+	cmd.Flags().StringVar(&g.DNSNamespace, "dns-namespace", "kube-system", "DNS namespace for the DNS network policy (for OKD/OCP set to \"openshift-dns\")")
+	cmd.Flags().StringVar(&g.DNSLabelKey, "dns-pod-selector-label", "k8s-app", "DNS pod selector label key for the DNS network policy (for OKD/OCP set to \"dns.operator.openshift.io/daemonset-dns\")")
+	cmd.Flags().StringVar(&g.DNSLabelValue, "dns-pod-selector-value", "kube-dns", "DNS pod selector label value for the DNS network policy (for OKD/OCP set to \"default\")")
+	cmd.Flags().Int32Var(&g.DNSPort, "dns-pod-port", 53, "DNS pod port value for the DNS network policy (for OKD/OCP set to \"5353\")")
+
+	return cmd
+}
+
+func marshal(obj any, w io.Writer) error {
+	data, err := yaml.Marshal(obj)
+	if err != nil {
+		return err
+	}
+
+	var r unstructured.Unstructured
+	if err := yaml.Unmarshal(data, &r.Object); err != nil {
+		return err
+	}
+
+	// remove metadata.creationTimestamp
+	unstructured.RemoveNestedField(r.Object, "metadata", "creationTimestamp")
+
+	data, err = yaml.Marshal(r.Object)
+	if err != nil {
+		return err
+	}
+
+	if _, err := w.Write([]byte("---\n")); err != nil {
+		return err
+	}
+	if _, err := w.Write(data); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/tools/network-policy-generator/networkpolicies.go
+++ b/tools/network-policy-generator/networkpolicies.go
@@ -1,0 +1,228 @@
+package main
+
+import (
+	k8sv1 "k8s.io/api/core/v1"
+	networkv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
+)
+
+type Generator struct {
+	Namespace     string
+	APINamespace  string
+	APILabelKey   string
+	APILabelValue string
+	APIPort       int32
+	DNSNamespace  string
+	DNSLabelKey   string
+	DNSLabelValue string
+	DNSPort       int32
+}
+
+func (g *Generator) Generate() []*networkv1.NetworkPolicy {
+	return []*networkv1.NetworkPolicy{
+		g.newEgressToKubeAPI(),
+		g.newEgressToKubeDNS(),
+		g.newIngressToSSPOperatorWebhook(),
+		g.newIngressToSSPOperatorMetrics(),
+		g.newIngressToVirtTemplateValidatorWebhookAndMetrics(),
+		g.newIngressToVMConsoleProxyAPI(),
+	}
+}
+
+func newNetworkPolicy(namespace, name string, spec *networkv1.NetworkPolicySpec) *networkv1.NetworkPolicy {
+	return &networkv1.NetworkPolicy{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "networking.k8s.io/v1",
+			Kind:       "NetworkPolicy",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: *spec,
+	}
+}
+
+func (g *Generator) newEgressToKubeAPI() *networkv1.NetworkPolicy {
+	return newNetworkPolicy(
+		g.Namespace,
+		"ssp-operator-allow-egress-to-kube-api",
+		&networkv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      "name",
+						Operator: metav1.LabelSelectorOpIn,
+						Values: []string{
+							"ssp-operator",
+							"virt-template-validator",
+							"vm-console-proxy",
+						},
+					},
+				},
+			},
+			PolicyTypes: []networkv1.PolicyType{networkv1.PolicyTypeEgress},
+			Egress: []networkv1.NetworkPolicyEgressRule{
+				{
+					To: []networkv1.NetworkPolicyPeer{
+						{
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{"kubernetes.io/metadata.name": g.APINamespace},
+							},
+							PodSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{g.APILabelKey: g.APILabelValue},
+							},
+						},
+					},
+					Ports: []networkv1.NetworkPolicyPort{
+						{
+							Port:     ptr.To(intstr.FromInt32(g.APIPort)),
+							Protocol: ptr.To(k8sv1.ProtocolTCP),
+						},
+					},
+				},
+			},
+		},
+	)
+}
+
+func (g *Generator) newEgressToKubeDNS() *networkv1.NetworkPolicy {
+	return newNetworkPolicy(
+		g.Namespace,
+		"ssp-operator-allow-egress-to-kube-dns",
+		&networkv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      "name",
+						Operator: metav1.LabelSelectorOpIn,
+						Values: []string{
+							"ssp-operator",
+							"virt-template-validator",
+							"vm-console-proxy",
+						},
+					},
+				},
+			},
+			PolicyTypes: []networkv1.PolicyType{networkv1.PolicyTypeEgress},
+			Egress: []networkv1.NetworkPolicyEgressRule{
+				{
+					To: []networkv1.NetworkPolicyPeer{
+						{
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{"kubernetes.io/metadata.name": g.DNSNamespace},
+							},
+							PodSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{g.DNSLabelKey: g.DNSLabelValue},
+							},
+						},
+					},
+					Ports: []networkv1.NetworkPolicyPort{
+						{
+							Port:     ptr.To(intstr.FromInt32(g.DNSPort)),
+							Protocol: ptr.To(k8sv1.ProtocolTCP),
+						},
+						{
+							Port:     ptr.To(intstr.FromInt32(g.DNSPort)),
+							Protocol: ptr.To(k8sv1.ProtocolUDP),
+						},
+					},
+				},
+			},
+		},
+	)
+}
+
+func (g *Generator) newIngressToSSPOperatorWebhook() *networkv1.NetworkPolicy {
+	return newNetworkPolicy(
+		g.Namespace,
+		"ssp-operator-allow-ingress-to-ssp-operator-webhook",
+		&networkv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{"name": "ssp-operator"},
+			},
+			PolicyTypes: []networkv1.PolicyType{networkv1.PolicyTypeIngress},
+			Ingress: []networkv1.NetworkPolicyIngressRule{
+				{
+					Ports: []networkv1.NetworkPolicyPort{
+						{
+							Port:     ptr.To(intstr.FromInt32(8443)),
+							Protocol: ptr.To(k8sv1.ProtocolTCP),
+						},
+					},
+				},
+			},
+		},
+	)
+}
+
+func (g *Generator) newIngressToSSPOperatorMetrics() *networkv1.NetworkPolicy {
+	return newNetworkPolicy(
+		g.Namespace,
+		"ssp-operator-allow-ingress-to-ssp-operator-metrics",
+		&networkv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{"name": "ssp-operator"},
+			},
+			PolicyTypes: []networkv1.PolicyType{networkv1.PolicyTypeIngress},
+			Ingress: []networkv1.NetworkPolicyIngressRule{
+				{
+					Ports: []networkv1.NetworkPolicyPort{
+						{
+							Port:     ptr.To(intstr.FromInt32(9443)),
+							Protocol: ptr.To(k8sv1.ProtocolTCP),
+						},
+					},
+				},
+			},
+		},
+	)
+}
+
+func (g *Generator) newIngressToVirtTemplateValidatorWebhookAndMetrics() *networkv1.NetworkPolicy {
+	return newNetworkPolicy(
+		g.Namespace,
+		"ssp-operator-allow-ingress-to-virt-template-validator-webhook-and-metrics",
+		&networkv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{"name": "virt-template-validator"},
+			},
+			PolicyTypes: []networkv1.PolicyType{networkv1.PolicyTypeIngress},
+			Ingress: []networkv1.NetworkPolicyIngressRule{
+				{
+					Ports: []networkv1.NetworkPolicyPort{
+						{
+							Port:     ptr.To(intstr.FromInt32(8443)),
+							Protocol: ptr.To(k8sv1.ProtocolTCP),
+						},
+					},
+				},
+			},
+		},
+	)
+}
+
+func (g *Generator) newIngressToVMConsoleProxyAPI() *networkv1.NetworkPolicy {
+	return newNetworkPolicy(
+		g.Namespace,
+		"ssp-operator-allow-ingress-to-vm-console-proxy-api",
+		&networkv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{"name": "vm-console-proxy"},
+			},
+			PolicyTypes: []networkv1.PolicyType{networkv1.PolicyTypeIngress},
+			Ingress: []networkv1.NetworkPolicyIngressRule{
+				{
+					Ports: []networkv1.NetworkPolicyPort{
+						{
+							Port:     ptr.To(intstr.FromInt32(8768)),
+							Protocol: ptr.To(k8sv1.ProtocolTCP),
+						},
+					},
+				},
+			},
+		},
+	)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Add network-policy-generator that creates static NetworkPolicies for ssp operator and the additional resources it deploys. These NetworkPolicies are required for ssp operator and the additional resources to work in a locked down environment with default deny NetworkPolicies in place.

**Which issue(s) this PR fixes**: 
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
