### PR TITLE
use tls for prometheus metrics in ssp operator and template validator

### DIFF
--- a/data/olm-catalog/ssp-operator.clusterserviceversion.yaml
+++ b/data/olm-catalog/ssp-operator.clusterserviceversion.yaml
@@ -343,6 +343,7 @@ spec:
               containers:
               - args:
                 - --leader-elect
+                - --olm-deployment
                 command:
                 - /manager
                 env:

--- a/internal/common/constants.go
+++ b/internal/common/constants.go
@@ -1,0 +1,7 @@
+package common
+
+const (
+	SspOperatorMetricsServiceName       = "ssp-operator-metrics"
+	TemplateValidatorMetricsServiceName = "template-validator-metrics"
+	VirtTemplateValidator               = "virt-template-validator"
+)

--- a/internal/common/request.go
+++ b/internal/common/request.go
@@ -23,7 +23,9 @@ type Request struct {
 	VersionCache    VersionCache
 	TopologyMode    osconfv1.TopologyMode
 
-	CrdList crd_watch.CrdList
+	CrdList            crd_watch.CrdList
+	OLMDeployment      bool
+	SSPServiceHostname string
 }
 
 func (r *Request) IsSingleReplicaTopologyMode() bool {

--- a/internal/controllers/services_controller.go
+++ b/internal/controllers/services_controller.go
@@ -26,7 +26,6 @@ import (
 
 const (
 	ServiceManagedByLabelValue = "ssp-operator-services"
-	MetricsServiceName         = "ssp-operator-metrics"
 	OperatorName               = "ssp-operator"
 	ServiceControllerName      = "service-controller"
 )
@@ -38,13 +37,14 @@ func ServiceObject(namespace string, appKubernetesPartOfValue string) *v1.Servic
 		common.AppKubernetesVersionLabel:   env.GetOperatorVersion(),
 		common.AppKubernetesComponentLabel: ServiceControllerName,
 		metrics.PrometheusLabelKey:         metrics.PrometheusLabelValue,
+		metrics.MetricsServiceKey:          common.SspOperatorMetricsServiceName,
 	}
 	if appKubernetesPartOfValue != "" {
 		labels[common.AppKubernetesPartOfLabel] = appKubernetesPartOfValue
 	}
 	return &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      MetricsServiceName,
+			Name:      common.SspOperatorMetricsServiceName,
 			Namespace: namespace,
 			Labels:    labels,
 		},
@@ -136,7 +136,7 @@ func (s *serviceReconciler) setupController(mgr ctrl.Manager) error {
 		Named("service-controller").
 		For(&v1.Service{}, builder.WithPredicates(predicate.NewPredicateFuncs(
 			func(object client.Object) bool {
-				return object.GetName() == MetricsServiceName && object.GetNamespace() == s.operatorNamespace
+				return object.GetName() == common.SspOperatorMetricsServiceName && object.GetNamespace() == s.operatorNamespace
 			}))).
 		Complete(s)
 }

--- a/internal/controllers/setup.go
+++ b/internal/controllers/setup.go
@@ -43,7 +43,7 @@ func StartControllers(ctx context.Context, mgr controllerruntime.Manager, contro
 	return nil
 }
 
