### PR TITLE
fix: Alert should not show when version label on templates changes

### DIFF
--- a/internal/operands/common-templates/reconcile.go
+++ b/internal/operands/common-templates/reconcile.go
@@ -146,7 +146,12 @@ func incrementTemplatesRestoredMetric(reconcileResults []common.ReconcileResult,
 			oldVersion := reconcileResult.InitialResource.GetLabels()[TemplateVersionLabel]
 			newVersion := reconcileResult.Resource.GetLabels()[TemplateVersionLabel]
 
-			if reconcileResult.OperationResult == common.OperationResultUpdated && oldVersion == newVersion {
+			oldAppVersion := reconcileResult.InitialResource.GetLabels()[common.AppKubernetesVersionLabel]
+			newAppVersion := reconcileResult.Resource.GetLabels()[common.AppKubernetesVersionLabel]
+
+			if reconcileResult.OperationResult == common.OperationResultUpdated &&
+				oldVersion == newVersion &&
+				oldAppVersion == newAppVersion {
 				logger.Info(fmt.Sprintf("Changes reverted in common template: %s", reconcileResult.Resource.GetName()))
 				metrics.IncCommonTemplatesRestored()
 			}

--- a/internal/operands/common-templates/reconcile_test.go
+++ b/internal/operands/common-templates/reconcile_test.go
@@ -118,6 +118,8 @@ var _ = Describe("Common-Templates operand", func() {
 			template.Namespace = namespace
 			template.Labels[defaultOsLabel] = "true"
 			template.Labels[testLabel] = "test"
+			template.Labels[common.AppKubernetesPartOfLabel] = request.Instance.Labels[common.AppKubernetesPartOfLabel]
+			template.Labels[common.AppKubernetesVersionLabel] = request.Instance.Labels[common.AppKubernetesVersionLabel]
 			Expect(request.Client.Create(request.Context, &template)).To(Succeed())
 		}
 
@@ -291,14 +293,16 @@ var _ = Describe("Common-Templates operand", func() {
 		})
 
 		It("should not increase when SSP CR is changed", func() {
+			_, err := operand.Reconcile(&request)
+			Expect(err).ToNot(HaveOccurred())
+
 			const updatedPartOf = "updated-part-of"
 			const updatedVersion = "v2.0.0"
 
 			request.Instance.Labels[common.AppKubernetesPartOfLabel] = updatedPartOf
 			request.Instance.Labels[common.AppKubernetesVersionLabel] = updatedVersion
-			request.InstanceChanged = true
 
-			_, err := operand.Reconcile(&request)
+			_, err = operand.Reconcile(&request)
 			Expect(err).ToNot(HaveOccurred())
 
 			updatedTemplate := &templatev1.Template{}


### PR DESCRIPTION
**What this PR does / why we need it**:
The label `app.kubernetes.io/version` on template is set from SSP object, and it should not trigger the alert.

This PR was assisted by AI.

**Which issue(s) this PR fixes**: 
Jira: https://redhat.atlassian.net/browse/CNV-77259

**Release note**:
```release-note
None
```
