### PR TITLE
chore: Update Golang version in CI builder container

### DIFF
--- a/ci-builder/Dockerfile
+++ b/ci-builder/Dockerfile
@@ -1,7 +1,7 @@
 # This Dockerfile is used in openshift CI
-FROM quay.io/fedora/fedora:42
+FROM quay.io/fedora/fedora:43
 
-RUN curl -L https://go.dev/dl/go1.24.3.linux-amd64.tar.gz | tar -C /usr/local -xzf -
+RUN curl -L https://go.dev/dl/go1.25.7.linux-amd64.tar.gz | tar -C /usr/local -xzf -
 ENV PATH=$PATH:/usr/local/go/bin
 
 # Install dependencies and tools


### PR DESCRIPTION
**What this PR does / why we need it**:
This needs to be done in a separate PR before updating golang version of the code.

**Release note**:
```release-note
None
```
