### PR TITLE
[release-v0.18] tests: Disable tekton tests for upstream CI

### DIFF
--- a/automation/common/deploy-kubevirt-and-cdi.sh
+++ b/automation/common/deploy-kubevirt-and-cdi.sh
@@ -12,9 +12,6 @@ metadata:
   name: ${NAMESPACE}
 EOF
 
-# Deploy Tekton
-oc apply -f "https://github.com/tektoncd/operator/releases/download/${TEKTON_VERSION}/openshift-release.yaml"
-
 # Deploying kuebvirt
 oc apply -n $NAMESPACE -f "https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VERSION}/kubevirt-operator.yaml"
 

--- a/automation/common/versions.sh
+++ b/automation/common/versions.sh
@@ -59,6 +59,3 @@ KUBEVIRT_VERSION=$(latest_patch_version "kubevirt" "kubevirt" "v1.0")
 
 # Fix CDI version to v.1.57.x
 CDI_VERSION=$(latest_patch_version "kubevirt" "containerized-data-importer" "v1.57")
-
-# Using LTS tekton version v0.67
-TEKTON_VERSION=$(latest_patch_version "tektoncd" "operator" "v0.67")

--- a/automation/e2e-functests/run.sh
+++ b/automation/e2e-functests/run.sh
@@ -14,4 +14,7 @@ export VALIDATOR_IMG=${CI_VALIDATOR_IMG}
 export IMG=${CI_OPERATOR_IMG}
 export SKIP_CLEANUP_AFTER_TESTS=true
 
+# Skipping tekton tests, because the upstream container image of tekton operator v0.67 was removed from the repository.
+export SKIP_TEKTON_TESTS="true"
+
 make deploy functest

--- a/automation/e2e-upgrade-functests/run.sh
+++ b/automation/e2e-upgrade-functests/run.sh
@@ -71,4 +71,7 @@ export TEST_EXISTING_CR_NAME="${SSP_NAME}"
 export TEST_EXISTING_CR_NAMESPACE="${SSP_NAMESPACE}"
 export IS_UPGRADE_LANE="true"
 
+# Skipping tekton tests, because the upstream container image of tekton operator v0.67 was removed from the repository.
+export SKIP_TEKTON_TESTS="true"
+
 make deploy functest

--- a/tests/env/env.go
+++ b/tests/env/env.go
@@ -13,6 +13,7 @@ const (
 	envExistingCrNamespace    = "TEST_EXISTING_CR_NAMESPACE"
 	envSkipUpdateSspTests     = "SKIP_UPDATE_SSP_TESTS"
 	envSkipCleanupAfterTests  = "SKIP_CLEANUP_AFTER_TESTS"
+	envSkipTektonTests        = "SKIP_TEKTON_TESTS"
 	envTimeout                = "TIMEOUT_MINUTES"
 	envShortTimeout           = "SHORT_TIMEOUT_MINUTES"
 	envTopologyMode           = "TOPOLOGY_MODE"
@@ -45,6 +46,10 @@ func SkipUpdateSspTests() bool {
 
 func ShouldSkipCleanupAfterTests() bool {
 	return getBoolEnv(envSkipCleanupAfterTests)
+}
+
+func SkipTektonTests() bool {
+	return getBoolEnv(envSkipTektonTests)
 }
 
 var timeout time.Duration

--- a/tests/tekton-pipelines_test.go
+++ b/tests/tekton-pipelines_test.go
@@ -16,6 +16,10 @@ import (
 )
 
 var _ = Describe("Tekton Pipelines Operand", func() {
+	BeforeEach(func() {
+		strategy.SkipTektonTestsIfNeeded()
+	})
+
 	Context("resource creation when DeployTektonTaskResources is set to true", func() {
 		BeforeEach(func() {
 			strategy.SkipSspUpdateTestsIfNeeded()

--- a/tests/tekton-tasks_test.go
+++ b/tests/tekton-tasks_test.go
@@ -18,6 +18,10 @@ import (
 )
 
 var _ = Describe("Tekton Tasks Operand", func() {
+	BeforeEach(func() {
+		strategy.SkipTektonTestsIfNeeded()
+	})
+
 	Context("resource creation when DeployTektonTaskResources is set to true", func() {
 		BeforeEach(func() {
 			strategy.SkipSspUpdateTestsIfNeeded()

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -73,6 +73,7 @@ type TestSuiteStrategy interface {
 
 	RevertToOriginalSspCr()
 	SkipSspUpdateTestsIfNeeded()
+	SkipTektonTestsIfNeeded()
 	SkipUnlessHighlyAvailableTopologyMode()
 	SkipUnlessSingleReplicaTopologyMode()
 	SkipIfUpgradeLane()
@@ -212,6 +213,12 @@ func (s *newSspStrategy) SkipSspUpdateTestsIfNeeded() {
 	// Do not skip SSP update tests in this strategy
 }
 
+func (s *newSspStrategy) SkipTektonTestsIfNeeded() {
+	if env.SkipTektonTests() {
+		Skip("Tekton tests are disabled", 1)
+	}
+}
+
 func (s *newSspStrategy) SkipUnlessSingleReplicaTopologyMode() {
 	if topologyMode != osconfv1.SingleReplicaTopologyMode {
 		Skip("Tests that are specific for SingleReplicaTopologyMode are disabled", 1)
@@ -342,6 +349,12 @@ func (s *existingSspStrategy) RevertToOriginalSspCr() {
 func (s *existingSspStrategy) SkipSspUpdateTestsIfNeeded() {
 	if s.sspModificationDisabled() {
 		Skip("Tests that update SSP CR are disabled", 1)
+	}
+}
+
+func (s *existingSspStrategy) SkipTektonTestsIfNeeded() {
+	if env.SkipTektonTests() {
+		Skip("Tekton tests are disabled", 1)
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The tekton is no longer installed properly from the github release yaml. Probably the upstream container image was removed from the repository, or is not accessible.

This commit also removes code that installs tekton in the upstream CI.

**Release note**:
```release-note
None
```
