### PR TITLE
chore: update vm-console-proxy manifests to v0.9.0

### DIFF
--- a/data/vm-console-proxy-bundle/vm-console-proxy.yaml
+++ b/data/vm-console-proxy-bundle/vm-console-proxy.yaml
@@ -154,18 +154,23 @@ spec:
       - args: []
         command:
         - /console
-        image: quay.io/kubevirt/vm-console-proxy:v0.8.1
+        image: quay.io/kubevirt/vm-console-proxy:v0.9.0
         imagePullPolicy: Always
         name: console
         ports:
         - containerPort: 8768
           name: api
           protocol: TCP
+        resources:
+          requests:
+            cpu: 100m
+            memory: 65Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
             drop:
             - ALL
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /config
           name: config

--- a/internal/operands/vm-console-proxy/defaults.go
+++ b/internal/operands/vm-console-proxy/defaults.go
@@ -3,6 +3,6 @@ package vm_console_proxy
 // This file is updated by GitHub action defined in .github/workflows/release-vm-console-proxy.yaml
 
 const (
-	defaultVmConsoleProxyImageTag = "v0.8.1"
+	defaultVmConsoleProxyImageTag = "v0.9.0"
 	defaultVmConsoleProxyImage    = "quay.io/kubevirt/vm-console-proxy:" + defaultVmConsoleProxyImageTag
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
Update vm-console-proxy manifests to `v0.9.0`

**Release note**:
```release-note
None
```
