### PR TITLE
tests: Change which common template is used in tests

### DIFF
--- a/tests/commonTemplates_test.go
+++ b/tests/commonTemplates_test.go
@@ -28,7 +28,7 @@ import (
 func createTestTemplate() testResource {
 	expectedLabels := expectedLabelsFor("common-templates", common.AppComponentTemplating)
 	return testResource{
-		Name:           "rhel8-desktop-tiny" + templatesSuffix,
+		Name:           "fedora-desktop-medium" + templatesSuffix,
 		Namespace:      strategy.GetTemplatesNamespace(),
 		Resource:       &templatev1.Template{},
 		ExpectedLabels: expectedLabels,


### PR DESCRIPTION
**What this PR does / why we need it**:
Previously functional tests used `rhel8-desktop-tiny`, but this template does not exist for arm architecture.

**Release note**:
```release-note
None
```
