### PR TITLE
fix: Use PATCH call to update metadata of immutable objects

### DIFF
--- a/internal/common/resource_test.go
+++ b/internal/common/resource_test.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"context"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	libhandler "github.com/operator-framework/operator-lib/handler"

--- a/tests/dataSources_test.go
+++ b/tests/dataSources_test.go
@@ -1118,6 +1118,25 @@ var _ = Describe("DataSources", func() {
 					return ds.GetLabels()
 				}, env.ShortTimeout(), time.Second).Should(HaveKeyWithValue(cdiLabel, cronName))
 			})
+
+			It("[test_id:TODO] should patch labels on existing DataImportCron", decorators.Conformance, func() {
+				const testVersion = "v1.99.99-test"
+
+				dic := &cdiv1beta1.DataImportCron{}
+				Expect(apiClient.Get(ctx, dataImportCron.GetKey(), dic)).To(Succeed())
+				Expect(dic.Labels[common.AppKubernetesVersionLabel]).ToNot(Equal(testVersion))
+
+				updateSsp(func(foundSsp *ssp.SSP) {
+					foundSsp.Labels[common.AppKubernetesVersionLabel] = testVersion
+				})
+				waitUntilDeployed()
+
+				Eventually(func(g Gomega) {
+					updatedDic := &cdiv1beta1.DataImportCron{}
+					g.Expect(apiClient.Get(ctx, dataImportCron.GetKey(), updatedDic)).To(Succeed())
+					g.Expect(updatedDic.Labels).To(HaveKeyWithValue(common.AppKubernetesVersionLabel, testVersion))
+				}, env.ShortTimeout(), time.Second).Should(Succeed())
+			})
 		})
 
 		Context("without existing PVC and custom namespace", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
When a new field is added to the API of an immutable object before SSP has the new API code imported, the operator will ignore the new fields.

If it tries to update metadata, the UPDATE request will not contain the new field in spec, and so it will look like spec modification. The webhook would reject it.

**Which issue(s) this PR fixes**: 
Related jira: https://issues.redhat.com/browse/CNV-74677

**Release note**:
```release-note
None
```
