### PR TITLE
tests: Wrap all API update calls in Eventually()

### DIFF
--- a/tests/metrics_test.go
+++ b/tests/metrics_test.go
@@ -183,8 +183,14 @@ var _ = Describe("Metrics", func() {
 				return err
 			}, env.ShortTimeout(), time.Second).Should(Succeed())
 
-			template.Labels[common_templates.TemplateTypeLabel] = "test"
-			Expect(apiClient.Update(ctx, template)).To(Succeed())
+			Eventually(func(g Gomega) {
+				foundTemplate := &templatev1.Template{}
+				g.Expect(apiClient.Get(ctx, client.ObjectKeyFromObject(template), foundTemplate)).To(Succeed())
+
+				foundTemplate.Labels[common_templates.TemplateTypeLabel] = "test"
+
+				g.Expect(apiClient.Update(ctx, foundTemplate)).To(Succeed())
+			}, env.ShortTimeout(), time.Second).Should(Succeed())
 
 			Eventually(func() (int, error) {
 				return totalRestoredTemplatesCount()
@@ -199,9 +205,15 @@ var _ = Describe("Metrics", func() {
 				return err
 			}, env.ShortTimeout(), time.Second).Should(Succeed())
 
-			template.Labels[common_templates.TemplateTypeLabel] = "test"
-			template.Labels[common_templates.TemplateVersionLabel] = "v" + rand.String(5)
-			Expect(apiClient.Update(ctx, template)).To(Succeed())
+			Eventually(func(g Gomega) {
+				foundTemplate := &templatev1.Template{}
+				g.Expect(apiClient.Get(ctx, client.ObjectKeyFromObject(template), foundTemplate)).To(Succeed())
+
+				foundTemplate.Labels[common_templates.TemplateTypeLabel] = "test"
+				foundTemplate.Labels[common_templates.TemplateVersionLabel] = "v" + rand.String(5)
+
+				g.Expect(apiClient.Update(ctx, foundTemplate)).To(Succeed())
+			}, env.ShortTimeout(), time.Second).Should(Succeed())
 
 			// TODO: replace 'Consistently' with a direct wait for the template update
 			Consistently(func() (int, error) {

--- a/tests/monitoring_test.go
+++ b/tests/monitoring_test.go
@@ -141,11 +141,14 @@ var _ = Describe("Prometheus Alerts", func() {
 				Namespace: strategy.GetSSPDeploymentNameSpace(),
 			}
 			replicas = 0
-			deployment = &apps.Deployment{}
-			Expect(apiClient.Get(ctx, sspDeploymentKeys, deployment)).ToNot(HaveOccurred())
-			origReplicas = *deployment.Spec.Replicas
-			deployment.Spec.Replicas = &replicas
-			Expect(apiClient.Update(ctx, deployment)).ToNot(HaveOccurred())
+
+			Eventually(func(g Gomega) {
+				deployment = &apps.Deployment{}
+				g.Expect(apiClient.Get(ctx, sspDeploymentKeys, deployment)).ToNot(HaveOccurred())
+				origReplicas = *deployment.Spec.Replicas
+				deployment.Spec.Replicas = &replicas
+				g.Expect(apiClient.Update(ctx, deployment)).ToNot(HaveOccurred())
+			}, env.ShortTimeout(), time.Second).Should(Succeed())
 		})
 
 		AfterEach(func() {

--- a/tests/tests_common_test.go
+++ b/tests/tests_common_test.go
@@ -183,9 +183,12 @@ func expectRestoreAfterUpdate(res *testResource) {
 	Expect(err).ToNot(HaveOccurred())
 	defer watch.Stop()
 
-	changed := original.DeepCopyObject().(client.Object)
-	res.Update(changed)
-	Expect(apiClient.Update(ctx, changed)).ToNot(HaveOccurred())
+	Eventually(func(g Gomega) {
+		found := res.NewResource()
+		g.Expect(apiClient.Get(ctx, res.GetKey(), found)).To(Succeed())
+		res.Update(found)
+		g.Expect(apiClient.Update(ctx, found)).ToNot(HaveOccurred())
+	}, env.ShortTimeout(), time.Second).Should(Succeed())
 
 	err = WatchChangesUntil(watch, isStatusDeploying, env.ShortTimeout())
 	Expect(err).ToNot(HaveOccurred(), "SSP status should be deploying.")
@@ -210,9 +213,13 @@ func expectRestoreAfterUpdateWithPause(res *testResource) {
 
 	pauseSsp()
 
-	changed := original.DeepCopyObject().(client.Object)
-	res.Update(changed)
-	Expect(apiClient.Update(ctx, changed)).ToNot(HaveOccurred())
+	changed := res.NewResource()
+	Eventually(func(g Gomega) {
+		changed = res.NewResource()
+		g.Expect(apiClient.Get(ctx, res.GetKey(), changed)).To(Succeed())
+		res.Update(changed)
+		g.Expect(apiClient.Update(ctx, changed)).ToNot(HaveOccurred())
+	}, env.ShortTimeout(), time.Second).Should(Succeed())
 
 	Consistently(func() (client.Object, error) {
 		found := res.NewResource()


### PR DESCRIPTION
**What this PR does / why we need it**:
Sometimes the Update calls fail, because there is a concurrent update to the object. This causes the test to fail and makes the test lane flaky.

This change makes the tests more stable.

**Release note**:
```release-note
None
```
