### PR TITLE
chore: Bump golangci-lint version

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,14 +1,35 @@
+version: "2"
 linters:
-  # Disable all linters.
-  disable-all: true
-  # Enable specific linter
-  # https://golangci-lint.run/usage/linters/#enabled-by-default
+  default: none
   enable:
-    - whitespace
-    - misspell
-    - ginkgolinter
     - errcheck
+    - errname
+    - ginkgolinter
     - ineffassign
+    - misspell
     - staticcheck
     - unused
-    - errname
+    - whitespace
+  settings:
+    staticcheck:
+      dot-import-whitelist:
+        - github.com/onsi/ginkgo/v2
+        - github.com/onsi/gomega
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -330,7 +330,7 @@ kubevirt-sync:
 	KUSTOMIZE=$(KUSTOMIZE) ./hack/kubevirt.sh sync
 
 GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
-GOLANGCI_LINT_VERSION ?= v1.64.6
+GOLANGCI_LINT_VERSION ?= v2.3.1
 
 .PHONY: lint
 lint:

--- a/hack/validate-no-offensive-lang.sh
+++ b/hack/validate-no-offensive-lang.sh
@@ -3,7 +3,7 @@
 OFFENSIVE_WORDS="black[ -]?list|white[ -]?list|master|slave"
 ALLOW_LIST=".+[:/=]master[a-zA-Z]*/?"
 
-if git grep -inE "${OFFENSIVE_WORDS}" -- ':!vendor' ':!api/vendor' ':!automation/e2e-upgrade-functests' ":!${BASH_SOURCE[0]}" ':!.github/workflows/' | grep -viE "${ALLOW_LIST}"; then
+if git grep -inE "${OFFENSIVE_WORDS}" -- ':!vendor' ':!api/vendor' ':!automation/e2e-upgrade-functests' ":!${BASH_SOURCE[0]}" ':!.github/workflows/' ':!.golangci.yaml' | grep -viE "${ALLOW_LIST}"; then
   echo "Validation failed. Found offensive language"
   exit 1
 fi

--- a/internal/common/crypto_policy.go
+++ b/internal/common/crypto_policy.go
@@ -79,7 +79,7 @@ func selectCipherSuitesAndMinTLSVersion(profile *ocpv1.TLSSecurityProfile) ([]st
 		return nil, ""
 	}
 	if profile.Custom != nil {
-		return profile.Custom.TLSProfileSpec.Ciphers, profile.Custom.TLSProfileSpec.MinTLSVersion
+		return profile.Custom.Ciphers, profile.Custom.MinTLSVersion
 	}
 	tlsProfileSpec := ocpv1.TLSProfiles[profile.Type]
 	return tlsProfileSpec.Ciphers, tlsProfileSpec.MinTLSVersion

