### PR TITLE
Add NetworkPolicies required by SSP

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -24,6 +24,7 @@ bases:
 #- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
+- ../network-policy
 
 patchesStrategicMerge:
 # Protect the /metrics endpoint by putting it behind auth.

--- a/config/hco-network-policy/hco_allow_egress_to_api_server.yaml
+++ b/config/hco-network-policy/hco_allow_egress_to_api_server.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: hco-allow-egress-to-api-server
+spec:
+  podSelector:
+    matchExpressions:
+    - key: hco.kubevirt.io/allow-access-cluster-services
+      operator: Exists
+  policyTypes:
+    - Egress
+  egress:
+  - ports:
+    - protocol: TCP
+      port: 6443

--- a/config/hco-network-policy/k8s_hco-allow-egress-to-dns.yaml
+++ b/config/hco-network-policy/k8s_hco-allow-egress-to-dns.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: hco-allow-egress-to-dns
+spec:
+  podSelector:
+    matchExpressions:
+    - key: hco.kubevirt.io/allow-access-cluster-services
+      operator: Exists
+  policyTypes:
+  - Egress
+  egress:
+  - ports:
+    - protocol: TCP
+      port: 53
+    - protocol: UDP
+      port: 53
+    to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+      podSelector:
+        matchLabels:
+          k8s-app: kube-dns

--- a/config/hco-network-policy/kustomization.yaml
+++ b/config/hco-network-policy/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# Adds namespace to all resources.
+namespace: kubevirt
+
+resources:
+  - hco_allow_egress_to_api_server.yaml
+  - ocp_hco-allow-egress-to-dns.yaml
+  # - k8s_hco-allow-egress-to-dns.yaml

--- a/config/hco-network-policy/ocp_hco-allow-egress-to-dns.yaml
+++ b/config/hco-network-policy/ocp_hco-allow-egress-to-dns.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: hco-allow-egress-to-dns
+spec:
+  podSelector:
+    matchExpressions:
+    - key: hco.kubevirt.io/allow-access-cluster-services
+      operator: Exists
+  policyTypes:
+  - Egress
+  egress:
+  - ports:
+    - protocol: TCP
+      port: 5353
+    - protocol: UDP
+      port: 5353
+    to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-dns
+      podSelector:
+        matchLabels:
+          dns.operator.openshift.io/daemonset-dns: default

--- a/config/manager/manager.template.yaml
+++ b/config/manager/manager.template.yaml
@@ -20,6 +20,7 @@ spec:
         kubectl.kubernetes.io/default-container: manager
       labels:
         control-plane: ssp-operator
+        hco.kubevirt.io/allow-access-cluster-services: "true"
         name: ssp-operator
         prometheus.ssp.kubevirt.io: "true"
     spec:

--- a/config/network-policy/allow_ingress_to_ssp_operator_webhook_and_metrics.yaml
+++ b/config/network-policy/allow_ingress_to_ssp_operator_webhook_and_metrics.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: ssp-operator-allow-ingress-to-ssp-operator-webhook-and-metrics
+spec:
+  ingress:
+  - ports:
+    - port: 8443
+      protocol: TCP
+  - ports:
+    - port: 9443
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      name: ssp-operator
+  policyTypes:
+  - Ingress

--- a/config/network-policy/kustomization.yaml
+++ b/config/network-policy/kustomization.yaml
@@ -1,0 +1,3 @@
+---
+resources:
+  - allow_ingress_to_ssp_operator_webhook_and_metrics.yaml

--- a/data/network-policy/allow_ingress_to_ssp_operator_webhook_and_metrics.yaml
+++ b/data/network-policy/allow_ingress_to_ssp_operator_webhook_and_metrics.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: ssp-operator-allow-ingress-to-ssp-operator-webhook-and-metrics
+spec:
+  ingress:
+  - ports:
+    - port: 8443
+      protocol: TCP
+  - ports:
+    - port: 9443
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      name: ssp-operator
+  policyTypes:
+  - Ingress


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

By adding the hco.kubevirt.io/allow-access-cluster-services label to
SSP's deployment it gains access to the cluster API and DNS. These
network policies are provided by HCO.

Add the --dump-network-policies flag to csv-generator. If set the
csv-generator will dump all additionally network policies required by SSP to
function apart from the ones already provided by adding the
hco.kubevirt.io/allow-access-cluster-services label to SSP's deployment.

Add network policies to kustomize config so they can be tested in
deployments without OLM.

**Which issue(s) this PR fixes**: 
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NetworkPolicies required by SSP are added
```
