### PR TITLE
fix(instancetypes): Protect instancetype/preference `controllerRevision` objects

### DIFF
--- a/internal/operands/vm-delete-protection/resources.go
+++ b/internal/operands/vm-delete-protection/resources.go
@@ -1,6 +1,8 @@
 package vm_delete_protection
 
 import (
+	"fmt"
+
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
@@ -9,6 +11,7 @@ import (
 )
 
 const vmDeleteProtectionCELExpression = `(!has(oldObject.metadata.labels) || !(variables.label in oldObject.metadata.labels) || !oldObject.metadata.labels[variables.label].matches('^(true|True)$'))`
+const instancetypeControllerRevisionsCELExpressionTemplate = `request.userInfo.username == 'system:serviceaccount:kube-system:generic-garbage-collector' || request.userInfo.username == 'system:serviceaccount:%s:kubevirt-controller'`
 
 func newVMDeletionProtectionValidatingAdmissionPolicy() *admissionregistrationv1.ValidatingAdmissionPolicy {
 	var apiVersions []string
@@ -63,6 +66,69 @@ func newVMDeletionProtectionValidatingAdmissionPolicyBinding() *admissionregistr
 			PolicyName: virtualMachineDeleteProtectionPolicyName,
 			ValidationActions: []admissionregistrationv1.ValidationAction{
 				admissionregistrationv1.Deny,
+			},
+		},
+	}
+}
+
+func newInstancetypeControllerRevisionsValidatingAdmissionPolicy(namespace string) *admissionregistrationv1.ValidatingAdmissionPolicy {
+	return &admissionregistrationv1.ValidatingAdmissionPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: instancetypeControllerRevisionsPolicyName,
+		},
+		Spec: admissionregistrationv1.ValidatingAdmissionPolicySpec{
+			FailurePolicy: ptr.To(admissionregistrationv1.Fail),
+			MatchConstraints: &admissionregistrationv1.MatchResources{
+				ResourceRules: []admissionregistrationv1.NamedRuleWithOperations{
+					{
+						RuleWithOperations: admissionregistrationv1.RuleWithOperations{
+							Operations: []admissionregistrationv1.OperationType{
+								admissionregistrationv1.Delete,
+							},
+							Rule: admissionregistrationv1.Rule{
+								APIGroups:   []string{"apps"},
+								APIVersions: []string{"v1"},
+								Resources:   []string{"controllerrevisions"},
+							},
+						},
+					},
+				},
+			},
+			Validations: []admissionregistrationv1.Validation{
+				{
+					Expression:        fmt.Sprintf(instancetypeControllerRevisionsCELExpressionTemplate, namespace),
+					MessageExpression: "'Instancetype controller revision deletion is blocked only GC/kubevirt-controller: ' + string(request.userInfo.username)",
+				},
+			},
+		},
+	}
+}
+
+func newInstancetypeControllerRevisionsValidatingAdmissionPolicyBinding() *admissionregistrationv1.ValidatingAdmissionPolicyBinding {
+	return &admissionregistrationv1.ValidatingAdmissionPolicyBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: instancetypeControllerRevisionsPolicyName + "-binding",
+		},
+		Spec: admissionregistrationv1.ValidatingAdmissionPolicyBindingSpec{
+			PolicyName: instancetypeControllerRevisionsPolicyName,
+			ValidationActions: []admissionregistrationv1.ValidationAction{
+				admissionregistrationv1.Deny,
+			},
+			MatchResources: &admissionregistrationv1.MatchResources{
+				ObjectSelector: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      "instancetype.kubevirt.io/object-kind",
+							Operator: metav1.LabelSelectorOpIn,
+							Values: []string{
+								"VirtualMachineClusterInstancetype",
+								"VirtualMachineClusterPreference",
+								"VirtualMachineInstancetype",
+								"VirtualMachinePreference",
+							},
+						},
+					},
+				},
 			},
 		},
 	}

--- a/tests/vm_delete_protection_test.go
+++ b/tests/vm_delete_protection_test.go
@@ -7,8 +7,12 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/utils/ptr"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -16,7 +20,10 @@ import (
 	"kubevirt.io/ssp-operator/tests/env"
 )
 
