### PR TITLE
[release-v0.24] chore(deps): update module kubevirt.io/containerized-data-importer-api to v1.63.0

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -5,7 +5,7 @@ go 1.24.3
 require (
 	github.com/openshift/api v0.0.0-20250305013520-e7f23be12279 // release-4.18
 	k8s.io/apimachinery v0.33.3
-	kubevirt.io/containerized-data-importer-api v1.63.0-alpha.0
+	kubevirt.io/containerized-data-importer-api v1.63.0
 	kubevirt.io/controller-lifecycle-operator-sdk/api v0.2.4
 	sigs.k8s.io/controller-runtime v0.21.0
 )

--- a/api/go.sum
+++ b/api/go.sum
@@ -315,8 +315,8 @@ k8s.io/utils v0.0.0-20210802155522-efc7438f0176/go.mod h1:jPW/WVKK9YHAvNhRxK0md/
 k8s.io/utils v0.0.0-20211116205334-6203023598ed/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 h1:M3sRQVHv7vB20Xc2ybTt7ODCeFj6JSWYFzOFnYeS6Ro=
 k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
-kubevirt.io/containerized-data-importer-api v1.63.0-alpha.0 h1:fxhXZCD6tFvFxo16gVYaIqJ63QomqoEMxjcf5QbbKHE=
-kubevirt.io/containerized-data-importer-api v1.63.0-alpha.0/go.mod h1:VGp35wxpLXU18b7cnEpmcThI3AjcZUSfg/Zfql44U4o=
+kubevirt.io/containerized-data-importer-api v1.63.0 h1:+y378kAPIitSHFZCThSx9jr8UxwoArbEF5zRHA3xRMM=
+kubevirt.io/containerized-data-importer-api v1.63.0/go.mod h1:VGp35wxpLXU18b7cnEpmcThI3AjcZUSfg/Zfql44U4o=
 kubevirt.io/controller-lifecycle-operator-sdk/api v0.2.4 h1:fZYvD3/Vnitfkx6IJxjLAk8ugnZQ7CXVYcRfkSKmuZY=
 kubevirt.io/controller-lifecycle-operator-sdk/api v0.2.4/go.mod h1:018lASpFYBsYN6XwmA2TIrPCx6e0gviTd/ZNtSitKgc=
 sigs.k8s.io/controller-runtime v0.21.0 h1:CYfjpEuicjUecRk+KAeyYh+ouUBn4llGyDYytIGcJS8=