--- a/internal/operands/common-templates/reconcile.go
+++ b/internal/operands/common-templates/reconcile.go
@@ -307,7 +307,7 @@ func reconcileTemplatesFuncs(templatesBundle []templatev1.Template) []common.Rec
 		template := &templatesBundle[i]
 		funcs = append(funcs, func(request *common.Request) (common.ReconcileResult, error) {
 			namespace := request.Instance.Spec.CommonTemplates.Namespace
-			template.ObjectMeta.Namespace = namespace
+			template.Namespace = namespace
 			return common.CreateOrUpdate(request).
 				ClusterResource(template).
 				WithAppLabels(operandName, operandComponent).

--- a/internal/operands/vm-delete-protection/reconcile.go
+++ b/internal/operands/vm-delete-protection/reconcile.go
@@ -70,7 +70,7 @@ func reconcileVAP(request *common.Request) (common.ReconcileResult, error) {
 		StatusFunc(func(resource client.Object) common.ResourceStatus {
 			vap := resource.(*admissionregistrationv1.ValidatingAdmissionPolicy)
 			if vap.Status.TypeChecking == nil {
-				msg := fmt.Sprintf("Delete protection VAP type checking in progress")
+				msg := "Delete protection VAP type checking in progress"
 				return common.ResourceStatus{
 					Progressing:  &msg,
 					NotAvailable: &msg,

--- a/internal/template-validator/kubevirtjobs/virtualmachine.go
+++ b/internal/template-validator/kubevirtjobs/virtualmachine.go
@@ -60,8 +60,8 @@ func setVirtualMachineDefaults(in *k6tv1.VirtualMachine) {
 	if in.Spec.Template != nil {
 		for i := range in.Spec.Template.Spec.Domain.Devices.Disks {
 			a := &in.Spec.Template.Spec.Domain.Devices.Disks[i]
-			if a.DiskDevice.CDRom != nil {
-				setCDRomTargetDefaults(a.DiskDevice.CDRom)
+			if a.CDRom != nil {
+				setCDRomTargetDefaults(a.CDRom)
 			}
 		}
 	}

--- a/internal/template-validator/tlsinfo/tlsinfo.go
+++ b/internal/template-validator/tlsinfo/tlsinfo.go
@@ -149,11 +149,11 @@ func loadCertificates(directory string) (serverCrt *tls.Certificate, err error) 
 
 	cert, err := tls.X509KeyPair(certBytes, keyBytes)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load certificate: %v\n", err)
+		return nil, fmt.Errorf("failed to load certificate: %v", err)
 	}
 	leaf, err := x509.ParseCertificate(cert.Certificate[0])
 	if err != nil {
-		return nil, fmt.Errorf("failed to load leaf certificate: %v\n", err)
+		return nil, fmt.Errorf("failed to load leaf certificate: %v", err)
 	}
 	cert.Leaf = leaf
 	return &cert, nil

--- a/pkg/monitoring/metrics/ssp-operator/rbd_metrics.go
+++ b/pkg/monitoring/metrics/ssp-operator/rbd_metrics.go
@@ -37,14 +37,14 @@ func SetVmWithVolume(vm *kubevirtv1.VirtualMachine, pvc *k8sv1.PersistentVolumeC
 		return
 	}
 
-	mounter, ok := pv.Spec.PersistentVolumeSource.CSI.VolumeAttributes["mounter"]
+	mounter, ok := pv.Spec.CSI.VolumeAttributes["mounter"]
 	// If mounter is not set, it is using the default mounter, which is "rbd"
 	if ok && mounter != "rbd" {
 		vmRbdVolume.WithLabelValues(vm.Name, vm.Namespace).Set(0)
 		return
 	}
 
-	rxbounce, ok := pv.Spec.PersistentVolumeSource.CSI.VolumeAttributes["mapOptions"]
+	rxbounce, ok := pv.Spec.CSI.VolumeAttributes["mapOptions"]
 	// If mapOptions is not set, or if it is set but does not contain "krbd:rxbounce", it might be impacted by https://bugzilla.redhat.com/2109455
 	if !ok || !strings.Contains(rxbounce, "krbd:rxbounce") {
 		vmRbdVolume.WithLabelValues(vm.Name, vm.Namespace).Set(1)
@@ -55,5 +55,5 @@ func SetVmWithVolume(vm *kubevirtv1.VirtualMachine, pvc *k8sv1.PersistentVolumeC
 }
 
 func usesRbdCsiDriver(pv *k8sv1.PersistentVolume) bool {
-	return pv.Spec.PersistentVolumeSource.CSI != nil && strings.Contains(pv.Spec.PersistentVolumeSource.CSI.Driver, "rbd.csi.ceph.com")
+	return pv.Spec.CSI != nil && strings.Contains(pv.Spec.CSI.Driver, "rbd.csi.ceph.com")
 }

--- a/pkg/monitoring/metrics/ssp-operator/rbd_metrics_test.go
+++ b/pkg/monitoring/metrics/ssp-operator/rbd_metrics_test.go
@@ -60,7 +60,7 @@ var _ = Describe("rbd_metrics", func() {
 		}
 
 		if mounter != "" {
-			pv.Spec.PersistentVolumeSource.CSI.VolumeAttributes["mounter"] = mounter
+			pv.Spec.CSI.VolumeAttributes["mounter"] = mounter
 		}
 	}
 

--- a/tests/commonTemplates_test.go
+++ b/tests/commonTemplates_test.go
@@ -111,7 +111,7 @@ var _ = Describe("Common templates", func() {
 					flavors   []string
 				)
 
-				for labelKey := range template.ObjectMeta.Labels {
+				for labelKey := range template.Labels {
 					if strings.HasPrefix(labelKey, commonTemplates.TemplateOsLabelPrefix) {
 						oss = append(oss, labelKey)
 						continue

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -19,7 +19,6 @@ import (
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	apps "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -89,7 +88,7 @@ func (s *newSspStrategy) Init() {
 	validateDeploymentExists()
 
 	Eventually(func() error {
-		namespaceObj := &v1.Namespace{
+		namespaceObj := &core.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: s.GetNamespace(),
 				Labels: map[string]string{
@@ -100,7 +99,7 @@ func (s *newSspStrategy) Init() {
 	}, env.Timeout(), time.Second).ShouldNot(HaveOccurred())
 
 	Eventually(func() error {
-		namespaceObj := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: s.GetTemplatesNamespace()}}
+		namespaceObj := &core.Namespace{ObjectMeta: metav1.ObjectMeta{Name: s.GetTemplatesNamespace()}}
 		return apiClient.Create(ctx, namespaceObj)
 	}, env.Timeout(), time.Second).ShouldNot(HaveOccurred())
 
@@ -149,13 +148,13 @@ func (s *newSspStrategy) Cleanup() {
 		}, &sspv1beta3.SSP{})
 	}
 
-	err1 := apiClient.Delete(ctx, &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: s.GetNamespace()}})
-	err2 := apiClient.Delete(ctx, &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: s.GetTemplatesNamespace()}})
+	err1 := apiClient.Delete(ctx, &core.Namespace{ObjectMeta: metav1.ObjectMeta{Name: s.GetNamespace()}})
+	err2 := apiClient.Delete(ctx, &core.Namespace{ObjectMeta: metav1.ObjectMeta{Name: s.GetTemplatesNamespace()}})
 	expectSuccessOrNotFound(err1)
 	expectSuccessOrNotFound(err2)
 
-	waitForDeletion(client.ObjectKey{Name: s.GetNamespace()}, &v1.Namespace{})
-	waitForDeletion(client.ObjectKey{Name: s.GetTemplatesNamespace()}, &v1.Namespace{})
+	waitForDeletion(client.ObjectKey{Name: s.GetNamespace()}, &core.Namespace{})
+	waitForDeletion(client.ObjectKey{Name: s.GetTemplatesNamespace()}, &core.Namespace{})
 }
 
 func (s *newSspStrategy) GetName() string {
@@ -243,7 +242,7 @@ func (s *existingSspStrategy) Init() {
 	Expect(err).ToNot(HaveOccurred())
 
 	templatesNamespace := existingSsp.Spec.CommonTemplates.Namespace
-	Expect(apiClient.Get(ctx, client.ObjectKey{Name: templatesNamespace}, &v1.Namespace{})).To(Succeed())
+	Expect(apiClient.Get(ctx, client.ObjectKey{Name: templatesNamespace}, &core.Namespace{})).To(Succeed())
 
 	validateDeploymentExists()
 
@@ -383,27 +382,27 @@ var _ = BeforeSuite(func() {
 		strategy = &existingSspStrategy{Name: existingCrName, Namespace: existingCrNamespace}
 	}
 
-	fmt.Println(fmt.Sprintf("timeout set to %d minutes", env.Timeout()))
-	fmt.Println(fmt.Sprintf("short timeout set to %d minutes", env.ShortTimeout()))
+	fmt.Printf("timeout set to %d minutes\n", env.Timeout())
+	fmt.Printf("short timeout set to %d minutes\n", env.ShortTimeout())
 
 	if envTopologyMode, set := env.TopologyMode(); set {
 		topologyMode = envTopologyMode
-		fmt.Println(fmt.Sprintf("TopologyMode set to %s", envTopologyMode))
+		fmt.Printf("TopologyMode set to %s\n", envTopologyMode)
 	}
 
 	if envSspDeploymentName := env.SspDeploymentName(); envSspDeploymentName != "" {
 		sspDeploymentName = envSspDeploymentName
-		fmt.Println(fmt.Sprintf("SspDeploymentName set to %s", envSspDeploymentName))
+		fmt.Printf("SspDeploymentName set to %s\n", envSspDeploymentName)
 	}
 
 	if envSspDeploymentNamespace := env.SspDeploymentNamespace(); envSspDeploymentNamespace != "" {
 		sspDeploymentNamespace = envSspDeploymentNamespace
-		fmt.Println(fmt.Sprintf("SspDeploymentNamespace set to %s", envSspDeploymentNamespace))
+		fmt.Printf("SspDeploymentNamespace set to %s\n", envSspDeploymentNamespace)
 	}
 
 	if envSspWebhookServiceName := env.SspWebhookServiceName(); envSspWebhookServiceName != "" {
 		sspWebhookServiceName = envSspWebhookServiceName
-		fmt.Println(fmt.Sprintf("SspWebhookServiceName set to %s", envSspWebhookServiceName))
+		fmt.Printf("SspWebhookServiceName set to %s\n", envSspWebhookServiceName)
 	}
 
 	testScheme = runtime.NewScheme()

--- a/tests/validator_test.go
+++ b/tests/validator_test.go
@@ -511,7 +511,7 @@ var _ = Describe("Template validator webhooks", func() {
 			Expect(apiClient.Create(ctx, template)).ToNot(HaveOccurred(), "Failed to create template: %s", template.Name)
 
 			vm = NewVirtualMachine(vmi)
-			vm.ObjectMeta.Annotations = map[string]string{
+			vm.Annotations = map[string]string{
 				TemplateNameAnnotation:      template.Name,
 				TemplateNamespaceAnnotation: template.Namespace,
 			}
@@ -523,7 +523,7 @@ var _ = Describe("Template validator webhooks", func() {
 
 			vmi = addDomainResourcesToVMI(vmi, 2, clusterMachineType, "128M")
 			vm = NewVirtualMachine(vmi)
-			vm.ObjectMeta.Annotations = map[string]string{
+			vm.Annotations = map[string]string{
 				TemplateNameAnnotation:      template.Name,
 				TemplateNamespaceAnnotation: template.Namespace,
 			}
@@ -535,7 +535,7 @@ var _ = Describe("Template validator webhooks", func() {
 			// set value unfulfilling validation
 			vmi = addDomainResourcesToVMI(vmi, 2, "test", "128M")
 			vm = NewVirtualMachine(vmi)
-			vm.ObjectMeta.Annotations = map[string]string{
+			vm.Annotations = map[string]string{
 				TemplateNameAnnotation:      template.Name,
 				TemplateNamespaceAnnotation: template.Namespace,
 			}
@@ -555,7 +555,7 @@ var _ = Describe("Template validator webhooks", func() {
 			vmi = addDomainResourcesToVMI(vmi, 0, clusterMachineType, "128M")
 			vmi.Spec.Domain.CPU = nil
 			vm = NewVirtualMachine(vmi)
-			vm.ObjectMeta.Annotations = map[string]string{
+			vm.Annotations = map[string]string{
 				TemplateNameAnnotation:      template.Name,
 				TemplateNamespaceAnnotation: template.Namespace,
 			}
@@ -568,7 +568,7 @@ var _ = Describe("Template validator webhooks", func() {
 			vmi = addDomainResourcesToVMI(vmi, 0, clusterMachineType, "128M")
 			vmi.Spec.Domain.CPU = nil
 			vm = NewVirtualMachine(vmi)
-			vm.ObjectMeta.Annotations = map[string]string{
+			vm.Annotations = map[string]string{
 				TemplateNameAnnotation:      template.Name,
 				TemplateNamespaceAnnotation: template.Namespace,
 			}
@@ -581,7 +581,7 @@ var _ = Describe("Template validator webhooks", func() {
 			vmi = addDomainResourcesToVMI(vmi, 0, clusterMachineType, "128M")
 			vmi.Spec.Domain.CPU = nil
 			vm = NewVirtualMachine(vmi)
-			vm.ObjectMeta.Annotations = map[string]string{
+			vm.Annotations = map[string]string{
 				TemplateNameAnnotation:      template.Name,
 				TemplateNamespaceAnnotation: template.Namespace,
 			}
@@ -594,7 +594,7 @@ var _ = Describe("Template validator webhooks", func() {
 			vmi = addDomainResourcesToVMI(vmi, 0, clusterMachineType, "32M")
 			vmi.Spec.Domain.CPU = nil
 			vm = NewVirtualMachine(vmi)
-			vm.ObjectMeta.Annotations = map[string]string{
+			vm.Annotations = map[string]string{
 				TemplateNameAnnotation:      template.Name,
 				TemplateNamespaceAnnotation: template.Namespace,
 			}
@@ -607,7 +607,7 @@ var _ = Describe("Template validator webhooks", func() {
 			vmi = addDomainResourcesToVMI(vmi, 0, clusterMachineType, "1G")
 			vmi.Spec.Domain.CPU = nil
 			vm = NewVirtualMachine(vmi)
-			vm.ObjectMeta.Annotations = map[string]string{
+			vm.Annotations = map[string]string{
 				TemplateNameAnnotation:      template.Name,
 				TemplateNamespaceAnnotation: template.Namespace,
 			}
@@ -629,7 +629,7 @@ var _ = Describe("Template validator webhooks", func() {
 		It("[test_id:5591]test with partial annotations", decorators.Conformance, func() {
 			vmi = addDomainResourcesToVMI(vmi, 2, clusterMachineType, "128M")
 			vm = NewVirtualMachine(vmi)
-			vm.ObjectMeta.Annotations = map[string]string{
+			vm.Annotations = map[string]string{
 				"vm.kubevirt.io/template-namespace": strategy.GetNamespace(),
 			}
 			eventuallyCreateVm(vm)
@@ -640,7 +640,7 @@ var _ = Describe("Template validator webhooks", func() {
 
 			vmi = addDomainResourcesToVMI(vmi, 2, clusterMachineType, "128M")
 			vm = NewVirtualMachine(vmi)
-			vm.ObjectMeta.Annotations = map[string]string{
+			vm.Annotations = map[string]string{
 				TemplateNameAnnotation:              template.Name,
 				"vm.kubevirt.io/template.namespace": template.Namespace,
 			}
@@ -652,7 +652,7 @@ var _ = Describe("Template validator webhooks", func() {
 
 			vmi = addDomainResourcesToVMI(vmi, 2, clusterMachineType, "128M")
 			vm = NewVirtualMachine(vmi)
-			vm.ObjectMeta.Labels = map[string]string{
+			vm.Labels = map[string]string{
 				TemplateNameAnnotation:              template.Name,
 				"vm.kubevirt.io/template.namespace": template.Namespace,
 			}
@@ -667,7 +667,7 @@ var _ = Describe("Template validator webhooks", func() {
 				Sockets: 1,
 			}
 			vm = NewVirtualMachine(vmi)
-			vm.ObjectMeta.Annotations = map[string]string{
+			vm.Annotations = map[string]string{
 				TemplateNameAnnotation:      template.Name,
 				TemplateNamespaceAnnotation: template.Namespace,
 			}
@@ -682,7 +682,7 @@ var _ = Describe("Template validator webhooks", func() {
 
 			vmi = addDomainResourcesToVMI(vmi, 1, clusterMachineType, "64M")
 			vm = NewVirtualMachine(vmi)
-			vm.ObjectMeta.Annotations = map[string]string{
+			vm.Annotations = map[string]string{
 				TemplateNameAnnotation:      template.Name,
 				TemplateNamespaceAnnotation: template.Namespace,
 				"vm.kubevirt.io/validations": `[
@@ -704,7 +704,7 @@ var _ = Describe("Template validator webhooks", func() {
 
 			vmi = addDomainResourcesToVMI(vmi, 5, clusterMachineType, "64M")
 			vm = NewVirtualMachine(vmi)
-			vm.ObjectMeta.Annotations = map[string]string{
+			vm.Annotations = map[string]string{
 				TemplateNameAnnotation:      template.Name,
 				TemplateNamespaceAnnotation: template.Namespace,
 				"vm.kubevirt.io/validations": `[
@@ -726,7 +726,7 @@ var _ = Describe("Template validator webhooks", func() {
 
 			vmi = addDomainResourcesToVMI(vmi, 5, clusterMachineType, "64M")
 			vm = NewVirtualMachine(vmi)
-			vm.ObjectMeta.Annotations = map[string]string{
+			vm.Annotations = map[string]string{
 				TemplateNameAnnotation:      template.Name,
 				TemplateNamespaceAnnotation: template.Namespace,
 				"vm.kubevirt.io/validations": `[
@@ -748,7 +748,7 @@ var _ = Describe("Template validator webhooks", func() {
 
 			vmi = addDomainResourcesToVMI(vmi, 5, clusterMachineType, "64M")
 			vm = NewVirtualMachine(vmi)
-			vm.ObjectMeta.Annotations = map[string]string{
+			vm.Annotations = map[string]string{
 				TemplateNameAnnotation:      template.Name,
 				TemplateNamespaceAnnotation: template.Namespace,
 				"vm.kubevirt.io/validations": `[
@@ -767,7 +767,7 @@ var _ = Describe("Template validator webhooks", func() {
 		It("[test_id:5174]: VM with validations and deleted template", decorators.Conformance, func() {
 			vmi = addDomainResourcesToVMI(vmi, 3, clusterMachineType, "64M")
 			vm = NewVirtualMachine(vmi)
-			vm.ObjectMeta.Annotations = map[string]string{
+			vm.Annotations = map[string]string{
 				TemplateNameAnnotation:      "nonexisting-vm-template",
 				TemplateNamespaceAnnotation: strategy.GetTemplatesNamespace(),
 				"vm.kubevirt.io/validations": `[
@@ -786,7 +786,7 @@ var _ = Describe("Template validator webhooks", func() {
 		It("[test_id:5046]: should override template rules and fail to create a VM based on the VM validation rules", decorators.Conformance, func() {
 			vmi = addDomainResourcesToVMI(vmi, 5, clusterMachineType, "64M")
 			vm = NewVirtualMachine(vmi)
-			vm.ObjectMeta.Annotations = map[string]string{
+			vm.Annotations = map[string]string{
 				TemplateNameAnnotation:      "nonexisting-vm-template",
 				TemplateNamespaceAnnotation: strategy.GetTemplatesNamespace(),
 				"vm.kubevirt.io/validations": `[
@@ -805,7 +805,7 @@ var _ = Describe("Template validator webhooks", func() {
 		It("[test_id:5047]: should fail to create a VM based on the VM validation rules", decorators.Conformance, func() {
 			vmi = addDomainResourcesToVMI(vmi, 5, clusterMachineType, "64M")
 			vm = NewVirtualMachine(vmi)
-			vm.ObjectMeta.Annotations = map[string]string{
+			vm.Annotations = map[string]string{
 				"vm.kubevirt.io/validations": `[
 												 {
 														"name": "LimitCores",
@@ -822,7 +822,7 @@ var _ = Describe("Template validator webhooks", func() {
 		It("[test_id:5175]: VM with validations without template", decorators.Conformance, func() {
 			vmi = addDomainResourcesToVMI(vmi, 3, clusterMachineType, "64M")
 			vm = NewVirtualMachine(vmi)
-			vm.ObjectMeta.Annotations = map[string]string{
+			vm.Annotations = map[string]string{
 				"vm.kubevirt.io/validations": `[
 												 {
 														"name": "LimitCores",
@@ -854,7 +854,7 @@ var _ = Describe("Template validator webhooks", func() {
 
 			vmi = addDomainResourcesToVMI(vmi, 2, clusterMachineType, "128M")
 			vm = NewVirtualMachine(vmi)
-			vm.ObjectMeta.Annotations = map[string]string{
+			vm.Annotations = map[string]string{
 				TemplateNameAnnotation:      template.Name,
 				TemplateNamespaceAnnotation: template.Namespace,
 			}
@@ -873,7 +873,7 @@ var _ = Describe("Template validator webhooks", func() {
 			Expect(apiClient.Create(ctx, template)).To(Succeed())
 
 			vm = NewVirtualMachine(vmi)
-			vm.ObjectMeta.Annotations = map[string]string{
+			vm.Annotations = map[string]string{
 				TemplateNameAnnotation:      template.Name,
 				TemplateNamespaceAnnotation: template.Namespace,
 			}
@@ -890,7 +890,7 @@ var _ = Describe("Template validator webhooks", func() {
 
 			vmi = addDomainResourcesToVMI(vmi, 2, clusterMachineType, "128M")
 			vm = NewVirtualMachine(vmi)
-			vm.ObjectMeta.Annotations = map[string]string{
+			vm.Annotations = map[string]string{
 				TemplateNameAnnotation:      template.Name,
 				TemplateNamespaceAnnotation: template.Namespace,
 				"vm.kubevirt.io/validations": `[
@@ -991,7 +991,7 @@ func failVmCreationToIncreaseRejectedVmsMetrics(template *templatev1.Template) {
 	// set values that will fail validation
 	vmi = addDomainResourcesToVMI(vmi, 2, "test", "128M")
 	vm := NewVirtualMachine(vmi)
-	vm.ObjectMeta.Annotations = map[string]string{
+	vm.Annotations = map[string]string{
 		labels.AnnotationTemplateNameKey:      template.Name,
 		labels.AnnotationTemplateNamespaceKey: template.Namespace,
 	}

--- a/tests/webhook_test.go
+++ b/tests/webhook_test.go
@@ -9,7 +9,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	"kubevirt.io/controller-lifecycle-operator-sdk/api"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -76,7 +75,7 @@ var _ = Describe("Validation webhook", func() {
 		It("[test_id:5242] [v1beta2] should fail to create a second SSP CR", decorators.Conformance, func() {
 			foundSsp := getSspV1Beta2()
 			ssp2 := foundSsp.DeepCopy()
-			ssp2.ObjectMeta = v1.ObjectMeta{
+			ssp2.ObjectMeta = metav1.ObjectMeta{
 				Name:      "test-ssp2",
 				Namespace: foundSsp.GetNamespace(),
 			}
@@ -92,7 +91,7 @@ var _ = Describe("Validation webhook", func() {
 		It("[test_id:TODO] [v1beta3] should fail to create a second SSP CR", decorators.Conformance, func() {
 			foundSsp := getSsp()
 			ssp2 := foundSsp.DeepCopy()
-			ssp2.ObjectMeta = v1.ObjectMeta{
+			ssp2.ObjectMeta = metav1.ObjectMeta{
 				Name:      "test-ssp2",
 				Namespace: foundSsp.GetNamespace(),
 			}
@@ -120,7 +119,7 @@ var _ = Describe("Validation webhook", func() {
 				Expect(apiClient.Delete(ctx, foundSsp)).ToNot(HaveOccurred())
 				waitForDeletion(client.ObjectKey{Name: foundSsp.GetName(), Namespace: foundSsp.GetNamespace()}, &sspv1beta2.SSP{})
 
-				foundSsp.ObjectMeta = v1.ObjectMeta{
+				foundSsp.ObjectMeta = metav1.ObjectMeta{
 					Name:      foundSsp.GetName(),
 					Namespace: foundSsp.GetNamespace(),
 				}
@@ -255,7 +254,7 @@ var _ = Describe("Validation webhook", func() {
 			})
 
 			It("[test_id:5989] [v1beta2] should fail with invalid template-validator placement fields", func() {
-				Eventually(func() v1.StatusReason {
+				Eventually(func() metav1.StatusReason {
 					foundSsp := getSspV1Beta2()
 					foundSsp.Spec.TemplateValidator = &sspv1beta2.TemplateValidator{
 						Placement: &placementAPIValidationInvalidPlacement,
@@ -266,7 +265,7 @@ var _ = Describe("Validation webhook", func() {
 			})
 
 			It("[test_id:5989] [v1beta3] should fail with invalid template-validator placement fields", decorators.Conformance, func() {
-				Eventually(func() v1.StatusReason {
+				Eventually(func() metav1.StatusReason {
 					foundSsp := getSsp()
 					foundSsp.Spec.TemplateValidator = &sspv1beta3.TemplateValidator{
 						Placement: &placementAPIValidationInvalidPlacement,

--- a/webhooks/ssp_webhook.go
+++ b/webhooks/ssp_webhook.go
@@ -83,7 +83,7 @@ func (s *sspValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (
 		return nil, fmt.Errorf("could not list SSPs for validation, please try again: %v", err)
 	}
 	if len(ssps.Items) > 0 {
-		return nil, fmt.Errorf("creation failed, an SSP CR already exists in namespace %v: %v", ssps.Items[0].ObjectMeta.Namespace, ssps.Items[0].ObjectMeta.Name)
+		return nil, fmt.Errorf("creation failed, an SSP CR already exists in namespace %v: %v", ssps.Items[0].Namespace, ssps.Items[0].Name)
 	}
 
 	return s.validateSspObject(ctx, sspObj)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Bump golangci-lint version to v2.3.1. Run golangci-lint migrate to migrate existing configuration to the new v2 format and re-add dot-import-whitelist for ginkgo and gomega. This also fixes all new findings that occured after the upgrade.

Also avoids CI failues because of golangci-lint going haywire.

**Which issue(s) this PR fixes**: 
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