-const deleteProtectionLabel = "kubevirt.io/vm-delete-protection"
+const (
+	deleteProtectionLabel = "kubevirt.io/vm-delete-protection"
+	vmReadyTimeout        = 5 * time.Minute
+)
 
 var _ = Describe("VM delete protection", func() {
 
@@ -49,7 +56,7 @@ var _ = Describe("VM delete protection", func() {
 	})
 
 	DescribeTable("should not allow to delete a VM if the protection is enabled", decorators.Conformance, func(labelValue string) {
-		vm = createVMWithDeleteProtection(labelValue)
+		vm = createVMWithDeleteProtection(labelValue, strategy.GetNamespace())
 
 		Expect(apiClient.Delete(ctx, vm)).To(MatchError(ContainSubstring("VirtualMachine %v cannot be deleted, disable/remove label "+
 			"'kubevirt.io/vm-delete-protection' from VirtualMachine before deleting it", vm.Name)))
@@ -59,7 +66,7 @@ var _ = Describe("VM delete protection", func() {
 	)
 
 	DescribeTable("should be able to delete a VM if the protection is disabled", decorators.Conformance, func(labelValue string) {
-		vm = createVMWithDeleteProtection(labelValue)
+		vm = createVMWithDeleteProtection(labelValue, strategy.GetNamespace())
 
 		Expect(apiClient.Delete(ctx, vm)).To(Succeed())
 		waitForDeletion(client.ObjectKeyFromObject(vm), &kubevirtv1.VirtualMachine{})
@@ -72,24 +79,192 @@ var _ = Describe("VM delete protection", func() {
 	)
 
 	It("[test_id:11934] should be able to delete a VM if the VM does not have any label", decorators.Conformance, func() {
-		vm = createVMWithLabels(nil)
+		vm = createVMWithLabels(nil, strategy.GetNamespace())
 
 		Expect(apiClient.Delete(ctx, vm)).To(Succeed())
 		waitForDeletion(client.ObjectKeyFromObject(vm), &kubevirtv1.VirtualMachine{})
 	})
+
+	It("should not be able to delete the controller revision directly", func() {
+		vm = createVMWithDeleteProtection("false", strategy.GetNamespace())
+
+		startVM(vm.Name, vm.Namespace, vmReadyTimeout)
+
+		Expect(apiClient.Get(ctx, client.ObjectKey{Name: vm.Name, Namespace: vm.Namespace}, vm)).ToNot(HaveOccurred())
+
+		controllerRevision := &appsv1.ControllerRevision{}
+		Expect(apiClient.Get(ctx, client.ObjectKey{Name: vm.Status.InstancetypeRef.ControllerRevisionRef.Name, Namespace: vm.Namespace}, controllerRevision)).ToNot(HaveOccurred())
+
+		Expect(apiClient.Delete(ctx, controllerRevision)).To(MatchError(ContainSubstring("Instancetype controller revision deletion is blocked only GC/kubevirt-controller")))
+	})
+
+	It("should be able to clean up the controller revision when the VM is deleted", func() {
+		vm = createVMWithDeleteProtection("false", strategy.GetNamespace())
+
+		startVM(vm.Name, vm.Namespace, vmReadyTimeout)
+
+		Expect(apiClient.Get(ctx, client.ObjectKey{Name: vm.Name, Namespace: vm.Namespace}, vm)).ToNot(HaveOccurred())
+
+		controllerRevisionName := vm.Status.InstancetypeRef.ControllerRevisionRef.Name
+
+		Expect(apiClient.Delete(ctx, vm)).To(Succeed())
+		waitForDeletion(client.ObjectKeyFromObject(vm), &kubevirtv1.VirtualMachine{})
+
+		Eventually(func() error {
+			controllerRevision := &appsv1.ControllerRevision{}
+			return apiClient.Get(ctx, client.ObjectKey{Name: controllerRevisionName, Namespace: vm.Namespace}, controllerRevision)
+		}, env.ShortTimeout(), time.Second).Should(MatchError(errors.IsNotFound, "errors.IsNotFound"))
+	})
+
+	It("should not able to delete the controller revisions if the VM is protected", func() {
+		vm = createVMWithDeleteProtection("true", strategy.GetNamespace())
+
+		startVM(vm.Name, vm.Namespace, vmReadyTimeout)
+
+		Expect(apiClient.Get(ctx, client.ObjectKey{Name: vm.Name, Namespace: vm.Namespace}, vm)).ToNot(HaveOccurred())
+
+		controllerRevisionName := vm.Status.InstancetypeRef.ControllerRevisionRef.Name
+
+		Expect(apiClient.Delete(ctx, vm)).To(MatchError(ContainSubstring("VirtualMachine %v cannot be deleted, disable/remove label "+
+			"'kubevirt.io/vm-delete-protection' from VirtualMachine before deleting it", vm.Name)))
+
+		Consistently(func() error {
+			controllerRevision := &appsv1.ControllerRevision{}
+			return apiClient.Get(ctx, client.ObjectKey{Name: controllerRevisionName, Namespace: vm.Namespace}, controllerRevision)
+		}, 30*time.Second, time.Second).Should(Succeed(), "controllerRevision should not be deleted")
+	})
+
+	It("should not be able to delete the controller revisions if the VM is protected when the namespace is deleted", func() {
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: fmt.Sprintf("test-ns-%v", rand.String(5)),
+			},
+		}
+		Expect(apiClient.Create(ctx, ns)).To(Succeed())
+		DeferCleanup(func() {
+			_ = apiClient.Delete(ctx, ns)
+		})
+
+		vm = createVMWithDeleteProtection("true", ns.Name)
+
+		startVM(vm.Name, vm.Namespace, vmReadyTimeout)
+
+		Expect(apiClient.Get(ctx, client.ObjectKey{Name: vm.Name, Namespace: vm.Namespace}, vm)).ToNot(HaveOccurred())
+		controllerRevisionName := vm.Status.InstancetypeRef.ControllerRevisionRef.Name
+
+		_ = apiClient.Delete(ctx, ns)
+
+		// Just check the namespace is in Terminating state (has DeletionTimestamp)
+		Eventually(func(g Gomega) {
+			updatedNs := &corev1.Namespace{}
+			err := apiClient.Get(ctx, client.ObjectKey{Name: ns.Name}, updatedNs)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(updatedNs.DeletionTimestamp).ToNot(BeNil())
+		}, env.ShortTimeout(), time.Second).Should(Succeed())
+
+		Expect(apiClient.Get(ctx, client.ObjectKey{Name: vm.Name, Namespace: vm.Namespace}, vm)).ToNot(HaveOccurred())
+
+		Consistently(func() error {
+			controllerRevision := &appsv1.ControllerRevision{}
+			return apiClient.Get(ctx, client.ObjectKey{Name: controllerRevisionName, Namespace: vm.Namespace}, controllerRevision)
+		}, 30*time.Second, time.Second).Should(Succeed(), "controllerRevision should not be deleted")
+	})
+
+	It("should be able to delete the namespace if the VM delete protection is disabled", func() {
+		namespaceName := fmt.Sprintf("test-ns-%v", rand.String(5))
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: namespaceName,
+			},
+		}
+		Expect(apiClient.Create(ctx, ns)).To(Succeed())
+		DeferCleanup(func() {
+			_ = apiClient.Delete(ctx, ns)
+		})
+
+		vm = createVMWithDeleteProtection("true", ns.Name)
+
+		startVM(vm.Name, vm.Namespace, vmReadyTimeout)
+
+		_ = apiClient.Delete(ctx, ns)
+
+		// Just check the namespace is in Terminating state (has DeletionTimestamp)
+		Eventually(func(g Gomega) {
+			updatedNs := &corev1.Namespace{}
+			err := apiClient.Get(ctx, client.ObjectKey{Name: namespaceName}, updatedNs)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(updatedNs.DeletionTimestamp).ToNot(BeNil())
+		}, env.ShortTimeout(), time.Second).Should(Succeed())
+
+		// Disable the delete protection
+		Eventually(func() error {
+			Expect(apiClient.Get(ctx, client.ObjectKey{Name: vm.Name, Namespace: vm.Namespace}, vm)).ToNot(HaveOccurred())
+			vm.Labels[deleteProtectionLabel] = "False"
+			return apiClient.Update(ctx, vm)
+		}, env.ShortTimeout(), time.Second).ToNot(HaveOccurred())
+
+		// Check the namespace is deleted
+		Eventually(func() error {
+			updatedNs := &corev1.Namespace{}
+			return apiClient.Get(ctx, client.ObjectKey{Name: namespaceName}, updatedNs)
+		}, env.ShortTimeout(), time.Second).Should(MatchError(errors.IsNotFound, "errors.IsNotFound"))
+	})
 })
 
-func createVMWithDeleteProtection(protected string) *kubevirtv1.VirtualMachine {
-	return createVMWithLabels(map[string]string{deleteProtectionLabel: protected})
+func createVMWithDeleteProtection(protected string, namespace string) *kubevirtv1.VirtualMachine {
+	return createVMWithLabels(map[string]string{deleteProtectionLabel: protected}, namespace)
 }
 
-func createVMWithLabels(labels map[string]string) *kubevirtv1.VirtualMachine {
+func createVMWithLabels(labels map[string]string, namespace string) *kubevirtv1.VirtualMachine {
 	vmName := fmt.Sprintf("testvmi-%v", rand.String(10))
-	vmi := NewMinimalVMIWithNS(strategy.GetNamespace(), vmName)
+	vmi := NewMinimalVMIWithNS(namespace, vmName)
+	vmi.Spec.Volumes = []kubevirtv1.Volume{
+		{
+			Name: "containerdisk",
+			VolumeSource: kubevirtv1.VolumeSource{
+				ContainerDisk: &kubevirtv1.ContainerDiskSource{
+					Image: "quay.io/containerdisks/debian:latest",
+				},
+			},
+		},
+	}
+
+	//Get rid of the resources requirements, we want to use preferences and instancetypes
+	vmi.Spec.Domain.Resources = kubevirtv1.ResourceRequirements{}
+
 	vm := NewVirtualMachine(vmi)
+
+	vm.Spec.Instancetype = &kubevirtv1.InstancetypeMatcher{
+		Name: "u1.small",
+	}
+
+	vm.Spec.Preference = &kubevirtv1.PreferenceMatcher{
+		Name: "debian",
+	}
 
 	vm.Labels = labels
 	eventuallyCreateVm(vm)
 
 	return vm
+}
+
+func startVM(vmName string, namespace string, vmReadyTimeout time.Duration) {
+	vm := &kubevirtv1.VirtualMachine{}
+	err := apiClient.Get(ctx, client.ObjectKey{Name: vmName, Namespace: namespace}, vm)
+	Expect(err).ToNot(HaveOccurred())
+
+	Eventually(func(g Gomega) {
+		vm := &kubevirtv1.VirtualMachine{}
+		g.Expect(apiClient.Get(ctx, client.ObjectKey{Name: vmName, Namespace: namespace}, vm)).ToNot(HaveOccurred())
+
+		vm.Spec.RunStrategy = ptr.To(kubevirtv1.RunStrategyAlways)
+		g.Expect(apiClient.Update(ctx, vm)).To(Succeed())
+	}, env.ShortTimeout(), time.Second).Should(Succeed())
+
+	Eventually(func(g Gomega) {
+		vm := &kubevirtv1.VirtualMachine{}
+		err := apiClient.Get(ctx, client.ObjectKey{Name: vmName, Namespace: namespace}, vm)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(vm.Status.Ready).To(BeTrue())
+	}, vmReadyTimeout, time.Second).Should(Succeed())
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

It refactors the VAP and VAPB VM delete protection function names to be more descriptive.

Moreover, it enables a protection for instancetype and preference `controllerRevision` objects, which ensures that they are not deleted before `VirtualMachine` objects. This is due to the fact that in some scenarios, such as when a VM is deleted protected, if the `controllerRevision` is deleted, but the VM object is still alive, users will not be able to patch or update the VM object. This leads to virtually deadlocking the VM object.

The VAP ensures that only the Kubernetes garbage collector and kubevirt-controller are able to delete these objects:

* Garbage-collector: It deletes objects when the `ownerReference`'d object is removed, e.g., the instancetype "test-it" with
  `ownerReference: test-vm` is removed when the VM test-vm is removed. Therefore, by only allowing it to drop these objects, we ensure the deletion order.
* Kubevirt-controller: It is required to no block this SA because it is the main owner of these `controllerRevision`, it needs to delete them in upgrade scenarios, live migration, etc.

**Which issue(s) this PR fixes**: 
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

Fixes # [CNV-69511](https://issues.redhat.com/browse/CNV-69511)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add protection to preference and instancetype `controllerRevision` objects.
```
