### PR TITLE
[release-v0.18] tests: Improve timeouts for SSP deployed phase and deletion

### DIFF
--- a/tests/cleanup_test.go
+++ b/tests/cleanup_test.go
@@ -50,7 +50,7 @@ var _ = Describe("Cleanup", func() {
 		sspObj := getSsp()
 
 		Expect(apiClient.Delete(ctx, sspObj)).To(Succeed())
-		waitForDeletion(client.ObjectKeyFromObject(sspObj), &ssp.SSP{})
+		waitForDeletionOrAbort(client.ObjectKeyFromObject(sspObj), &ssp.SSP{})
 
 		// Check that all deployed resources were deleted
 		for _, watchType := range allWatchTypes {

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"reflect"
@@ -365,14 +366,13 @@ func (s *existingSspStrategy) SkipIfUpgradeLane() {
 }
 
 var (
-	apiClient          client.Client
-	coreClient         *kubernetes.Clientset
-	apiServerHostname  string
-	ctx                context.Context
-	strategy           TestSuiteStrategy
-	sspListerWatcher   cache.ListerWatcher
-	portForwarder      PortForwarder
-	deploymentTimedOut bool
+	apiClient         client.Client
+	coreClient        *kubernetes.Clientset
+	apiServerHostname string
+	ctx               context.Context
+	strategy          TestSuiteStrategy
+	sspListerWatcher  cache.ListerWatcher
+	portForwarder     PortForwarder
 )
 
 var _ = BeforeSuite(func() {
@@ -483,19 +483,37 @@ func getTemplateValidatorDeployment() *apps.Deployment {
 }
 
 func waitUntilDeployed() {
-	if deploymentTimedOut {
-		Fail("Timed out waiting for SSP to be in phase Deployed.")
-	}
+	defer func() {
+		// If the below check fails, output the SSP object to log.
+		// Its .status.conditions can be helpful.
+		if rec := recover(); rec != nil {
+			ssp := &sspv1beta2.SSP{}
+			err := apiClient.Get(ctx, client.ObjectKey{
+				Name:      strategy.GetName(),
+				Namespace: strategy.GetNamespace(),
+			}, ssp)
+			if err != nil {
+				_, _ = fmt.Fprintf(GinkgoWriter, "Could not get SSP object: %s\n", err.Error())
+				panic(rec)
+			}
 
-	// Set to true before waiting. In case Eventually fails,
-	// it will panic and the deploymentTimedOut will be left true
-	deploymentTimedOut = true
-	EventuallyWithOffset(1, func() bool {
+			sspJson, err := json.MarshalIndent(ssp, "", "    ")
+			if err != nil {
+				_, _ = fmt.Fprintf(GinkgoWriter, "Could not convert SSP to JSON: %s\n", err.Error())
+				panic(rec)
+			}
+
+			_, _ = fmt.Fprintf(GinkgoWriter, "SSP object:\n%s\n", sspJson)
+			panic(rec)
+		}
+	}()
+
+	// If SSP will not be in "deployed" state in 10 minutes, we want to abort the whole test suite.
+	NewGomega(AbortSuite).EventuallyWithOffset(1, func(g Gomega) {
 		ssp := getSsp()
-		return ssp.Status.ObservedGeneration == ssp.Generation &&
-			ssp.Status.Phase == lifecycleapi.PhaseDeployed
-	}, env.Timeout(), time.Second).Should(BeTrue())
-	deploymentTimedOut = false
+		g.Expect(ssp.Status.ObservedGeneration).To(Equal(ssp.Generation))
+		g.Expect(ssp.Status.Phase).To(Equal(lifecycleapi.PhaseDeployed))
+	}, env.Timeout(), time.Second).Should(Succeed())
 }
 
 func waitForDeletion(key client.ObjectKey, obj client.Object) {
@@ -505,9 +523,17 @@ func waitForDeletion(key client.ObjectKey, obj client.Object) {
 	}, env.Timeout(), time.Second).Should(BeTrue())
 }
 
+// waitForDeletionOrAbort aborts the whole test suite if object is not deleted in env.Timeout time.
+func waitForDeletionOrAbort(key client.ObjectKey, obj client.Object) {
+	NewGomega(AbortSuite).EventuallyWithOffset(1, func() bool {
+		err := apiClient.Get(ctx, key, obj)
+		return errors.IsNotFound(err)
+	}, env.Timeout(), time.Second).Should(BeTrue())
+}
+
 func waitForSspDeletionIfNeeded(sspObj *sspv1beta2.SSP) {
 	key := client.ObjectKey{Name: sspObj.Name, Namespace: sspObj.Namespace}
-	Eventually(func() error {
+	NewGomega(AbortSuite).Eventually(func() error {
 		foundSsp := &sspv1beta2.SSP{}
 		err := apiClient.Get(ctx, key, foundSsp)
 		if errors.IsNotFound(err) {


### PR DESCRIPTION
Manual cherry pick of https://github.com/kubevirt/ssp-operator/pull/1703 . Also backported a `defer` block for better logging.

---

**What this PR does / why we need it**:
Many tests wait for SSP to be in deployed phase, or for the SSP object to be deleted, so it can be recreated.
The timeouts for these checks can add up, and then the whole test suite is interrupted after 2 hours.

This commit adds logic to abort the test suite immediately when waiting for SSP to be in phase deployed for more than 10 minutes, or when waiting for deletion for more than 10 minutes.

**Release note**:
```release-note
None
```
