### PR TITLE
cleanup(template-validator): Listen on separate ports

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/prometheus/common v0.65.0
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.7
+	golang.org/x/sync v0.16.0
 	gomodules.xyz/jsonpatch/v2 v2.5.0
 	k8s.io/api v0.33.3
 	k8s.io/apiextensions-apiserver v0.33.3
@@ -37,8 +38,6 @@ require (
 	sigs.k8s.io/controller-runtime v0.21.0
 	sigs.k8s.io/yaml v1.6.0
 )
-
-require golang.org/x/sync v0.16.0
 
 require (
 	cel.dev/expr v0.24.0 // indirect

--- a/internal/networkpolicies/networkpolicies.go
+++ b/internal/networkpolicies/networkpolicies.go
@@ -1,12 +1,13 @@
 package networkpolicies
 
 import (
+	"strings"
+
 	k8sv1 "k8s.io/api/core/v1"
 	networkv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
-	"strings"
 )
 
 const (
@@ -126,6 +127,10 @@ func NewIngressToVirtTemplateValidatorWebhookAndMetrics(namespace string) *netwo
 					Ports: []networkv1.NetworkPolicyPort{
 						{
 							Port:     ptr.To(intstr.FromInt32(8443)),
+							Protocol: ptr.To(k8sv1.ProtocolTCP),
+						},
+						{
+							Port:     ptr.To(intstr.FromInt32(9443)),
 							Protocol: ptr.To(k8sv1.ProtocolTCP),
 						},
 					},

--- a/internal/operands/template-validator/resources.go
+++ b/internal/operands/template-validator/resources.go
@@ -27,8 +27,8 @@ import (
 )
 
 const (
-	ContainerPort                 = 8443
 	MetricsPort                   = 8443
+	WebhookPort                   = 9443
 	KubevirtIo                    = "kubevirt.io"
 	SecretName                    = "virt-template-validator-certs"
 	VirtTemplateValidator         = "virt-template-validator"
@@ -119,7 +119,7 @@ func newService(namespace string) *core.Service {
 			Ports: []core.ServicePort{{
 				Name:       "webhook",
 				Port:       443,
-				TargetPort: intstr.FromInt32(ContainerPort),
+				TargetPort: intstr.FromInt32(WebhookPort),
 			}},
 			Selector: CommonLabels(),
 		},
@@ -205,7 +205,8 @@ func newDeployment(namespace string, replicas int32, image string) *apps.Deploym
 							},
 						},
 						Args: []string{
-							fmt.Sprintf("--port=%d", ContainerPort),
+							fmt.Sprintf("--webhook-port=%d", WebhookPort),
+							fmt.Sprintf("--metrics-port=%d", MetricsPort),
 							fmt.Sprintf("--cert-dir=%s", certMountPath),
 						},
 						VolumeMounts: []core.VolumeMount{{
@@ -226,7 +227,7 @@ func newDeployment(namespace string, replicas int32, image string) *apps.Deploym
 						},
 						Ports: []core.ContainerPort{{
 							Name:          "webhook",
-							ContainerPort: ContainerPort,
+							ContainerPort: WebhookPort,
 							Protocol:      core.ProtocolTCP,
 						}, {
 							Name:          metrics.MetricsPortName,
@@ -237,7 +238,7 @@ func newDeployment(namespace string, replicas int32, image string) *apps.Deploym
 							ProbeHandler: core.ProbeHandler{
 								HTTPGet: &core.HTTPGetAction{
 									Path:   "/readyz",
-									Port:   intstr.FromInt32(ContainerPort),
+									Port:   intstr.FromInt32(WebhookPort),
 									Scheme: core.URISchemeHTTPS,
 								},
 							},

--- a/internal/template-validator/service/service.go
+++ b/internal/template-validator/service/service.go
@@ -18,15 +18,20 @@ type Service interface {
 type ServiceListen struct {
 	Name        string
 	BindAddress string
-	Port        int
+	MetricsPort int
+	WebhookPort int
 }
 
 type ServiceLibvirt struct {
 	LibvirtUri string
 }
 
-func (service *ServiceListen) Address() string {
-	return fmt.Sprintf("%s:%s", service.BindAddress, strconv.Itoa(service.Port))
+func (service *ServiceListen) MetricsAddress() string {
+	return fmt.Sprintf("%s:%s", service.BindAddress, strconv.Itoa(service.MetricsPort))
+}
+
+func (service *ServiceListen) WebhookAddress() string {
+	return fmt.Sprintf("%s:%s", service.BindAddress, strconv.Itoa(service.WebhookPort))
 }
 
 func (service *ServiceListen) InitFlags() {
@@ -35,7 +40,8 @@ func (service *ServiceListen) InitFlags() {
 
 func (service *ServiceListen) AddCommonFlags() {
 	flag.StringVar(&service.BindAddress, "listen", service.BindAddress, "Address where to listen on")
-	flag.IntVar(&service.Port, "port", service.Port, "Port to listen on")
+	flag.IntVar(&service.MetricsPort, "metrics-port", service.MetricsPort, "Port to listen on for metrics")
+	flag.IntVar(&service.WebhookPort, "webhook-port", service.WebhookPort, "Port to listen on for webhooks")
 }
 
 func (service *ServiceLibvirt) AddLibvirtFlags() {

--- a/internal/template-validator/validator/app.go
+++ b/internal/template-validator/validator/app.go
@@ -1,13 +1,16 @@
 package validator
 
 import (
+	"context"
 	"crypto/tls"
 	"net/http"
 	"os"
+	"time"
 
 	templatev1 "github.com/openshift/api/template/v1"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	flag "github.com/spf13/pflag"
+	"golang.org/x/sync/errgroup"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -23,10 +26,14 @@ import (
 )
 
 const (
-	defaultPort = 8443
-	defaultHost = "0.0.0.0"
+	defaultMetricsPort = 8443
+	defaultWebhookPort = 9443
+	defaultHost        = "0.0.0.0"
 
 	tlsOptionsDirectory = "/tls-options"
+
+	metricsServerType = "metrics"
+	webhookServerType = "webhook"
 )
 
 type App struct {
@@ -40,7 +47,8 @@ var _ service.Service = &App{}
 func (app *App) AddFlags() {
 	app.InitFlags()
 	app.BindAddress = defaultHost
-	app.Port = defaultPort
+	app.MetricsPort = defaultMetricsPort
+	app.WebhookPort = defaultWebhookPort
 	app.AddCommonFlags()
 
 	flag.StringVarP(&app.certsDir, "cert-dir", "c", "", "specify path to the directory containing TLS key and certificate - this enables TLS")
@@ -71,68 +79,120 @@ func (app *App) Run() {
 	informers.Start()
 	defer informers.Stop()
 
-	validating.NewWebhooks(informers).Register()
-
-	registerReadinessProbe()
-
-	// setup monitoring
-	err = validatorMetrics.SetupMetrics()
-	if err != nil {
+	if err := validatorMetrics.SetupMetrics(); err != nil {
 		logger.Log.Error(err, "Error setting up metrics")
 		panic(err)
 	}
 
-	http.Handle("/metrics", promhttp.Handler())
-
-	if app.certsDir != "" {
-		logger.Log.Info("TLS certs directory", "directory", app.certsDir)
-
-		tlsInfo := tlsinfo.TLSInfo{
-			CertsDirectory:      app.certsDir,
-			TLSOptionsDirectory: tlsOptionsDirectory,
-		}
-
-		if err := tlsInfo.Init(); err != nil {
-			logger.Log.Error(err, "Failed initializing TLSInfo")
-			panic(err)
-		}
+	tlsInfo, err := app.setupTLS()
+	if err != nil {
+		panic(err)
+	}
+	if tlsInfo != nil {
 		defer tlsInfo.Clean()
+	}
 
-		server := &http.Server{
-			Addr: app.Address(),
-			TLSConfig: &tls.Config{
-				GetConfigForClient: func(_ *tls.ClientHelloInfo) (*tls.Config, error) {
-					return tlsInfo.CreateTlsConfig()
-				},
-				GetCertificate: func(_ *tls.ClientHelloInfo) (*tls.Certificate, error) {
-					// This function is not called, but it needs to be non-nil, otherwise
-					// the server tries to load certificate from filenames passed to
-					// ListenAndServe().
-					panic("function should not be called")
-				},
-			},
-		}
+	metricsServer := app.createMetricsServer()
+	webhookServer := app.createWebhookServer(informers)
+	if tlsInfo != nil {
+		metricsServer.TLSConfig = createTLSConfig(tlsInfo)
+		webhookServer.TLSConfig = createTLSConfig(tlsInfo)
+	}
 
-		logger.Log.Info("TLS configured, serving over HTTPS", "address", app.Address())
-		if err := server.ListenAndServeTLS("", ""); err != nil {
-			logger.Log.Error(err, "Error listening TLS")
-			panic(err)
-		}
-	} else {
-		logger.Log.Info("TLS disabled, serving over HTTP", "address", app.Address())
-		if err := http.ListenAndServe(app.Address(), nil); err != nil {
-			logger.Log.Error(err, "Error listening")
-			panic(err)
-		}
+	g, ctx := errgroup.WithContext(context.Background())
+	g.Go(func() error { return startServer(metricsServer, metricsServerType) })
+	g.Go(func() error { return startServer(webhookServer, webhookServerType) })
+	g.Go(func() error { return shutdownServer(metricsServer, metricsServerType, ctx) })
+	g.Go(func() error { return shutdownServer(webhookServer, webhookServerType, ctx) })
+
+	if err := g.Wait(); err != nil {
+		panic(err)
 	}
 }
 
-func registerReadinessProbe() {
-	http.HandleFunc("/readyz", func(resp http.ResponseWriter, req *http.Request) {
+func (app *App) setupTLS() (*tlsinfo.TLSInfo, error) {
+	if app.certsDir == "" {
+		return nil, nil
+	}
+
+	logger.Log.Info("TLS certs directory", "directory", app.certsDir)
+
+	tlsInfo := &tlsinfo.TLSInfo{
+		CertsDirectory:      app.certsDir,
+		TLSOptionsDirectory: tlsOptionsDirectory,
+	}
+
+	if err := tlsInfo.Init(); err != nil {
+		logger.Log.Error(err, "Failed initializing TLSInfo")
+		return nil, err
+	}
+
+	return tlsInfo, nil
+}
+
+func (app *App) createMetricsServer() *http.Server {
+	metricsMux := http.NewServeMux()
+	metricsMux.Handle("/metrics", promhttp.Handler())
+
+	return &http.Server{
+		Addr:    app.MetricsAddress(),
+		Handler: metricsMux,
+	}
+}
+
+func (app *App) createWebhookServer(informers *virtinformers.Informers) *http.Server {
+	webhookMux := http.NewServeMux()
+	validating.NewWebhooks(informers).Register(webhookMux)
+
+	webhookMux.HandleFunc("/readyz", func(resp http.ResponseWriter, req *http.Request) {
 		if _, err := resp.Write([]byte("ok")); err != nil {
 			logger.Log.Error(err, "Failed to write response to /readyz")
 		}
 	})
+
+	return &http.Server{
+		Addr:    app.WebhookAddress(),
+		Handler: webhookMux,
+	}
+}
+
+func startServer(server *http.Server, serverType string) error {
+	if server.TLSConfig != nil {
+		logger.Log.Info("TLS configured, serving "+serverType+" over HTTPS", "address", server.Addr)
+		if err := server.ListenAndServeTLS("", ""); err != nil && err != http.ErrServerClosed {
+			logger.Log.Error(err, "Error listening "+serverType+" TLS")
+			return err
+		}
+	} else {
+		logger.Log.Info("TLS disabled, serving "+serverType+" over HTTP", "address", server.Addr)
+		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			logger.Log.Error(err, "Error listening "+serverType)
+			return err
+		}
+	}
+	return nil
+}
+
+func shutdownServer(server *http.Server, serverType string, ctx context.Context) error {
+	<-ctx.Done()
+	logger.Log.Info("Shutting down " + serverType + " server")
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	return server.Shutdown(shutdownCtx)
+}
+
+func createTLSConfig(tlsInfo *tlsinfo.TLSInfo) *tls.Config {
+	return &tls.Config{
+		GetConfigForClient: func(_ *tls.ClientHelloInfo) (*tls.Config, error) {
+			return tlsInfo.CreateTlsConfig()
+		},
+		GetCertificate: func(_ *tls.ClientHelloInfo) (*tls.Certificate, error) {
+			// This function is not called, but it needs to be non-nil, otherwise
+			// the server tries to load certificate from filenames passed to
+			// ListenAndServe().
+			panic("function should not be called")
+		},
+	}
 }
 
 func createScheme() *runtime.Scheme {

--- a/internal/template-validator/webhooks/hook.go
+++ b/internal/template-validator/webhooks/hook.go
@@ -43,7 +43,7 @@ const (
 type admitFunc func(*admissionv1.AdmissionReview) *admissionv1.AdmissionResponse
 
 type Webhooks interface {
-	Register()
+	Register(mux *http.ServeMux)
 }
 
 type webhooks struct {
@@ -56,11 +56,11 @@ func NewWebhooks(informers *virtinformers.Informers) Webhooks {
 	}
 }
 
-func (w *webhooks) Register() {
-	http.HandleFunc(VmValidatePath, func(resp http.ResponseWriter, req *http.Request) {
+func (w *webhooks) Register(mux *http.ServeMux) {
+	mux.HandleFunc(VmValidatePath, func(resp http.ResponseWriter, req *http.Request) {
 		serve(resp, req, w.admitVm)
 	})
-	http.HandleFunc(TemplateValidatePath, func(resp http.ResponseWriter, req *http.Request) {
+	mux.HandleFunc(TemplateValidatePath, func(resp http.ResponseWriter, req *http.Request) {
 		serve(resp, req, w.admitTemplate)
 	})
 }

--- a/tests/validator_test.go
+++ b/tests/validator_test.go
@@ -1252,7 +1252,7 @@ func TemplateWithoutRules() *templatev1.Template {
 }
 
 func getWebhookServerCertificates(validatorPod *core.Pod) ([]*x509.Certificate, error) {
-	conn, err := portForwarder.Connect(validatorPod, validator.ContainerPort)
+	conn, err := portForwarder.Connect(validatorPod, validator.WebhookPort)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Listen on separate ports for metrics and webhooks in template-validator.
This can be useful in the future because it allows to create more specific network policies.

**Which issue(s) this PR fixes**: 
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Listen on separate ports for metrics and webhooks in template-validator.
```
