### PR TITLE
feat: Add support for multi-arch DataSources and DataImportCrons

### DIFF
--- a/automation/common/versions.sh
+++ b/automation/common/versions.sh
@@ -58,4 +58,7 @@ function latest_version() {
 KUBEVIRT_VERSION=$(latest_version "kubevirt" "kubevirt")
 
 # Latest released CDI version
-CDI_VERSION=$(latest_version "kubevirt" "containerized-data-importer")
+
+# Using the latest pre-release of CDI, so the new API is available.
+# TODO: Revert back this line when CDI creates a proper release.
+CDI_VERSION="v1.63.0-alpha.0"

--- a/internal/architecture/architecture.go
+++ b/internal/architecture/architecture.go
@@ -1,6 +1,12 @@
 package architecture
 
-import "fmt"
+import (
+	"fmt"
+	"runtime"
+
+	"k8s.io/utils/ptr"
+	ssp "kubevirt.io/ssp-operator/api/v1beta3"
+)
 
 type Arch string
 
@@ -29,4 +35,52 @@ func ToArchOrPanic(arch string) Arch {
 		panic(err)
 	}
 	return result
+}
+
+func GetSSPArchs(sspSpec *ssp.SSPSpec) ([]Arch, error) {
+	if sspSpec.Cluster == nil {
+		if ptr.Deref(sspSpec.EnableMultipleArchitectures, false) {
+			return nil, fmt.Errorf(".spec.cluster cannot be nil, if .spec.enableMultipleArchitectures is true")
+		}
+		defaultArchitecture, err := ToArch(runtime.GOARCH)
+		if err != nil {
+			return nil, fmt.Errorf("default architecture is not supported: %w", err)
+		}
+		return []Arch{defaultArchitecture}, nil
+	}
+
+	archs := sspSpec.Cluster.WorkloadArchitectures
+	if len(archs) == 0 {
+		archs = sspSpec.Cluster.ControlPlaneArchitectures
+	}
+
+	if len(archs) == 0 {
+		return nil, fmt.Errorf("no architectures are defined in .spec.cluster")
+	}
+
+	if ptr.Deref(sspSpec.EnableMultipleArchitectures, false) {
+		result := make([]Arch, 0, len(archs))
+		for _, archStr := range archs {
+			arch, err := ToArch(archStr)
+			if err != nil {
+				return nil, err
+			}
+			result = append(result, arch)
+		}
+		return result, nil
+	}
+
+	// For single architecture case, we prefer the first of ControlPlaneArchitectures.
+	// If there are none, we use the first of WorkloadArchitectures.
+	archStr := archs[0]
+	if len(sspSpec.Cluster.ControlPlaneArchitectures) > 0 {
+		archStr = sspSpec.Cluster.ControlPlaneArchitectures[0]
+	}
+
+	arch, err := ToArch(archStr)
+	if err != nil {
+		return nil, err
+	}
+
+	return []Arch{arch}, nil
 }

