### PR TITLE
feat: Create PodDisruptionBudget for template validator

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -168,6 +168,17 @@ rules:
   - update
   - watch
 - apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - clusterrolebindings

--- a/data/olm-catalog/ssp-operator.clusterserviceversion.yaml
+++ b/data/olm-catalog/ssp-operator.clusterserviceversion.yaml
@@ -236,6 +236,17 @@ spec:
           - update
           - watch
         - apiGroups:
+          - policy
+          resources:
+          - poddisruptionbudgets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
           - rbac.authorization.k8s.io
           resources:
           - clusterrolebindings

--- a/internal/operands/template-validator/reconcile_test.go
+++ b/internal/operands/template-validator/reconcile_test.go
@@ -89,6 +89,7 @@ var _ = Describe("Template validator operand", func() {
 		ExpectResourceExists(newDeployment(namespace, replicas, "test-img"), request)
 		ExpectResourceExists(newValidatingWebhook(namespace), request)
 		ExpectResourceExists(newPrometheusService(namespace), request)
+		ExpectResourceExists(newPodDisruptionBudget(namespace), request)
 		for _, policy := range newNetworkPolicies(namespace) {
 			ExpectResourceExists(policy, request)
 		}

--- a/internal/operands/template-validator/resources.go
+++ b/internal/operands/template-validator/resources.go
@@ -9,6 +9,7 @@ import (
 	apps "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
 	networkv1 "k8s.io/api/networking/v1"
+	policy "k8s.io/api/policy/v1"
 	rbac "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -387,5 +388,20 @@ func newNetworkPolicies(namespace string) []*networkv1.NetworkPolicy {
 	return []*networkv1.NetworkPolicy{
 		g.NewEgressToKubeAPIAndDNS(namespace, KubevirtIo, VirtTemplateValidator),
 		networkpolicies.NewIngressToVirtTemplateValidatorWebhookAndMetrics(namespace),
+	}
+}
+
+func newPodDisruptionBudget(namespace string) *policy.PodDisruptionBudget {
+	return &policy.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      DeploymentName,
+			Namespace: namespace,
+		},
+		Spec: policy.PodDisruptionBudgetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: CommonLabels(),
+			},
+			MinAvailable: ptr.To(intstr.FromInt32(1)),
+		},
 	}
 }

--- a/tests/validator_test.go
+++ b/tests/validator_test.go
@@ -17,6 +17,7 @@ import (
 	apps "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
 	networkv1 "k8s.io/api/networking/v1"
+	policy "k8s.io/api/policy/v1"
 	rbac "k8s.io/api/rbac/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -79,6 +80,7 @@ var _ = Describe("Template validator operand", func() {
 		deploymentRes                     testResource
 		networkPolicyKubeAPIAndDNSRes     testResource
 		networkPolicyWebhookAndMetricsRes testResource
+		podDisruptionBudgetRes            testResource
 
 		replicas int32 = 2
 	)
@@ -174,6 +176,18 @@ var _ = Describe("Template validator operand", func() {
 			"ssp-operator-allow-ingress-to-virt-template-validator-webhook-and-metrics",
 			strategy.GetNamespace(), expectedLabels,
 		)
+		podDisruptionBudgetRes = testResource{
+			Name:           validator.DeploymentName,
+			Namespace:      strategy.GetNamespace(),
+			Resource:       &policy.PodDisruptionBudget{},
+			ExpectedLabels: expectedLabels,
+			UpdateFunc: func(pdb *policy.PodDisruptionBudget) {
+				pdb.Spec.MinAvailable = ptr.To(intstr.FromInt32(0))
+			},
+			EqualsFunc: func(old *policy.PodDisruptionBudget, new *policy.PodDisruptionBudget) bool {
+				return reflect.DeepEqual(old.Spec, new.Spec)
+			},
+		}
 
 		waitUntilDeployed()
 	})
@@ -201,6 +215,7 @@ var _ = Describe("Template validator operand", func() {
 			Entry("[test_id:4912] deployment", &deploymentRes),
 			Entry("[test_id:TODO] network policy kube api and dns", &networkPolicyKubeAPIAndDNSRes),
 			Entry("[test_id:TODO] network policy webhook and metrics", &networkPolicyWebhookAndMetricsRes),
+			Entry("[test_id:TODO] PodDisruptionBudget", &podDisruptionBudgetRes),
 		)
 
 		DescribeTable("should set app labels", expectAppLabels,
@@ -214,6 +229,7 @@ var _ = Describe("Template validator operand", func() {
 			Entry("[test_id:5828]deployment", &deploymentRes),
 			Entry("[test_id:TODO]network policy kube api and dns", &networkPolicyKubeAPIAndDNSRes),
 			Entry("[test_id:TODO]network policy webhook and metrics", &networkPolicyWebhookAndMetricsRes),
+			Entry("[test_id:TODO] PodDisruptionBudget", &podDisruptionBudgetRes),
 		)
 	})
 
@@ -229,6 +245,7 @@ var _ = Describe("Template validator operand", func() {
 			Entry("[test_id:4924] deployment", &deploymentRes),
 			Entry("[test_id:TODO] network policy kube api and dns", &networkPolicyKubeAPIAndDNSRes),
 			Entry("[test_id:TODO] network policy webhook and metrics", &networkPolicyWebhookAndMetricsRes),
+			Entry("[test_id:TODO] PodDisruptionBudget", &podDisruptionBudgetRes),
 		)
 	})
 
@@ -243,6 +260,7 @@ var _ = Describe("Template validator operand", func() {
 			Entry("[test_id:4925] deployment", &deploymentRes),
 			Entry("[test_id:TODO] network policy kube api and dns", &networkPolicyKubeAPIAndDNSRes),
 			Entry("[test_id:TODO] network policy webhook and metrics", &networkPolicyWebhookAndMetricsRes),
+			Entry("[test_id:TODO] PodDisruptionBudget", &podDisruptionBudgetRes),
 		)
 
 		Context("with pause", func() {
@@ -264,6 +282,7 @@ var _ = Describe("Template validator operand", func() {
 				Entry("[test_id:5539] deployment", &deploymentRes),
 				Entry("[test_id:TODO] network policy kube api and dns", &networkPolicyKubeAPIAndDNSRes),
 				Entry("[test_id:TODO] network policy webhook and metrics", &networkPolicyWebhookAndMetricsRes),
+				Entry("[test_id:TODO] PodDisruptionBudget", &podDisruptionBudgetRes),
 			)
 		})
 
@@ -277,6 +296,7 @@ var _ = Describe("Template validator operand", func() {
 			Entry("[test_id:6209] deployment", &deploymentRes),
 			Entry("[test_id:TODO] network policy kube api and dns", &networkPolicyKubeAPIAndDNSRes),
 			Entry("[test_id:TODO] network policy webhook and metrics", &networkPolicyWebhookAndMetricsRes),
+			Entry("[test_id:TODO] PodDisruptionBudget", &podDisruptionBudgetRes),
 		)
 	})
 


### PR DESCRIPTION
**What this PR does / why we need it**:
At least one template validator pod should be available. 
This PR adds PodDisruptionBudget object that specifies this.

**Which issue(s) this PR fixes**: 
Fixes: https://issues.redhat.com/browse/CNV-67393

**Release note**:
```release-note
Create PodDisruptionBudget for template validator.
```
