### PR TITLE
[release-v0.21] tests: Wrap all API update calls in Eventually()

### DIFF
--- a/tests/metrics_test.go
+++ b/tests/metrics_test.go
@@ -20,6 +20,7 @@ import (
 	common_templates "kubevirt.io/ssp-operator/internal/operands/common-templates"
 	"kubevirt.io/ssp-operator/internal/operands/metrics"
 	"kubevirt.io/ssp-operator/pkg/monitoring/rules"
+	"kubevirt.io/ssp-operator/tests/env"
 )
 
 func mergeMaps(maps ...map[string]string) map[string]string {
@@ -176,8 +177,14 @@ var _ = Describe("Metrics", func() {
 
 			restoredCount := totalRestoredTemplatesCount()
 
-			template.Labels[common_templates.TemplateTypeLabel] = "test"
-			Expect(apiClient.Update(ctx, template)).To(Succeed())
+			Eventually(func(g Gomega) {
+				foundTemplate := &templatev1.Template{}
+				g.Expect(apiClient.Get(ctx, client.ObjectKeyFromObject(template), foundTemplate)).To(Succeed())
+
+				foundTemplate.Labels[common_templates.TemplateTypeLabel] = "test"
+
+				g.Expect(apiClient.Update(ctx, foundTemplate)).To(Succeed())
+			}, env.ShortTimeout(), time.Second).Should(Succeed())
 
 			Eventually(func() int {
 				return totalRestoredTemplatesCount()
@@ -187,9 +194,15 @@ var _ = Describe("Metrics", func() {
 		It("[test_id:TODO]should not increment kubevirt_ssp_common_templates_restored_total during upgrades", func() {
 			restoredCount := totalRestoredTemplatesCount()
 
-			template.Labels[common_templates.TemplateTypeLabel] = "test"
-			template.Labels[common_templates.TemplateVersionLabel] = "v" + rand.String(5)
-			Expect(apiClient.Update(ctx, template)).To(Succeed())
+			Eventually(func(g Gomega) {
+				foundTemplate := &templatev1.Template{}
+				g.Expect(apiClient.Get(ctx, client.ObjectKeyFromObject(template), foundTemplate)).To(Succeed())
+
+				foundTemplate.Labels[common_templates.TemplateTypeLabel] = "test"
+				foundTemplate.Labels[common_templates.TemplateVersionLabel] = "v" + rand.String(5)
+
+				g.Expect(apiClient.Update(ctx, foundTemplate)).To(Succeed())
+			}, env.ShortTimeout(), time.Second).Should(Succeed())
 
 			// TODO: replace 'Consistently' with a direct wait for the template update
 			Consistently(func() int {

--- a/tests/monitoring_test.go
+++ b/tests/monitoring_test.go
@@ -139,11 +139,14 @@ var _ = Describe("Prometheus Alerts", func() {
 				Namespace: strategy.GetSSPDeploymentNameSpace(),
 			}
 			replicas = 0
-			deployment = &apps.Deployment{}
-			Expect(apiClient.Get(ctx, sspDeploymentKeys, deployment)).ToNot(HaveOccurred())
-			origReplicas = *deployment.Spec.Replicas
-			deployment.Spec.Replicas = &replicas
-			Expect(apiClient.Update(ctx, deployment)).ToNot(HaveOccurred())
+
+			Eventually(func(g Gomega) {
+				deployment = &apps.Deployment{}
+				g.Expect(apiClient.Get(ctx, sspDeploymentKeys, deployment)).ToNot(HaveOccurred())
+				origReplicas = *deployment.Spec.Replicas
+				deployment.Spec.Replicas = &replicas
+				g.Expect(apiClient.Update(ctx, deployment)).ToNot(HaveOccurred())
+			}, env.ShortTimeout(), time.Second).Should(Succeed())
 		})
 
 		AfterEach(func() {


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/kubevirt/ssp-operator/pull/1503 .
The import line was missing in the automatic cherry-pick.

**What this PR does / why we need it**:
Sometimes the Update calls fail, because there is a concurrent update to the object. This causes the test to fail and makes the test lane flaky.

This change makes the tests more stable.

**Release note**:
```release-note
None
```