--- a/internal/architecture/architecture_test.go
+++ b/internal/architecture/architecture_test.go
@@ -1,0 +1,120 @@
+package architecture_test
+
+import (
+	"runtime"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/utils/ptr"
+
+	ssp "kubevirt.io/ssp-operator/api/v1beta3"
+	"kubevirt.io/ssp-operator/internal/architecture"
+)
+
+var _ = Describe("GetSSPArchs", func() {
+	It("should return defaultArchitecture if .spec.cluster is nil", func() {
+		var defaultArchitecture = architecture.ToArchOrPanic(runtime.GOARCH)
+
+		archs, err := architecture.GetSSPArchs(&ssp.SSPSpec{})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(archs).To(ConsistOf(defaultArchitecture))
+	})
+
+	It("should fail if .spec.cluster is nil and multi-architecture is enabled", func() {
+		_, err := architecture.GetSSPArchs(&ssp.SSPSpec{
+			EnableMultipleArchitectures: ptr.To(true),
+		})
+		Expect(err).To(MatchError(".spec.cluster cannot be nil, if .spec.enableMultipleArchitectures is true"))
+	})
+
+	It("should fail if no architectures are defined", func() {
+		_, err := architecture.GetSSPArchs(&ssp.SSPSpec{
+			Cluster: &ssp.Cluster{},
+		})
+		Expect(err).To(MatchError("no architectures are defined in .spec.cluster"))
+	})
+
+	Context("with multi-arch disabled", func() {
+		It("should return the first control plane architecture", func() {
+			archs, err := architecture.GetSSPArchs(&ssp.SSPSpec{
+				Cluster: &ssp.Cluster{
+					WorkloadArchitectures:     []string{string(architecture.AMD64), string(architecture.ARM64)},
+					ControlPlaneArchitectures: []string{string(architecture.S390X)},
+				},
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(archs).To(ConsistOf(architecture.S390X))
+		})
+
+		It("should return the first workload architecture if control plane architectures are empty", func() {
+			archs, err := architecture.GetSSPArchs(&ssp.SSPSpec{
+				Cluster: &ssp.Cluster{
+					WorkloadArchitectures: []string{string(architecture.AMD64), string(architecture.ARM64)},
+				},
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(archs).To(ConsistOf(architecture.AMD64))
+		})
+
+		It("should fail if the selected architecture is unknown", func() {
+			_, err := architecture.GetSSPArchs(&ssp.SSPSpec{
+				Cluster: &ssp.Cluster{
+					ControlPlaneArchitectures: []string{"invalid-arch"},
+				},
+			})
+			Expect(err).To(MatchError("unknown architecture: invalid-arch"))
+		})
+	})
+
+	Context("with multi-arch enabled", func() {
+		It("should return workload architectures", func() {
+			archs, err := architecture.GetSSPArchs(&ssp.SSPSpec{
+				EnableMultipleArchitectures: ptr.To(true),
+				Cluster: &ssp.Cluster{
+					WorkloadArchitectures:     []string{string(architecture.AMD64), string(architecture.ARM64)},
+					ControlPlaneArchitectures: []string{string(architecture.S390X)},
+				},
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(archs).To(ConsistOf(architecture.AMD64, architecture.ARM64))
+		})
+
+		It("should return control plane architectures if workload architectures are empty", func() {
+			archs, err := architecture.GetSSPArchs(&ssp.SSPSpec{
+				EnableMultipleArchitectures: ptr.To(true),
+				Cluster: &ssp.Cluster{
+					ControlPlaneArchitectures: []string{string(architecture.S390X)},
+				},
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(archs).To(ConsistOf(architecture.S390X))
+		})
+
+		It("should fail if workload architectures contain an unknown architecture", func() {
+			_, err := architecture.GetSSPArchs(&ssp.SSPSpec{
+				EnableMultipleArchitectures: ptr.To(true),
+				Cluster: &ssp.Cluster{
+					WorkloadArchitectures: []string{string(architecture.AMD64), "unknown-arch"},
+				},
+			})
+			Expect(err).To(MatchError("unknown architecture: unknown-arch"))
+		})
+
+		It("should fail if control plane architectures contain an unknown architecture", func() {
+			_, err := architecture.GetSSPArchs(&ssp.SSPSpec{
+				EnableMultipleArchitectures: ptr.To(true),
+				Cluster: &ssp.Cluster{
+					ControlPlaneArchitectures: []string{string(architecture.S390X), "invalid-arch"},
+				},
+			})
+			Expect(err).To(MatchError("unknown architecture: invalid-arch"))
+		})
+	})
+})
+
+func TestArchitecture(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Architecture Suite")
+}

--- a/internal/architecture/architecture_test.go
+++ b/internal/architecture/architecture_test.go
@@ -69,7 +69,7 @@ var _ = Describe("GetSSPArchs", func() {
 	})
 
 	Context("with multi-arch enabled", func() {
-		It("should return workload architectures", func() {
+		It("should return control plane architectures followed by workload architectures", func() {
 			archs, err := architecture.GetSSPArchs(&ssp.SSPSpec{
 				EnableMultipleArchitectures: ptr.To(true),
 				Cluster: &ssp.Cluster{
@@ -78,18 +78,7 @@ var _ = Describe("GetSSPArchs", func() {
 				},
 			})
 			Expect(err).ToNot(HaveOccurred())
-			Expect(archs).To(ConsistOf(architecture.AMD64, architecture.ARM64))
-		})
-
-		It("should return control plane architectures if workload architectures are empty", func() {
-			archs, err := architecture.GetSSPArchs(&ssp.SSPSpec{
-				EnableMultipleArchitectures: ptr.To(true),
-				Cluster: &ssp.Cluster{
-					ControlPlaneArchitectures: []string{string(architecture.S390X)},
-				},
-			})
-			Expect(err).ToNot(HaveOccurred())
-			Expect(archs).To(ConsistOf(architecture.S390X))
+			Expect(archs).To(ConsistOf(architecture.S390X, architecture.AMD64, architecture.ARM64))
 		})
 
 		It("should fail if workload architectures contain an unknown architecture", func() {

--- a/internal/controllers/setup.go
+++ b/internal/controllers/setup.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
-	"slices"
 
 	"github.com/go-logr/logr"
 	v1 "github.com/openshift/api/config/v1"
@@ -67,12 +66,8 @@ func CreateControllers(ctx context.Context, apiReader client.Reader) ([]Controll
 		return nil, fmt.Errorf("failed to read vm-console-proxy bundle: %w", err)
 	}
 
-	// Temporarily, only create DataSources for one architecture.
-	// TODO: Create all DataSources, when multi-arch DataSource logic is implemented
-	dataSourceNames := slices.Collect(dataSourceCollection.Names())
-
 	sspOperands := []operands.Operand{
-		data_sources.New(dataSourceNames, runningOnOpenShift),
+		data_sources.New(dataSourceCollection, runningOnOpenShift),
 		vm_delete_protection.New(),
 	}
 

--- a/internal/operands/common-templates/constants.go
+++ b/internal/operands/common-templates/constants.go
@@ -12,4 +12,6 @@ const (
 	TemplateFlavorLabelPrefix    = "flavor.template.kubevirt.io/"
 	TemplateWorkloadLabelPrefix  = "workload.template.kubevirt.io/"
 	TemplateDeprecatedAnnotation = "template.kubevirt.io/deprecated"
+
+	TemplateDataSourceParameterName = "DATA_SOURCE_NAME"
 )

--- a/internal/operands/common-templates/reconcile_test.go
+++ b/internal/operands/common-templates/reconcile_test.go
@@ -45,8 +45,6 @@ var _ = Describe("Common-Templates operand", func() {
 	)
 
 	BeforeEach(func() {
-		defaultArchitecture = architecture.AMD64
-
 		var err error
 		operand, err = New(getTestTemplatesMultiArch())
 		Expect(err).ToNot(HaveOccurred())
@@ -79,6 +77,9 @@ var _ = Describe("Common-Templates operand", func() {
 				Spec: ssp.SSPSpec{
 					CommonTemplates: ssp.CommonTemplates{
 						Namespace: namespace,
+					},
+					Cluster: &ssp.Cluster{
+						ControlPlaneArchitectures: []string{string(architecture.AMD64)},
 					},
 				},
 				Status: ssp.SSPStatus{

--- a/internal/operands/data-sources/constants.go
+++ b/internal/operands/data-sources/constants.go
@@ -1,0 +1,6 @@
+package data_sources
+
+const (
+	DataImportCronArchsAnnotation     = "ssp.kubevirt.io/dict.architectures"
+	DataImportCronDataSourceNameLabel = "cdi.kubevirt.io/storage.import.datasource-name"
+)

--- a/internal/operands/data-sources/reconcile.go
+++ b/internal/operands/data-sources/reconcile.go
@@ -111,30 +111,13 @@ func (d *dataSources) Reconcile(request *common.Request) ([]common.ReconcileResu
 	funcs = append(funcs, dsFuncs...)
 	funcs = append(funcs, d.reconcileNetworkPolicies()...)
 
-	results, err := common.CollectResourceStatus(request, funcs...)
-	if err != nil {
-		return nil, err
-	}
-
-	var allSucceeded = true
-	for i := range results {
-		if !results[i].IsSuccess() {
-			allSucceeded = false
-			break
-		}
-	}
-
-	// DataImportCrons can be reconciled only after all resources successfully reconciled.
-	if !allSucceeded {
-		return results, nil
-	}
-
 	dicFuncs, err := reconcileDataImportCrons(dsAndCrons.dataImportCrons, request)
 	if err != nil {
 		return nil, err
 	}
+	funcs = append(funcs, dicFuncs...)
 
-	return common.CollectResourceStatus(request, dicFuncs...)
+	return common.CollectResourceStatus(request, funcs...)
 }
 
 func (d *dataSources) Cleanup(request *common.Request) ([]common.CleanupResult, error) {

--- a/internal/operands/data-sources/reconcile.go
+++ b/internal/operands/data-sources/reconcile.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"maps"
 	"slices"
+	"strings"
 
+	"github.com/go-logr/logr"
 	core "k8s.io/api/core/v1"
 	networkv1 "k8s.io/api/networking/v1"
 	rbac "k8s.io/api/rbac/v1"
@@ -19,6 +21,7 @@ import (
 	"kubevirt.io/ssp-operator/internal/architecture"
 	"kubevirt.io/ssp-operator/internal/common"
 	"kubevirt.io/ssp-operator/internal/operands"
+	common_templates "kubevirt.io/ssp-operator/internal/operands/common-templates"
 	template_bundle "kubevirt.io/ssp-operator/internal/template-bundle"
 )
 
@@ -204,10 +207,28 @@ func reconcileEditRole(request *common.Request) (common.ReconcileResult, error) 
 }
 
 func (d *dataSources) getDataSourcesAndCrons(request *common.Request) (dataSourcesAndCrons, error) {
-	cronByDataSource := getCronsByDataSource(&request.Instance.Spec)
-	dataSourceInfos, err := getDataSourceInfos(d.sourceCollection, cronByDataSource, request)
+	isMultiarch := ptr.Deref(request.Instance.Spec.EnableMultipleArchitectures, false)
+
+	var cronByDataSource map[client.ObjectKey]*cdiv1beta1.DataImportCron
+	if isMultiarch {
+		var err error
+		cronByDataSource, err = getCronsByDataSourceMultiArch(&request.Instance.Spec, d.sourceCollection, &request.Logger)
+		if err != nil {
+			return dataSourcesAndCrons{}, fmt.Errorf("failed to get DataImportCrons: %w", err)
+		}
+	} else {
+		cronByDataSource = getCronsByDataSource(&request.Instance.Spec)
+	}
+
+	var err error
+	var dataSourceInfos []dataSourceInfo
+	if isMultiarch {
+		dataSourceInfos, err = getDataSourceInfosMultiArch(d.sourceCollection, cronByDataSource, request)
+	} else {
+		dataSourceInfos, err = getDataSourceInfos(d.sourceCollection, cronByDataSource, request)
+	}
 	if err != nil {
-		return dataSourcesAndCrons{}, err
+		return dataSourcesAndCrons{}, fmt.Errorf("failed to get DataSources: %w", err)
 	}
 
 	for i := range dataSourceInfos {
@@ -231,13 +252,106 @@ func getCronsByDataSource(sspSpec *ssp.SSPSpec) map[client.ObjectKey]*cdiv1beta1
 		if cron.Namespace == "" {
 			cron.Namespace = internal.GoldenImagesNamespace
 		}
-		cronByDataSource[client.ObjectKey{
-			Name:      cron.Spec.ManagedDataSource,
-			Namespace: cron.Namespace,
-		}] = cron
+		// The architecture annotation should not be in the created DataImportCron.
+		delete(cron.Annotations, DataImportCronArchsAnnotation)
+
+		addToCronMap(cronByDataSource, cron)
 	}
 
 	return cronByDataSource
+}
+
+func getCronsByDataSourceMultiArch(sspSpec *ssp.SSPSpec, sourceCollection template_bundle.DataSourceCollection, logger *logr.Logger) (map[client.ObjectKey]*cdiv1beta1.DataImportCron, error) {
+	if !ptr.Deref(sspSpec.EnableMultipleArchitectures, false) {
+		return nil, fmt.Errorf("multi-architecture needs to be enabled")
+	}
+
+	clusterArchs, err := architecture.GetSSPArchs(sspSpec)
+	if err != nil {
+		return nil, err
+	}
+
+	cronByDataSource := map[client.ObjectKey]*cdiv1beta1.DataImportCron{}
+	cronTemplates := sspSpec.CommonTemplates.DataImportCronTemplates
+	for i := range cronTemplates {
+		originalCron := cronTemplates[i].AsDataImportCron()
+
+		// Need a copy, because it is modified later.
+		cron := originalCron.DeepCopy()
+		if cron.Namespace == "" {
+			cron.Namespace = internal.GoldenImagesNamespace
+		}
+
+		archsAnnotationValue := cron.Annotations[DataImportCronArchsAnnotation]
+
+		// The architecture annotation should not be in the created DataImportCron.
+		delete(cron.Annotations, DataImportCronArchsAnnotation)
+
+		if archsAnnotationValue == "" {
+			// The ManagedDataSource needs to point to the default DataSource architecture.
+			dsArchs, dsExists := sourceCollection[cron.Spec.ManagedDataSource]
+			if !dsExists {
+				addToCronMap(cronByDataSource, cron)
+				continue
+			}
+
+			defaultArch := getDefaultDataSourceArch(clusterArchs, dsArchs)
+			if defaultArch == "" {
+				// If there is no compatible DataSource architecture, no DataSource is created.
+				addToCronMap(cronByDataSource, cron)
+				continue
+			}
+
+			cron.Spec.ManagedDataSource = cron.Spec.ManagedDataSource + "-" + string(defaultArch)
+			addToCronMap(cronByDataSource, cron)
+			continue
+		}
+
+		cronArchs := parseArchsAnnotation(archsAnnotationValue, logger)
+		for _, arch := range cronArchs {
+			if !slices.Contains(clusterArchs, arch) {
+				continue
+			}
+
+			cronCopy := cron.DeepCopy()
+			cronCopy.Name = cron.Name + "-" + string(arch)
+			setDataImportCronArchFields(cronCopy, arch)
+			addToCronMap(cronByDataSource, cronCopy)
+		}
+	}
+
+	return cronByDataSource, nil
+}
+
+func addToCronMap(cronMap map[client.ObjectKey]*cdiv1beta1.DataImportCron, cron *cdiv1beta1.DataImportCron) {
+	cronMap[client.ObjectKey{
+		Name:      cron.Spec.ManagedDataSource,
+		Namespace: cron.Namespace,
+	}] = cron
+}
+
+func setDataImportCronArchFields(cron *cdiv1beta1.DataImportCron, arch architecture.Arch) {
+	archStr := string(arch)
+	managedSource := cron.Spec.ManagedDataSource
+
+	if cron.Labels == nil {
+		cron.Labels = map[string]string{}
+	}
+	cron.Labels[common_templates.TemplateArchitectureLabel] = archStr
+	cron.Labels[DataImportCronDataSourceNameLabel] = managedSource
+
+	cron.Spec.ManagedDataSource = managedSource + "-" + archStr
+
+	if cron.Spec.Template.Spec.Source != nil {
+		source := cron.Spec.Template.Spec.Source
+		if source.Registry != nil {
+			registry := source.Registry
+			if registry.Platform == nil {
+				registry.Platform = &cdiv1beta1.PlatformOptions{}
+			}
+			registry.Platform.Architecture = archStr
+		}
+	}
 }
 
 func getDataSourceInfos(sourceCollection template_bundle.DataSourceCollection, cronByDataSource map[client.ObjectKey]*cdiv1beta1.DataImportCron, request *common.Request) ([]dataSourceInfo, error) {
@@ -271,6 +385,69 @@ func getDataSourceInfos(sourceCollection template_bundle.DataSourceCollection, c
 			autoUpdateEnabled:  autoUpdateEnabled,
 			dataImportCronName: dicName,
 		})
+	}
+	return dataSourceInfos, nil
+}
+
+func getDataSourceInfosMultiArch(sourceCollection template_bundle.DataSourceCollection, cronByDataSource map[client.ObjectKey]*cdiv1beta1.DataImportCron, request *common.Request) ([]dataSourceInfo, error) {
+	if !ptr.Deref(request.Instance.Spec.EnableMultipleArchitectures, false) {
+		return nil, fmt.Errorf("multi-architecture needs to be enabled")
+	}
+
+	clusterArchs, err := architecture.GetSSPArchs(&request.Instance.Spec)
+	if err != nil {
+		return nil, err
+	}
+
+	var dataSourceInfos []dataSourceInfo
+	for name, dsArchs := range sourceCollection {
+		defaultArch := getDefaultDataSourceArch(clusterArchs, dsArchs)
+		if defaultArch == "" {
+			// We can skip creating the DataSources, because none of its architectures
+			// are supported on the cluster.
+			continue
+		}
+
+		dataSourceInfos = append(dataSourceInfos, dataSourceInfo{
+			dataSource: newDataSourceReference(name, name+"-"+string(defaultArch)),
+		})
+
+		for _, arch := range dsArchs {
+			if !slices.Contains(clusterArchs, arch) {
+				continue
+			}
+
+			dsName := name + "-" + string(arch)
+			dataSource := newDataSource(dsName)
+			dataSource.Labels = map[string]string{
+				common_templates.TemplateArchitectureLabel: string(arch),
+			}
+
+			autoUpdateEnabled, err := dataSourceAutoUpdateEnabled(dataSource, cronByDataSource, request)
+			if err != nil {
+				return nil, err
+			}
+
+			if arch == defaultArch {
+				// Special logic is needed for the default DataSource to keep backward compatibility.
+				var err error
+				dataSource, autoUpdateEnabled, err = handleDefaultDataSource(dataSource, autoUpdateEnabled, name, request)
+				if err != nil {
+					return nil, fmt.Errorf("faield to handle default DataSource: %w", err)
+				}
+			}
+
+			var dicName string
+			if dic, ok := cronByDataSource[client.ObjectKeyFromObject(dataSource)]; ok {
+				dicName = dic.GetName()
+			}
+
+			dataSourceInfos = append(dataSourceInfos, dataSourceInfo{
+				dataSource:         dataSource,
+				autoUpdateEnabled:  autoUpdateEnabled,
+				dataImportCronName: dicName,
+			})
+		}
 	}
 	return dataSourceInfos, nil
 }
@@ -343,6 +520,55 @@ func checkIfPvcExists(dataSource *cdiv1beta1.DataSource, request *common.Request
 	}
 
 	return true, nil
+}
+
+func handleDefaultDataSource(dataSource *cdiv1beta1.DataSource, autoUpdate bool, originalPvcName string, request *common.Request) (*cdiv1beta1.DataSource, bool, error) {
+	foundDataSource := &cdiv1beta1.DataSource{}
+	err := request.Client.Get(request.Context, client.ObjectKeyFromObject(dataSource), foundDataSource)
+	if err != nil && !errors.IsNotFound(err) {
+		return nil, false, err
+	}
+
+	if errors.IsNotFound(err) {
+		err := request.UncachedReader.Get(request.Context, client.ObjectKey{
+			Name:      originalPvcName,
+			Namespace: dataSource.Spec.Source.PVC.Namespace,
+		}, &core.PersistentVolumeClaim{})
+		if err != nil && !errors.IsNotFound(err) {
+			return nil, false, err
+		}
+
+		// For backward compatibility, if the original PVC exist,
+		// the default DataSource should point to it.
+		if !errors.IsNotFound(err) {
+			dataSource.Spec.Source.PVC.Name = originalPvcName
+			return dataSource, false, nil
+		}
+		return dataSource, autoUpdate, nil
+	}
+
+	if _, foundDsUsesAutoUpdate := foundDataSource.GetLabels()[dataImportCronLabel]; foundDsUsesAutoUpdate {
+		// Found DS is labeled to use auto-update.
+		return dataSource, autoUpdate, nil
+	}
+
+	dsReadyCondition := getDataSourceReadyCondition(foundDataSource)
+	if dsReadyCondition == nil {
+		// CDI has not yet seen this DataSource, so it is left unchanged.
+		dataSource.Spec = foundDataSource.Spec
+		return dataSource, false, nil
+	}
+
+	if dsReadyCondition.Status == core.ConditionTrue {
+		// If the found DataSource is pointing to the old PVC, don't change it.
+		sourcePVC := foundDataSource.Spec.Source.PVC
+		if sourcePVC != nil && sourcePVC.Name == originalPvcName && sourcePVC.Namespace == dataSource.Namespace {
+			dataSource.Spec.Source.PVC.Name = originalPvcName
+			return dataSource, false, nil
+		}
+	}
+
+	return dataSource, autoUpdate, nil
 }
 
 func reconcileDataSources(dataSourceInfos []dataSourceInfo, request *common.Request) ([]common.ReconcileFunc, error) {
@@ -497,4 +723,28 @@ func (d *dataSources) reconcileNetworkPolicies() []common.ReconcileFunc {
 		})
 	}
 	return funcs
+}
+
+func getDefaultDataSourceArch(clusterArchs, dataSourceArchs []architecture.Arch) architecture.Arch {
+	// Default arch is the first one that is defined in the SSP and in the common templates
+	for _, arch := range clusterArchs {
+		if slices.Contains(dataSourceArchs, arch) {
+			return arch
+		}
+	}
+	return ""
+}
+
+func parseArchsAnnotation(value string, logger *logr.Logger) []architecture.Arch {
+	var result []architecture.Arch
+	for archStr := range strings.SplitSeq(value, ",") {
+		arch, err := architecture.ToArch(strings.TrimSpace(archStr))
+		if err != nil {
+			// Ignoring invalid architectures
+			logger.V(4).Info("Unknown DataImportCron template architecture, ignoring it.", "value", archStr)
+			continue
+		}
+		result = append(result, arch)
+	}
+	return result
 }

--- a/internal/operands/data-sources/reconcile_test.go
+++ b/internal/operands/data-sources/reconcile_test.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	cdiv1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -22,6 +23,7 @@ import (
 	"kubevirt.io/ssp-operator/internal/architecture"
 	"kubevirt.io/ssp-operator/internal/common"
 	"kubevirt.io/ssp-operator/internal/operands"
+	common_templates "kubevirt.io/ssp-operator/internal/operands/common-templates"
 	template_bundle "kubevirt.io/ssp-operator/internal/template-bundle"
 	. "kubevirt.io/ssp-operator/internal/test-utils"
 )
@@ -372,6 +374,439 @@ var _ = Describe("Data-Sources operand", func() {
 
 			ExpectResourceExists(cron, request)
 		})
+	})
+
+	Context("with multi-arch enabled", func() {
+		BeforeEach(func() {
+			request.Instance.Spec.EnableMultipleArchitectures = ptr.To(true)
+			request.Instance.Spec.Cluster = &ssp.Cluster{
+				WorkloadArchitectures:     []string{string(architecture.AMD64), string(architecture.ARM64), string(architecture.S390X)},
+				ControlPlaneArchitectures: []string{string(architecture.AMD64)},
+			}
+		})
+
+		It("should create arch-specific DataSources", func() {
+			_, err := operand.Reconcile(&request)
+			Expect(err).ToNot(HaveOccurred())
+
+			for dsName, archs := range dataSourceCollection {
+				dataSource := testDataSource(dsName)
+				for _, arch := range archs {
+					key := client.ObjectKey{
+						Name:      dataSource.Name + "-" + string(arch),
+						Namespace: dataSource.Namespace,
+					}
+
+					found := &cdiv1beta1.DataSource{}
+					Expect(request.Client.Get(request.Context, key, found)).To(Succeed())
+					Expect(found.Spec.Source.PVC.Name).To(Equal(dataSource.Spec.Source.PVC.Name + "-" + string(arch)))
+					Expect(found.Labels).To(HaveKeyWithValue(common_templates.TemplateArchitectureLabel, string(arch)))
+				}
+			}
+		})
+
+		It("should not create DataSources for architectures not supported in cluster", func() {
+			request.Instance.Spec.Cluster = &ssp.Cluster{
+				WorkloadArchitectures:     []string{string(architecture.S390X)},
+				ControlPlaneArchitectures: []string{string(architecture.S390X)},
+			}
+
+			_, err := operand.Reconcile(&request)
+			Expect(err).ToNot(HaveOccurred())
+
+			for dsName, archs := range dataSourceCollection {
+				dataSource := testDataSource(dsName)
+				for _, arch := range archs {
+					if arch == architecture.S390X {
+						continue
+					}
+
+					Expect(request.Client.Get(request.Context, client.ObjectKey{
+						Name:      dataSource.Name + "-" + string(arch),
+						Namespace: dataSource.Namespace,
+					}, &cdiv1beta1.DataSource{})).
+						To(MatchError(errors.IsNotFound, "errors.IsNotFound"))
+				}
+			}
+		})
+
+		It("should remove DataSources for architecture that is no longer in cluster", func() {
+			_, err := operand.Reconcile(&request)
+			Expect(err).ToNot(HaveOccurred())
+
+			key := client.ObjectKey{
+				Name:      centos8 + "-" + string(architecture.S390X),
+				Namespace: internal.GoldenImagesNamespace,
+			}
+
+			Expect(request.Client.Get(request.Context, key, &cdiv1beta1.DataSource{})).To(Succeed())
+
+			request.Instance.Spec.Cluster = &ssp.Cluster{
+				WorkloadArchitectures:     []string{string(architecture.AMD64), string(architecture.ARM64)},
+				ControlPlaneArchitectures: []string{string(architecture.AMD64)},
+			}
+
+			_, err = operand.Reconcile(&request)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(request.Client.Get(request.Context, key, &cdiv1beta1.DataSource{})).
+				To(MatchError(errors.IsNotFound, "errors.IsNotFound"))
+		})
+
+		It("should create DataSource reference pointing to default arch DataSource", func() {
+			_, err := operand.Reconcile(&request)
+			Expect(err).ToNot(HaveOccurred())
+
+			for dsName := range dataSourceCollection.Names() {
+				dataSource := testDataSource(dsName)
+				key := client.ObjectKey{
+					Name:      dataSource.Name,
+					Namespace: dataSource.Namespace,
+				}
+
+				found := &cdiv1beta1.DataSource{}
+				Expect(request.Client.Get(request.Context, key, found)).To(Succeed())
+
+				defaultDsName := dsName + "-" + string(architecture.AMD64)
+
+				Expect(found.Spec.Source.DataSource).ToNot(BeNil())
+				Expect(found.Spec.Source.DataSource.Name).To(Equal(defaultDsName))
+				Expect(found.Spec.Source.DataSource.Namespace).To(Equal(dataSource.Namespace))
+
+				Expect(found.Spec.Source.PVC).To(BeNil())
+				Expect(found.Spec.Source.Snapshot).To(BeNil())
+			}
+		})
+
+		It("should create DataSource reference pointing to existing DataSource", func() {
+			request.Instance.Spec.Cluster = &ssp.Cluster{
+				WorkloadArchitectures:     []string{string(architecture.AMD64), string(architecture.ARM64), string(architecture.S390X)},
+				ControlPlaneArchitectures: []string{string(architecture.S390X)},
+			}
+
+			_, err := operand.Reconcile(&request)
+			Expect(err).ToNot(HaveOccurred())
+
+			foundCentosDs := &cdiv1beta1.DataSource{}
+			Expect(request.Client.Get(request.Context, client.ObjectKey{
+				Name:      centos8,
+				Namespace: internal.GoldenImagesNamespace,
+			}, foundCentosDs)).To(Succeed())
+
+			// Default DataSource for centos8 can be control plane architecture
+			centosDefaultDsName := centos8 + "-" + string(architecture.S390X)
+			Expect(foundCentosDs.Spec.Source.DataSource).ToNot(BeNil())
+			Expect(foundCentosDs.Spec.Source.DataSource.Name).To(Equal(centosDefaultDsName))
+			Expect(foundCentosDs.Spec.Source.DataSource.Namespace).To(Equal(internal.GoldenImagesNamespace))
+
+			foundWinDs := &cdiv1beta1.DataSource{}
+			Expect(request.Client.Get(request.Context, client.ObjectKey{
+				Name:      win10,
+				Namespace: internal.GoldenImagesNamespace,
+			}, foundWinDs)).To(Succeed())
+
+			// Default DataSource for windows will be the first compatible workload arch
+			winDefaultDsName := win10 + "-" + string(architecture.AMD64)
+			Expect(foundWinDs.Spec.Source.DataSource).ToNot(BeNil())
+			Expect(foundWinDs.Spec.Source.DataSource.Name).To(Equal(winDefaultDsName))
+			Expect(foundWinDs.Spec.Source.DataSource.Namespace).To(Equal(internal.GoldenImagesNamespace))
+		})
+
+		It("should remove arch-specific DataSources when multi-arch is disabled", func() {
+			_, err := operand.Reconcile(&request)
+			Expect(err).ToNot(HaveOccurred())
+
+			request.Instance.Spec.EnableMultipleArchitectures = nil
+
+			_, err = operand.Reconcile(&request)
+			Expect(err).ToNot(HaveOccurred())
+
+			for dsName := range dataSourceCollection.Names() {
+				dataSource := testDataSource(dsName)
+				for _, arch := range []architecture.Arch{architecture.AMD64, architecture.ARM64, architecture.S390X} {
+					key := client.ObjectKey{
+						Name:      dataSource.Name + "-" + string(arch),
+						Namespace: dataSource.Namespace,
+					}
+
+					Expect(request.Client.Get(request.Context, key, &cdiv1beta1.DataSource{})).
+						To(MatchError(errors.IsNotFound, "errors.IsNotFound"))
+				}
+			}
+		})
+
+		It("should update default DataSource when multi-arch is disabled", func() {
+			_, err := operand.Reconcile(&request)
+			Expect(err).ToNot(HaveOccurred())
+
+			request.Instance.Spec.EnableMultipleArchitectures = nil
+
+			_, err = operand.Reconcile(&request)
+			Expect(err).ToNot(HaveOccurred())
+
+			for dsName := range dataSourceCollection.Names() {
+				dataSource := testDataSource(dsName)
+				key := client.ObjectKey{
+					Name:      dataSource.Name,
+					Namespace: dataSource.Namespace,
+				}
+
+				found := &cdiv1beta1.DataSource{}
+				Expect(request.Client.Get(request.Context, key, found)).To(Succeed())
+				Expect(found.Spec.Source.PVC.Name).To(Equal(dataSource.Spec.Source.PVC.Name))
+			}
+		})
+
+		It("default DataSource should point to PVC without arch specific suffix", func() {
+			pvc := &v1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      centos8,
+					Namespace: internal.GoldenImagesNamespace,
+				},
+				Spec: v1.PersistentVolumeClaimSpec{},
+			}
+			Expect(request.Client.Create(request.Context, pvc)).To(Succeed())
+
+			_, err := operand.Reconcile(&request)
+			Expect(err).ToNot(HaveOccurred())
+
+			found := &cdiv1beta1.DataSource{}
+			Expect(request.Client.Get(request.Context, client.ObjectKey{
+				Name:      centos8 + "-" + string(architecture.AMD64),
+				Namespace: internal.GoldenImagesNamespace,
+			}, found)).To(Succeed())
+
+			Expect(found.Spec.Source.PVC.Name).To(Equal(pvc.Name))
+		})
+
+		Context("with DataImportCron template", func() {
+			var (
+				cronTemplate ssp.DataImportCronTemplate
+				cronArchs    []architecture.Arch
+			)
+
+			BeforeEach(func() {
+				cronArchs = []architecture.Arch{
+					architecture.AMD64,
+					architecture.ARM64,
+					architecture.S390X,
+				}
+				cronTemplate = ssp.DataImportCronTemplate{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: centos8,
+						Annotations: map[string]string{
+							DataImportCronArchsAnnotation: "amd64,arm64,s390x",
+						},
+					},
+					Spec: cdiv1beta1.DataImportCronSpec{
+						ManagedDataSource: centos8,
+						Template: cdiv1beta1.DataVolume{
+							Spec: cdiv1beta1.DataVolumeSpec{
+								Source: &cdiv1beta1.DataVolumeSource{
+									Registry: &cdiv1beta1.DataVolumeSourceRegistry{},
+								},
+							},
+						},
+					},
+				}
+
+				request.Instance.Spec.CommonTemplates.DataImportCronTemplates = []ssp.DataImportCronTemplate{cronTemplate}
+			})
+
+			It("should create multiple DataImportCrons", func() {
+				_, err := operand.Reconcile(&request)
+				Expect(err).ToNot(HaveOccurred())
+
+				for _, arch := range cronArchs {
+					cron := cdiv1beta1.DataImportCron{}
+					Expect(request.Client.Get(request.Context, client.ObjectKey{
+						Name:      cronTemplate.Name + "-" + string(arch),
+						Namespace: internal.GoldenImagesNamespace,
+					}, &cron)).To(Succeed())
+
+					Expect(cron.Annotations).ToNot(HaveKey(DataImportCronArchsAnnotation))
+					Expect(cron.Labels).To(HaveKeyWithValue(DataImportCronDataSourceNameLabel, cronTemplate.Spec.ManagedDataSource))
+					Expect(cron.Labels).To(HaveKeyWithValue(common_templates.TemplateArchitectureLabel, string(arch)))
+					Expect(cron.Spec.ManagedDataSource).To(HaveSuffix(string(arch)))
+					Expect(cron.Spec.Template.Spec.Source.Registry.Platform).ToNot(BeNil())
+					Expect(cron.Spec.Template.Spec.Source.Registry.Platform.Architecture).To(Equal(string(arch)))
+				}
+			})
+
+			It("should not create DataImportCron for unsupported architecture", func() {
+				request.Instance.Spec.Cluster.WorkloadArchitectures = []string{string(architecture.AMD64), string(architecture.ARM64)}
+
+				_, err := operand.Reconcile(&request)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(request.Client.Get(request.Context, client.ObjectKey{
+					Name:      cronTemplate.Name + "-" + string(architecture.S390X),
+					Namespace: internal.GoldenImagesNamespace,
+				}, &cdiv1beta1.DataImportCron{})).
+					To(MatchError(errors.IsNotFound, "errors.IsNotFound"))
+			})
+
+			It("should remove DataImportCron when multi-arch is disabled", func() {
+				_, err := operand.Reconcile(&request)
+				Expect(err).ToNot(HaveOccurred())
+
+				dataImportCronList := &cdiv1beta1.DataImportCronList{}
+				Expect(request.Client.List(request.Context, dataImportCronList)).To(Succeed())
+				Expect(dataImportCronList.Items).To(HaveLen(3))
+
+				request.Instance.Spec.EnableMultipleArchitectures = ptr.To(false)
+
+				_, err = operand.Reconcile(&request)
+				Expect(err).ToNot(HaveOccurred())
+
+				dataImportCronList = &cdiv1beta1.DataImportCronList{}
+				Expect(request.Client.List(request.Context, dataImportCronList)).To(Succeed())
+				Expect(dataImportCronList.Items).To(HaveLen(1))
+
+				dataImportCron := dataImportCronList.Items[0]
+				Expect(dataImportCron.Name).To(Equal(cronTemplate.Name))
+				Expect(dataImportCron.Annotations).ToNot(HaveKey(DataImportCronArchsAnnotation))
+				Expect(dataImportCron.Spec).To(Equal(cronTemplate.Spec))
+			})
+
+			Context("without architecture annotation", func() {
+				BeforeEach(func() {
+					cronTemplate.Annotations = nil
+					request.Instance.Spec.CommonTemplates.DataImportCronTemplates = []ssp.DataImportCronTemplate{cronTemplate}
+				})
+
+				It("should create DataImportCron for default arch, if it manages a DataSource from common template", func() {
+					_, err := operand.Reconcile(&request)
+					Expect(err).ToNot(HaveOccurred())
+
+					cron := cdiv1beta1.DataImportCron{}
+					Expect(request.Client.Get(request.Context, client.ObjectKey{
+						Name:      cronTemplate.Name,
+						Namespace: internal.GoldenImagesNamespace,
+					}, &cron)).To(Succeed())
+
+					const defaultArch = architecture.AMD64
+					Expect(cron.Spec.ManagedDataSource).To(Equal(cronTemplate.Spec.ManagedDataSource + "-" + string(defaultArch)))
+				})
+
+				It("should create DataImportCron for default arch that is different from control-plane arch, if it manages a DataSource from common template", func() {
+					request.Instance.Spec.Cluster = &ssp.Cluster{
+						WorkloadArchitectures:     []string{string(architecture.ARM64), string(architecture.S390X)},
+						ControlPlaneArchitectures: []string{string(architecture.S390X)},
+					}
+
+					cronTemplate.Name = win10
+					cronTemplate.Spec.ManagedDataSource = win10
+					request.Instance.Spec.CommonTemplates.DataImportCronTemplates = []ssp.DataImportCronTemplate{cronTemplate}
+
+					_, err := operand.Reconcile(&request)
+					Expect(err).ToNot(HaveOccurred())
+
+					cron := cdiv1beta1.DataImportCron{}
+					Expect(request.Client.Get(request.Context, client.ObjectKey{
+						Name:      cronTemplate.Name,
+						Namespace: internal.GoldenImagesNamespace,
+					}, &cron)).To(Succeed())
+
+					const defaultArch = architecture.ARM64
+					Expect(cron.Spec.ManagedDataSource).To(Equal(cronTemplate.Spec.ManagedDataSource + "-" + string(defaultArch)))
+				})
+
+				It("should create an architecture agnostic DataImportCron, if it does not manage DataSource from common template", func() {
+					cronTemplate.Name = "test-cron"
+					cronTemplate.Spec.ManagedDataSource = "test-ds"
+					request.Instance.Spec.CommonTemplates.DataImportCronTemplates = []ssp.DataImportCronTemplate{cronTemplate}
+
+					_, err := operand.Reconcile(&request)
+					Expect(err).ToNot(HaveOccurred())
+
+					cron := cdiv1beta1.DataImportCron{}
+					Expect(request.Client.Get(request.Context, client.ObjectKey{
+						Name:      cronTemplate.Name,
+						Namespace: internal.GoldenImagesNamespace,
+					}, &cron)).To(Succeed())
+
+					Expect(cron.Spec.ManagedDataSource).To(Equal(cronTemplate.Spec.ManagedDataSource))
+				})
+			})
+
+			It("should not create DataImportCron, if default DataSource points to an existing PVC without arch specific suffix", func() {
+				pvc := &v1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      centos8,
+						Namespace: internal.GoldenImagesNamespace,
+					},
+					Spec: v1.PersistentVolumeClaimSpec{},
+				}
+				Expect(request.Client.Create(request.Context, pvc)).To(Succeed())
+
+				_, err := operand.Reconcile(&request)
+				Expect(err).ToNot(HaveOccurred())
+
+				defaultArch := architecture.AMD64
+
+				for _, arch := range cronArchs {
+					err := request.Client.Get(request.Context, client.ObjectKey{
+						Name:      cronTemplate.Name + "-" + string(arch),
+						Namespace: internal.GoldenImagesNamespace,
+					}, &cdiv1beta1.DataImportCron{})
+
+					if arch == defaultArch {
+						Expect(err).To(MatchError(errors.IsNotFound, "errors.IsNotFound"))
+					} else {
+						Expect(err).ToNot(HaveOccurred())
+					}
+				}
+			})
+		})
+	})
+
+	It("should remove old DataImportCron when multi-arch is enabled", func() {
+		cronTemplate := ssp.DataImportCronTemplate{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: centos8,
+			},
+			Spec: cdiv1beta1.DataImportCronSpec{
+				ManagedDataSource: centos8,
+				Template: cdiv1beta1.DataVolume{
+					Spec: cdiv1beta1.DataVolumeSpec{
+						Source: &cdiv1beta1.DataVolumeSource{
+							Registry: &cdiv1beta1.DataVolumeSourceRegistry{},
+						},
+					},
+				},
+			},
+		}
+		request.Instance.Spec.CommonTemplates.DataImportCronTemplates = []ssp.DataImportCronTemplate{cronTemplate}
+
+		_, err := operand.Reconcile(&request)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(request.Client.Get(request.Context, client.ObjectKey{
+			Name:      cronTemplate.GetName(),
+			Namespace: internal.GoldenImagesNamespace,
+		}, &cdiv1beta1.DataImportCron{})).To(Succeed())
+
+		// Enable multi-arch
+		cronTemplate.Annotations = map[string]string{
+			DataImportCronArchsAnnotation: "amd64,arm64,s390x",
+		}
+		request.Instance.Spec.CommonTemplates.DataImportCronTemplates = []ssp.DataImportCronTemplate{cronTemplate}
+
+		request.Instance.Spec.EnableMultipleArchitectures = ptr.To(true)
+		request.Instance.Spec.Cluster = &ssp.Cluster{
+			WorkloadArchitectures:     []string{string(architecture.AMD64), string(architecture.ARM64), string(architecture.S390X)},
+			ControlPlaneArchitectures: []string{string(architecture.AMD64)},
+		}
+
+		_, err = operand.Reconcile(&request)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(request.Client.Get(request.Context, client.ObjectKey{
+			Name:      cronTemplate.GetName(),
+			Namespace: internal.GoldenImagesNamespace,
+		}, &cdiv1beta1.DataImportCron{})).
+			To(MatchError(errors.IsNotFound, "errors.IsNotFound"))
 	})
 })
 

--- a/internal/operands/data-sources/resource.go
+++ b/internal/operands/data-sources/resource.go
@@ -33,6 +33,23 @@ func newDataSource(name string) *cdiv1beta1.DataSource {
 	}
 }
 
+func newDataSourceReference(name string, referenceName string) *cdiv1beta1.DataSource {
+	return &cdiv1beta1.DataSource{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: internal.GoldenImagesNamespace,
+		},
+		Spec: cdiv1beta1.DataSourceSpec{
+			Source: cdiv1beta1.DataSourceSource{
+				DataSource: &cdiv1beta1.DataSourceRefSourceDataSource{
+					Name:      referenceName,
+					Namespace: internal.GoldenImagesNamespace,
+				},
+			},
+		},
+	}
+}
+
 func newGoldenImagesNS(namespace string) *core.Namespace {
 	return &core.Namespace{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/operands/data-sources/resource.go
+++ b/internal/operands/data-sources/resource.go
@@ -16,8 +16,8 @@ const (
 	EditClusterRoleName = "os-images.kubevirt.io:edit"
 )
 
-func newDataSource(name string) cdiv1beta1.DataSource {
-	return cdiv1beta1.DataSource{
+func newDataSource(name string) *cdiv1beta1.DataSource {
+	return &cdiv1beta1.DataSource{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: internal.GoldenImagesNamespace,

--- a/internal/template-bundle/bundle.go
+++ b/internal/template-bundle/bundle.go
@@ -138,9 +138,8 @@ func vmTemplateUsesSourceRef(template *templatev1.Template) (bool, error) {
 
 func findDataSourceName(template *templatev1.Template) (string, bool) {
 	const dataSourceNameOld = "SRC_PVC_NAME"
-	const dataSourceName = "DATA_SOURCE_NAME"
 
-	name, exists := findParameterValue(dataSourceName, template)
+	name, exists := findParameterValue(common_templates.TemplateDataSourceParameterName, template)
 	if exists {
 		return name, true
 	}

--- a/internal/template-bundle/bundle.go
+++ b/internal/template-bundle/bundle.go
@@ -95,6 +95,10 @@ func (d DataSourceCollection) Names() iter.Seq[string] {
 	return maps.Keys(d)
 }
 
+func (d DataSourceCollection) Contains(name string, arch architecture.Arch) bool {
+	return slices.Contains(d[name], arch)
+}
+
 func vmTemplateUsesSourceRef(template *templatev1.Template) (bool, error) {
 	vmUnstructured := &unstructured.Unstructured{}
 	err := yaml.NewYAMLOrJSONDecoder(bytes.NewReader(template.Objects[0].Raw), 1024).Decode(vmUnstructured)

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"reflect"
@@ -497,14 +498,39 @@ func waitUntilDeployed() {
 		Fail("Timed out waiting for SSP to be in phase Deployed.")
 	}
 
+	defer func() {
+		// If the below check fails, output the SSP object to log.
+		// Its .status.conditions can be helpful.
+		if rec := recover(); rec != nil {
+			ssp := &sspv1beta3.SSP{}
+			err := apiClient.Get(ctx, client.ObjectKey{
+				Name:      strategy.GetName(),
+				Namespace: strategy.GetNamespace(),
+			}, ssp)
+			if err != nil {
+				_, _ = fmt.Fprintf(GinkgoWriter, "Could not get SSP object: %s\n", err.Error())
+				panic(rec)
+			}
+
+			sspJson, err := json.MarshalIndent(ssp, "", "    ")
+			if err != nil {
+				_, _ = fmt.Fprintf(GinkgoWriter, "Could not convert SSP to JSON: %s\n", err.Error())
+				panic(rec)
+			}
+
+			_, _ = fmt.Fprintf(GinkgoWriter, "SSP object:\n%s\n", sspJson)
+			panic(rec)
+		}
+	}()
+
 	// Set to true before waiting. In case Eventually fails,
 	// it will panic and the deploymentTimedOut will be left true
 	deploymentTimedOut = true
-	EventuallyWithOffset(1, func() bool {
+	EventuallyWithOffset(1, func(g Gomega) {
 		ssp := getSsp()
-		return ssp.Status.ObservedGeneration == ssp.Generation &&
-			ssp.Status.Phase == lifecycleapi.PhaseDeployed
-	}, env.Timeout(), time.Second).Should(BeTrue())
+		g.Expect(ssp.Status.ObservedGeneration).To(Equal(ssp.Generation))
+		g.Expect(ssp.Status.Phase).To(Equal(lifecycleapi.PhaseDeployed))
+	}, env.Timeout(), time.Second).Should(Succeed())
 	deploymentTimedOut = false
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Added logic for creating `DataSources` and `DataImportCrons` for multiple architectures.

**Which issue(s) this PR fixes**: 
Jira: https://issues.redhat.com/browse/CNV-61574
Jira: https://issues.redhat.com/browse/CNV-61576

**Special notes for your reviewer**:
This implements part of the VEP: 
https://github.com/kubevirt/enhancements/blob/3f97affd5c9cd591439530f2e5615398c80c3bef/veps/sig-storage/dic-on-heterogeneous-cluster/dic-on-heterogeneous-cluster.md

**Release note**:
```release-note
Added support for multi-arch DataSources and DataImportCrons
```
