### PR TITLE
Trigger reconciliation at Deletiontimestamp change

### DIFF
--- a/internal/controller/predicates/predicates.go
+++ b/internal/controller/predicates/predicates.go
@@ -34,3 +34,19 @@ func getSpec(obj client.Object) (interface{}, bool) {
 	}
 	return specVal.Interface(), true
 }
+
+type DeletionTimestampChangedPredicate struct {
+	predicate.Funcs
+}
+
+func (p DeletionTimestampChangedPredicate) Update(e event.UpdateEvent) bool {
+	return !e.ObjectNew.GetDeletionTimestamp().Equal(e.ObjectOld.GetDeletionTimestamp())
+}
+
+type FinalizerChangedPredicate struct {
+	predicate.Funcs
+}
+
+func (p FinalizerChangedPredicate) Update(e event.UpdateEvent) bool {
+	return !reflect.DeepEqual(e.ObjectNew.GetFinalizers(), e.ObjectOld.GetFinalizers())
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
This PR makes sure that the ssp CR state is set to Deploying while deleting an owned resource.
For example, deleting the kubevirt-os-images namespace would not cause the change of state, because deleting this namespace required deleting many other resources, which took a lot of time.
I also extracted the Finalizer Changed Predicate.
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**: 
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

Fixes # https://issues.redhat.com/browse/CNV-68906

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
