### PR TITLE
Remove the "Could not set vm volumes metrics" log

### DIFF
--- a/internal/controllers/vm_controller.go
+++ b/internal/controllers/vm_controller.go
@@ -15,7 +15,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	crd_watch "kubevirt.io/ssp-operator/internal/crd-watch"
-	"kubevirt.io/ssp-operator/pkg/monitoring/metrics/ssp-operator"
+	metrics "kubevirt.io/ssp-operator/pkg/monitoring/metrics/ssp-operator"
 )
 
 // +kubebuilder:rbac:groups=kubevirt.io,resources=virtualmachines,verbs=get;list;watch
@@ -88,7 +88,6 @@ func (v *vmController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Re
 	}
 
 	if err := v.setVmVolumesMetrics(ctx, &vm); err != nil {
-		v.log.Error(err, "Could not set vm volumes metrics", "vm", req.NamespacedName)
 		return ctrl.Result{
 				Requeue:      true,
 				RequeueAfter: 5 * time.Second,


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Removed the "Could not set vm volumes metrics" log since this kind of error is already logged from
the controller-runtime.

**Which issue(s) this PR fixes**: 
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

Fixes #https://issues.redhat.com/browse/CNV-42458

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
