### PR TITLE
chore: Change labels for network policies

### DIFF
--- a/config/hco-network-policy/hco_allow_egress_to_api_server.yaml
+++ b/config/hco-network-policy/hco_allow_egress_to_api_server.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   podSelector:
     matchExpressions:
-    - key: hco.kubevirt.io/allow-access-cluster-services
+    - key: np.kubevirt.io/allow-access-cluster-services
       operator: Exists
   policyTypes:
     - Egress

--- a/config/hco-network-policy/k8s_hco-allow-egress-to-dns.yaml
+++ b/config/hco-network-policy/k8s_hco-allow-egress-to-dns.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   podSelector:
     matchExpressions:
-    - key: hco.kubevirt.io/allow-access-cluster-services
+    - key: np.kubevirt.io/allow-access-cluster-services
       operator: Exists
   policyTypes:
   - Egress

--- a/config/hco-network-policy/ocp_hco-allow-egress-to-dns.yaml
+++ b/config/hco-network-policy/ocp_hco-allow-egress-to-dns.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   podSelector:
     matchExpressions:
-    - key: hco.kubevirt.io/allow-access-cluster-services
+    - key: np.kubevirt.io/allow-access-cluster-services
       operator: Exists
   policyTypes:
   - Egress

--- a/config/manager/manager.template.yaml
+++ b/config/manager/manager.template.yaml
@@ -20,7 +20,7 @@ spec:
         kubectl.kubernetes.io/default-container: manager
       labels:
         control-plane: ssp-operator
-        hco.kubevirt.io/allow-access-cluster-services: "true"
+        np.kubevirt.io/allow-access-cluster-services: "true"
         name: ssp-operator
         prometheus.ssp.kubevirt.io: "true"
     spec:

--- a/data/olm-catalog/ssp-operator.clusterserviceversion.yaml
+++ b/data/olm-catalog/ssp-operator.clusterserviceversion.yaml
@@ -336,8 +336,8 @@ spec:
                 openshift.io/required-scc: restricted-v2
               labels:
                 control-plane: ssp-operator
-                hco.kubevirt.io/allow-access-cluster-services: "true"
                 name: ssp-operator
+                np.kubevirt.io/allow-access-cluster-services: "true"
                 prometheus.ssp.kubevirt.io: "true"
             spec:
               containers:


### PR DESCRIPTION
**What this PR does / why we need it**:
Changed labels from `hco.kubevirt.io` to `np.kubevirt.io`.

**Release note**:
```release-note
None
```
