### PR TITLE
ci: Use latest released CDI in CI

### DIFF
--- a/automation/common/versions.sh
+++ b/automation/common/versions.sh
@@ -58,7 +58,4 @@ function latest_version() {
 KUBEVIRT_VERSION=$(latest_version "kubevirt" "kubevirt")
 
 # Latest released CDI version
-
-# Using the latest pre-release of CDI, so the new API is available.
-# TODO: Revert back this line when CDI creates a proper release.
-CDI_VERSION="v1.63.0-alpha.0"
+CDI_VERSION=$(latest_version "kubevirt" "containerized-data-importer")


### PR DESCRIPTION
**What this PR does / why we need it**:
The CDI version `v1.63.0` was released.

**Release note**:
```release-note
None
```