--- a/api/vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/authorize_utils.go
+++ b/api/vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/authorize_utils.go
@@ -45,11 +45,12 @@ func newCloneSourceHandler(dataVolume *DataVolume, dsGet dsGetFunc) (CloneSource
 		if err != nil {
 			return CloneSourceHandler{}, err
 		}
-		if dataSource.Spec.Source.PVC != nil {
-			pvcSource = dataSource.Spec.Source.PVC
-		} else if dataSource.Spec.Source.Snapshot != nil {
-			snapshotSource = dataSource.Spec.Source.Snapshot
-		}
+		pvcSource = dataSource.Spec.Source.PVC
+		snapshotSource = dataSource.Spec.Source.Snapshot
+		if dataSource.Spec.Source.DataSource != nil {
+			pvcSource = dataSource.Status.Source.PVC
+			snapshotSource = dataSource.Status.Source.Snapshot
+		} 
 	}
 
 	switch {

--- a/api/vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types.go
+++ b/api/vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types.go
@@ -1027,7 +1027,7 @@ type CDIConfigSpec struct {
 	PodResourceRequirements *corev1.ResourceRequirements `json:"podResourceRequirements,omitempty"`
 	// FeatureGates are a list of specific enabled feature gates
 	FeatureGates []string `json:"featureGates,omitempty"`
-	// FilesystemOverhead describes the space reserved for overhead when using Filesystem volumes. A value is between 0 and 1, if not defined it is 0.055 (5.5% overhead)
+	// FilesystemOverhead describes the space reserved for overhead when using Filesystem volumes. A value is between 0 and 1, if not defined it is 0.06 (6% overhead)
 	FilesystemOverhead *FilesystemOverhead `json:"filesystemOverhead,omitempty"`
 	// Preallocation controls whether storage for DataVolumes should be allocated in advance.
 	Preallocation *bool `json:"preallocation,omitempty"`

--- a/api/vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types_swagger_generated.go
+++ b/api/vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types_swagger_generated.go
@@ -521,7 +521,7 @@ func (CDIConfigSpec) SwaggerDoc() map[string]string {
 		"scratchSpaceStorageClass": "Override the storage class to used for scratch space during transfer operations. The scratch space storage class is determined in the following order: 1. value of scratchSpaceStorageClass, if that doesn't exist, use the default storage class, if there is no default storage class, use the storage class of the DataVolume, if no storage class specified, use no storage class for scratch space",
 		"podResourceRequirements":  "ResourceRequirements describes the compute resource requirements.",
 		"featureGates":             "FeatureGates are a list of specific enabled feature gates",
-		"filesystemOverhead":       "FilesystemOverhead describes the space reserved for overhead when using Filesystem volumes. A value is between 0 and 1, if not defined it is 0.055 (5.5% overhead)",
+		"filesystemOverhead":       "FilesystemOverhead describes the space reserved for overhead when using Filesystem volumes. A value is between 0 and 1, if not defined it is 0.06 (6% overhead)",
 		"preallocation":            "Preallocation controls whether storage for DataVolumes should be allocated in advance.",
 		"insecureRegistries":       "InsecureRegistries is a list of TLS disabled registries",
 		"dataVolumeTTLSeconds":     "DataVolumeTTLSeconds is the time in seconds after DataVolume completion it can be garbage collected. Disabled by default.\nDeprecated: Removed in v1.62.\n+optional",

--- a/api/vendor/modules.txt
+++ b/api/vendor/modules.txt
@@ -91,7 +91,7 @@ k8s.io/klog/v2/internal/sloghandler
 k8s.io/utils/internal/third_party/forked/golang/net
 k8s.io/utils/net
 k8s.io/utils/ptr
-# kubevirt.io/containerized-data-importer-api v1.63.0-alpha.0
+# kubevirt.io/containerized-data-importer-api v1.63.0
 ## explicit; go 1.23.0
 kubevirt.io/containerized-data-importer-api/pkg/apis/core
 kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	k8s.io/kube-aggregator v0.33.3
 	k8s.io/utils v0.0.0-20250604170112-4c0f3b243397
 	kubevirt.io/api v1.6.0
-	kubevirt.io/containerized-data-importer-api v1.63.0-alpha.0
+	kubevirt.io/containerized-data-importer-api v1.63.0
 	kubevirt.io/controller-lifecycle-operator-sdk/api v0.2.4
 	kubevirt.io/ssp-operator/api v0.0.0
 	kubevirt.io/vm-console-proxy/api v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -457,8 +457,8 @@ k8s.io/utils v0.0.0-20250604170112-4c0f3b243397 h1:hwvWFiBzdWw1FhfY1FooPn3kzWuJ8
 k8s.io/utils v0.0.0-20250604170112-4c0f3b243397/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 kubevirt.io/api v1.6.0 h1:ZO3Dh0b24PCdCe76uLD4cRusXKrcarOzt229UFly7PQ=
 kubevirt.io/api v1.6.0/go.mod h1:p66fEy/g79x7VpgUwrkUgOoG2lYs5LQq37WM6JXMwj4=
-kubevirt.io/containerized-data-importer-api v1.63.0-alpha.0 h1:fxhXZCD6tFvFxo16gVYaIqJ63QomqoEMxjcf5QbbKHE=
-kubevirt.io/containerized-data-importer-api v1.63.0-alpha.0/go.mod h1:VGp35wxpLXU18b7cnEpmcThI3AjcZUSfg/Zfql44U4o=
+kubevirt.io/containerized-data-importer-api v1.63.0 h1:+y378kAPIitSHFZCThSx9jr8UxwoArbEF5zRHA3xRMM=
+kubevirt.io/containerized-data-importer-api v1.63.0/go.mod h1:VGp35wxpLXU18b7cnEpmcThI3AjcZUSfg/Zfql44U4o=
 kubevirt.io/controller-lifecycle-operator-sdk/api v0.2.4 h1:fZYvD3/Vnitfkx6IJxjLAk8ugnZQ7CXVYcRfkSKmuZY=
 kubevirt.io/controller-lifecycle-operator-sdk/api v0.2.4/go.mod h1:018lASpFYBsYN6XwmA2TIrPCx6e0gviTd/ZNtSitKgc=
 kubevirt.io/vm-console-proxy/api v0.8.1 h1:/Om37kh5A896A7cXzOSp4o/ePySd0w7XCkojBuCz3ms=

--- a/vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/authorize_utils.go
+++ b/vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/authorize_utils.go
@@ -45,11 +45,12 @@ func newCloneSourceHandler(dataVolume *DataVolume, dsGet dsGetFunc) (CloneSource
 		if err != nil {
 			return CloneSourceHandler{}, err
 		}
-		if dataSource.Spec.Source.PVC != nil {
-			pvcSource = dataSource.Spec.Source.PVC
-		} else if dataSource.Spec.Source.Snapshot != nil {
-			snapshotSource = dataSource.Spec.Source.Snapshot
-		}
+		pvcSource = dataSource.Spec.Source.PVC
+		snapshotSource = dataSource.Spec.Source.Snapshot
+		if dataSource.Spec.Source.DataSource != nil {
+			pvcSource = dataSource.Status.Source.PVC
+			snapshotSource = dataSource.Status.Source.Snapshot
+		} 
 	}
 
 	switch {

--- a/vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types.go
+++ b/vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types.go
@@ -1027,7 +1027,7 @@ type CDIConfigSpec struct {
 	PodResourceRequirements *corev1.ResourceRequirements `json:"podResourceRequirements,omitempty"`
 	// FeatureGates are a list of specific enabled feature gates
 	FeatureGates []string `json:"featureGates,omitempty"`
-	// FilesystemOverhead describes the space reserved for overhead when using Filesystem volumes. A value is between 0 and 1, if not defined it is 0.055 (5.5% overhead)
+	// FilesystemOverhead describes the space reserved for overhead when using Filesystem volumes. A value is between 0 and 1, if not defined it is 0.06 (6% overhead)
 	FilesystemOverhead *FilesystemOverhead `json:"filesystemOverhead,omitempty"`
 	// Preallocation controls whether storage for DataVolumes should be allocated in advance.
 	Preallocation *bool `json:"preallocation,omitempty"`

--- a/vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types_swagger_generated.go
+++ b/vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types_swagger_generated.go
@@ -521,7 +521,7 @@ func (CDIConfigSpec) SwaggerDoc() map[string]string {
 		"scratchSpaceStorageClass": "Override the storage class to used for scratch space during transfer operations. The scratch space storage class is determined in the following order: 1. value of scratchSpaceStorageClass, if that doesn't exist, use the default storage class, if there is no default storage class, use the storage class of the DataVolume, if no storage class specified, use no storage class for scratch space",
 		"podResourceRequirements":  "ResourceRequirements describes the compute resource requirements.",
 		"featureGates":             "FeatureGates are a list of specific enabled feature gates",
-		"filesystemOverhead":       "FilesystemOverhead describes the space reserved for overhead when using Filesystem volumes. A value is between 0 and 1, if not defined it is 0.055 (5.5% overhead)",
+		"filesystemOverhead":       "FilesystemOverhead describes the space reserved for overhead when using Filesystem volumes. A value is between 0 and 1, if not defined it is 0.06 (6% overhead)",
 		"preallocation":            "Preallocation controls whether storage for DataVolumes should be allocated in advance.",
 		"insecureRegistries":       "InsecureRegistries is a list of TLS disabled registries",
 		"dataVolumeTTLSeconds":     "DataVolumeTTLSeconds is the time in seconds after DataVolume completion it can be garbage collected. Disabled by default.\nDeprecated: Removed in v1.62.\n+optional",

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -867,7 +867,7 @@ k8s.io/utils/trace
 ## explicit; go 1.23.0
 kubevirt.io/api/core
 kubevirt.io/api/core/v1
-# kubevirt.io/containerized-data-importer-api v1.63.0-alpha.0
+# kubevirt.io/containerized-data-importer-api v1.63.0
 ## explicit; go 1.23.0
 kubevirt.io/containerized-data-importer-api/pkg/apis/core
 kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1


### PR DESCRIPTION
Manual cherry-pick of: https://github.com/kubevirt/ssp-operator/pull/1486

**Release note**:
```release-note
None
```
