### PR TITLE
[release-v0.23] ci: Set kubevirt and CDI versions to specific minor versions

### DIFF
--- a/automation/common/versions.sh
+++ b/automation/common/versions.sh
@@ -54,8 +54,8 @@ function latest_version() {
     tail -n1
 }
 
-# Latest released Kubevirt version
-KUBEVIRT_VERSION=$(latest_version "kubevirt" "kubevirt")
+# Fix kubevirt version to v1.5.x
+KUBEVIRT_VERSION=$(latest_patch_version "kubevirt" "kubevirt" "v1.5")
 
-# Latest released CDI version
-CDI_VERSION=$(latest_version "kubevirt" "containerized-data-importer")
+# Fix CDI version to v.1.62.x
+CDI_VERSION=$(latest_patch_version "kubevirt" "containerized-data-importer" "v1.62")


### PR DESCRIPTION
**What this PR does / why we need it**:
Sets Kubevirt version to v1.5.x.
Sets CDI version to v1.62.x.

**Release note**:
```release-note
None
```
