### PR TITLE
chore: Increase linter timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -340,7 +340,7 @@ GOLANGCI_LINT_VERSION ?= v2.3.1
 .PHONY: lint
 lint:
 	test -s $(GOLANGCI_LINT) || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(LOCALBIN) $(GOLANGCI_LINT_VERSION)
-	$(GOLANGCI_LINT) run --timeout 5m
+	$(GOLANGCI_LINT) run --timeout 10m
 
 .PHONY: lint-metrics
 lint-metrics:


### PR DESCRIPTION
**What this PR does / why we need it**:
Sometimes the CI is flaky, because 5 minutes was not enough. Restarting the test helps, so it probably depends on the CI worker load.

**Release note**:
```release-note
None
```