-func CreateControllers(ctx context.Context, apiReader client.Reader) ([]Controller, error) {
+func CreateControllers(ctx context.Context, apiReader client.Reader, olmDeployment bool, sspServiceHostname string) ([]Controller, error) {
 	runningOnOpenShift, err := env.RunningOnOpenshift(ctx, apiReader)
 	if err != nil {
 		return nil, fmt.Errorf("failed to check if running on openshift: %w", err)
@@ -102,7 +102,7 @@ func CreateControllers(ctx context.Context, apiReader client.Reader) ([]Controll
 		serviceController,
 		NewWebhookConfigurationController(),
 		NewVmController(),
-		NewSspController(infrastructureTopology, sspOperands),
+		NewSspController(infrastructureTopology, sspOperands, olmDeployment, sspServiceHostname),
 	}, nil
 }
 

--- a/internal/operands/metrics/reconcile.go
+++ b/internal/operands/metrics/reconcile.go
@@ -50,7 +50,8 @@ func (m *metrics) WatchClusterTypes() []operands.WatchType {
 
 func (m *metrics) Reconcile(request *common.Request) ([]common.ReconcileResult, error) {
 	return common.CollectResourceStatus(request,
-		reconcilePrometheusMonitor,
+		reconcileValidatorMetricsMonitor,
+		reconcileSspMetricsMonitor,
 		reconcilePrometheusRule,
 		reconcileMonitoringRbacRole,
 		reconcileMonitoringRbacRoleBinding,
@@ -75,9 +76,16 @@ const (
 	operandComponent = common.AppComponentMonitoring
 )
 
-func reconcilePrometheusMonitor(request *common.Request) (common.ReconcileResult, error) {
+func reconcileSspMetricsMonitor(request *common.Request) (common.ReconcileResult, error) {
 	return common.CreateOrUpdate(request).
-		NamespacedResource(newServiceMonitorCR(request.Namespace)).
+		NamespacedResource(newSspServiceMonitor(request)).
+		WithAppLabels(operandName, operandComponent).
+		Reconcile()
+}
+
+func reconcileValidatorMetricsMonitor(request *common.Request) (common.ReconcileResult, error) {
+	return common.CreateOrUpdate(request).
+		NamespacedResource(newValidatorServiceMonitor(request)).
 		WithAppLabels(operandName, operandComponent).
 		Reconcile()
 }

--- a/internal/operands/metrics/reconcile_test.go
+++ b/internal/operands/metrics/reconcile_test.go
@@ -74,7 +74,8 @@ var _ = Describe("Metrics operand", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		ExpectResourceExists(prometheusRule, request)
-		ExpectResourceExists(newServiceMonitorCR(namespace), request)
+		ExpectResourceExists(newSspServiceMonitor(&request), request)
+		ExpectResourceExists(newValidatorServiceMonitor(&request), request)
 		ExpectResourceExists(newMonitoringClusterRole(), request)
 		ExpectResourceExists(newMonitoringClusterRoleBinding(), request)
 	})

--- a/tests/misc_test.go
+++ b/tests/misc_test.go
@@ -25,6 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	ssp "kubevirt.io/ssp-operator/api/v1beta3"
+	"kubevirt.io/ssp-operator/internal/common"
 	validator "kubevirt.io/ssp-operator/internal/operands/template-validator"
 	"kubevirt.io/ssp-operator/tests/decorators"
 	"kubevirt.io/ssp-operator/tests/env"
@@ -200,7 +201,7 @@ var _ = Describe("SCC annotation", func() {
 		pods := &core.PodList{}
 		err := apiClient.List(ctx, pods,
 			client.InNamespace(strategy.GetNamespace()),
-			client.MatchingLabels{validator.KubevirtIo: validator.VirtTemplateValidator})
+			client.MatchingLabels{validator.KubevirtIo: common.VirtTemplateValidator})
 
 		Expect(err).ToNot(HaveOccurred())
 		Expect(pods.Items).ToNot(BeEmpty())

--- a/tests/service_controller_test.go
+++ b/tests/service_controller_test.go
@@ -8,7 +8,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -90,7 +89,7 @@ var _ = Describe("Service Controller", func() {
 				return "", err
 			}
 			return foundService.UID, nil
-		}, env.ShortTimeout(), time.Second).ShouldNot(Equal(oldUID), fmt.Sprintf("Did not recreate the %s service", controllers.MetricsServiceName))
+		}, env.ShortTimeout(), time.Second).ShouldNot(Equal(oldUID), fmt.Sprintf("Did not recreate the %s service", common.SspOperatorMetricsServiceName))
 	})
 
 	It("[test_id:8810] Should restore ssp-operator-metrics service after update", decorators.Conformance, func() {

--- a/tests/validator_test.go
+++ b/tests/validator_test.go
@@ -10,7 +10,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
 	templatev1 "github.com/openshift/api/template/v1"
 	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
 	admission "k8s.io/api/admissionregistration/v1"
@@ -155,7 +154,7 @@ var _ = Describe("Template validator operand", func() {
 			},
 		}
 		serviceMetricsRes = testResource{
-			Name:           validator.MetricsServiceName,
+			Name:           common.TemplateValidatorMetricsServiceName,
 			Namespace:      strategy.GetNamespace(),
 			Resource:       &core.Service{},
 			ExpectedLabels: validator.PrometheusServiceLabels(),
@@ -643,7 +642,7 @@ var _ = Describe("Template validator webhooks", func() {
 			}
 			eventuallyCreateVm(vm)
 
-			pods, err := GetRunningPodsByLabel(validator.VirtTemplateValidator, validator.KubevirtIo, strategy.GetNamespace())
+			pods, err := GetRunningPodsByLabel(common.VirtTemplateValidator, validator.KubevirtIo, strategy.GetNamespace())
 			Expect(err).ToNot(HaveOccurred(), "Could not find the validator pods")
 			Eventually(func() bool {
 				for _, pod := range pods.Items {
@@ -962,7 +961,7 @@ var _ = Describe("Template validator webhooks", func() {
 	})
 
 	It("[test_id:4375] Test refreshing of certificates", decorators.Conformance, func() {
-		pods, err := GetRunningPodsByLabel(validator.VirtTemplateValidator, validator.KubevirtIo, strategy.GetNamespace())
+		pods, err := GetRunningPodsByLabel(common.VirtTemplateValidator, validator.KubevirtIo, strategy.GetNamespace())
 		Expect(err).ToNot(HaveOccurred())
 		Expect(pods.Items).ToNot(BeEmpty(), "no pods found")
 
@@ -1062,7 +1061,7 @@ func failVmCreationToIncreaseRejectedVmsMetrics(template *templatev1.Template) {
 }
 
 func totalRejectedVmsMetricsValue() (int, error) {
-	pods, err := GetRunningPodsByLabel(validator.VirtTemplateValidator, validator.KubevirtIo, strategy.GetNamespace())
+	pods, err := GetRunningPodsByLabel(common.VirtTemplateValidator, validator.KubevirtIo, strategy.GetNamespace())
 	Expect(err).ToNot(HaveOccurred(), "Could not find the validator pods")
 	Expect(pods.Items).ToNot(BeEmpty())
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Creates a separate service monitor targeting the template validator metrics and verifies the metrics service tls certificate when querying prometheus metrics.

**Which issue(s) this PR fixes**: 
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

Fixes CNV-55455

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
