### PR TITLE
feat: Add probes to operator and template validator

### DIFF
--- a/config/manager/manager.template.yaml
+++ b/config/manager/manager.template.yaml
@@ -58,10 +58,11 @@ spec:
             - "ALL"
         livenessProbe:
           httpGet:
-            path: /healthz
+            path: /readyz
             port: 8081
           initialDelaySeconds: 15
-          periodSeconds: 20
+          periodSeconds: 10
+          failureThreshold: 5
         ports:
           - name: http-metrics
             protocol: TCP
@@ -72,4 +73,5 @@ spec:
             port: 8081
           initialDelaySeconds: 5
           periodSeconds: 10
+          failureThreshold: 2
       terminationGracePeriodSeconds: 10

--- a/internal/operands/template-validator/resources.go
+++ b/internal/operands/template-validator/resources.go
@@ -236,6 +236,18 @@ func newDeployment(namespace string, replicas int32, image string) *apps.Deploym
 							ContainerPort: MetricsPort,
 							Protocol:      core.ProtocolTCP,
 						}},
+						LivenessProbe: &core.Probe{
+							ProbeHandler: core.ProbeHandler{
+								HTTPGet: &core.HTTPGetAction{
+									Path:   "/readyz",
+									Port:   intstr.FromInt32(WebhookPort),
+									Scheme: core.URISchemeHTTPS,
+								},
+							},
+							InitialDelaySeconds: 10,
+							PeriodSeconds:       10,
+							FailureThreshold:    5,
+						},
 						ReadinessProbe: &core.Probe{
 							ProbeHandler: core.ProbeHandler{
 								HTTPGet: &core.HTTPGetAction{
@@ -246,6 +258,7 @@ func newDeployment(namespace string, replicas int32, image string) *apps.Deploym
 							},
 							InitialDelaySeconds: 5,
 							PeriodSeconds:       10,
+							FailureThreshold:    2,
 						},
 					}},
 					Volumes: []core.Volume{{

--- a/main.go
+++ b/main.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"golang.org/x/sync/errgroup"
 	"net/http"
 	"os"
 	"path"
@@ -35,6 +34,7 @@ import (
 	ocpconfigv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/library-go/pkg/crypto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"golang.org/x/sync/errgroup"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
@@ -301,11 +301,6 @@ func main() {
 
 	if err := mgr.AddReadyzCheck("check", healthz.Ping); err != nil {
 		setupLog.Error(err, "unable to set up ready check")
-		os.Exit(1)
-	}
-
-	if err := mgr.AddHealthzCheck("health", healthz.Ping); err != nil {
-		setupLog.Error(err, "unable to set up health check")
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Added:
- liveliness probe to template validator
- startup probe to ssp operator and template validator

The startup probes are the same as liveliness probes. We don't have specific logic for them.

**Which issue(s) this PR fixes**: 
Jira: https://issues.redhat.com/browse/CNV-67398

**Release note**:
```release-note
None
```
