### PR TITLE
[release-v0.24] chore: Set port names according to convention

### DIFF
--- a/config/default/manager_webhook_patch.yaml
+++ b/config/default/manager_webhook_patch.yaml
@@ -10,7 +10,7 @@ spec:
       - name: manager
         ports:
         - containerPort: 9443
-          name: webhook-server
+          name: http-webhook
           protocol: TCP
         volumeMounts:
         - mountPath: /tmp/k8s-webhook-server/serving-certs

--- a/config/manager/manager.template.yaml
+++ b/config/manager/manager.template.yaml
@@ -62,7 +62,7 @@ spec:
           initialDelaySeconds: 15
           periodSeconds: 20
         ports:
-          - name: metrics
+          - name: http-metrics
             protocol: TCP
             containerPort: 8443
         readinessProbe:

--- a/data/olm-catalog/ssp-operator.clusterserviceversion.yaml
+++ b/data/olm-catalog/ssp-operator.clusterserviceversion.yaml
@@ -365,10 +365,10 @@ spec:
                 name: manager
                 ports:
                 - containerPort: 9443
-                  name: webhook-server
+                  name: http-webhook
                   protocol: TCP
                 - containerPort: 8443
-                  name: metrics
+                  name: http-metrics
                   protocol: TCP
                 readinessProbe:
                   httpGet:

--- a/internal/operands/metrics/resources.go
+++ b/internal/operands/metrics/resources.go
@@ -17,7 +17,7 @@ const (
 	PrometheusLabelValue         = "true"
 	PrometheusClusterRoleName    = "prometheus-k8s-ssp"
 	PrometheusServiceAccountName = "prometheus-k8s"
-	MetricsPortName              = "metrics"
+	MetricsPortName              = "http-metrics"
 )
 
 func newMonitoringClusterRole() *rbac.ClusterRole {

--- a/internal/operands/template-validator/resources.go
+++ b/internal/operands/template-validator/resources.go
@@ -43,6 +43,7 @@ const (
 	ConfigMapName                 = VirtTemplateValidator
 	PrometheusLabel               = "prometheus.ssp.kubevirt.io"
 	kubernetesHostnameTopologyKey = "kubernetes.io/hostname"
+	webhookPortName               = "http-webhook"
 )
 
 func CommonLabels() map[string]string {
@@ -118,7 +119,7 @@ func newService(namespace string) *core.Service {
 		},
 		Spec: core.ServiceSpec{
 			Ports: []core.ServicePort{{
-				Name:       "webhook",
+				Name:       webhookPortName,
 				Port:       443,
 				TargetPort: intstr.FromInt32(ContainerPort),
 			}},
@@ -226,7 +227,7 @@ func newDeployment(namespace string, replicas int32, image string) *apps.Deploym
 							},
 						},
 						Ports: []core.ContainerPort{{
-							Name:          "webhook",
+							Name:          webhookPortName,
 							ContainerPort: ContainerPort,
 							Protocol:      core.ProtocolTCP,
 						}, {


### PR DESCRIPTION
Manual cherry-pick of: https://github.com/kubevirt/ssp-operator/pull/1514

**What this PR does / why we need it**:
The convention is, that port name should be prefixed with protocol.

https://redhat-best-practices-for-k8s.github.io/guide/#k8s-best-practices-requirements-cnf-reqs

The new names are different, because the maximum port name length is 15 characters.

**Which issue(s) this PR fixes**: 
Jira: https://issues.redhat.com/browse/CNV-67392

**Release note**:
```release-note
None
```