### PR TITLE
[release-v0.18] fix: check if ClusterTask CRD exists before listing it

### DIFF
--- a/internal/operands/tekton-pipelines/tekton-pipelines.go
+++ b/internal/operands/tekton-pipelines/tekton-pipelines.go
@@ -24,7 +24,7 @@ const (
 	namespacePattern           = "^(openshift|kube)-"
 	operandName                = "tekton-pipelines"
 	operandComponent           = common.AppComponentTektonPipelines
-	tektonCrd                  = "tasks.tekton.dev"
+	tektonPipelinesCrd         = "pipelines.tekton.dev"
 	deployNamespaceAnnotation  = "kubevirt.io/tekton-piplines-deploy-namespace"
 	pipelineServiceAccountName = "pipeline"
 	kubevirtNamespace          = "kubevirt"
@@ -40,7 +40,7 @@ func WatchClusterTypes() []operands.WatchType {
 	return []operands.WatchType{
 		// Solution to optional Tekton CRD is not implemented yet.
 		// Until then, do not watch to Tekton CRD.
-		// {Object: &pipeline.Pipeline{}, Crd: tektonCrd, WatchFullObject: true},
+		// {Object: &pipeline.Pipeline{}, Crd: tektonPipelinesCrd, WatchFullObject: true},
 		{Object: &v1.ConfigMap{}},
 		{Object: &rbac.RoleBinding{}},
 		{Object: &v1.ServiceAccount{}},
@@ -89,8 +89,8 @@ func (t *tektonPipelines) Reconcile(request *common.Request) ([]common.Reconcile
 		request.Logger.V(1).Info("Tekton Pipelines resources were not deployed, because spec.featureGates.deployTektonTaskResources is set to false")
 		return nil, nil
 	}
-	if !request.CrdList.CrdExists(tektonCrd) {
-		return nil, fmt.Errorf("tekton CRD %s does not exist", tektonCrd)
+	if !request.CrdList.CrdExists(tektonPipelinesCrd) {
+		return nil, fmt.Errorf("tekton CRD %s does not exist", tektonPipelinesCrd)
 	}
 
 	var reconcileFunc []common.ReconcileFunc
@@ -116,7 +116,7 @@ func (t *tektonPipelines) Reconcile(request *common.Request) ([]common.Reconcile
 
 func (t *tektonPipelines) Cleanup(request *common.Request) ([]common.CleanupResult, error) {
 	var objects []client.Object
-	if request.CrdList.CrdExists(tektonCrd) {
+	if request.CrdList.CrdExists(tektonPipelinesCrd) {
 		for _, p := range t.pipelines {
 			o := p.DeepCopy()
 			objects = append(objects, o)

--- a/internal/operands/tekton-pipelines/tekton-pipelines_test.go
+++ b/internal/operands/tekton-pipelines/tekton-pipelines_test.go
@@ -313,12 +313,12 @@ func getMockedRequest() *common.Request {
 			Kind:       "CustomResourceDefinition",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: tektonCrd,
+			Name: tektonPipelinesCrd,
 		},
 	}
 	Expect(client.Create(context.Background(), tektonCrdObj)).To(Succeed())
 
-	crdWatch := crd_watch.New(tektonCrd)
+	crdWatch := crd_watch.New(tektonPipelinesCrd)
 	Expect(crdWatch.Init(context.Background(), client)).To(Succeed())
 
 	return &common.Request{

--- a/internal/operands/tekton-tasks/tekton-tasks.go
+++ b/internal/operands/tekton-tasks/tekton-tasks.go
@@ -30,9 +30,10 @@ import (
 // +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;create;patch;delete
 
 const (
-	operandName      = "tekton-tasks"
-	operandComponent = common.AppComponentTektonTasks
-	tektonCrd        = "tasks.tekton.dev"
+	operandName           = "tekton-tasks"
+	operandComponent      = common.AppComponentTektonTasks
+	tektonTasksCrd        = "tasks.tekton.dev"
+	tektonClusterTasksCrd = "clustertasks.tekton.dev"
 
 	cleanVMTaskName              = "cleanup-vm"
 	copyTemplateTaskName         = "copy-template"
@@ -71,7 +72,7 @@ func WatchClusterTypes() []operands.WatchType {
 	return []operands.WatchType{
 		// Solution to optional Tekton CRD is not implemented yet.
 		// Until then, do not watch to Tekton CRD.
-		// {Object: &pipeline.Task{}, Crd: tektonCrd, WatchFullObject: true},
+		// {Object: &pipeline.Task{}, Crd: tektonTasksCrd, WatchFullObject: true},
 		{Object: &rbac.ClusterRole{}},
 		{Object: &rbac.RoleBinding{}},
 		{Object: &v1.ServiceAccount{}},
@@ -149,8 +150,8 @@ func (t *tektonTasks) Reconcile(request *common.Request) ([]common.ReconcileResu
 		request.Logger.V(1).Info("Tekton Tasks resources were not deployed, because spec.featureGates.deployTektonTaskResources is set to false")
 		return nil, nil
 	}
-	if !request.CrdList.CrdExists(tektonCrd) {
-		return nil, fmt.Errorf("Tekton CRD %s does not exist", tektonCrd)
+	if !request.CrdList.CrdExists(tektonTasksCrd) {
+		return nil, fmt.Errorf("Tekton CRD %s does not exist", tektonTasksCrd)
 	}
 
 	var reconcileFunc []common.ReconcileFunc
@@ -175,7 +176,7 @@ func (t *tektonTasks) Reconcile(request *common.Request) ([]common.ReconcileResu
 
 func (t *tektonTasks) Cleanup(request *common.Request) ([]common.CleanupResult, error) {
 	var objects []client.Object
-	if request.CrdList.CrdExists(tektonCrd) {
+	if request.CrdList.CrdExists(tektonTasksCrd) {
 		for _, t := range t.tasks {
 			o := t.DeepCopy()
 			objects = append(objects, o)
@@ -199,7 +200,7 @@ func (t *tektonTasks) Cleanup(request *common.Request) ([]common.CleanupResult, 
 		objects = append(objects, o)
 	}
 
-	if request.CrdList.CrdExists(tektonCrd) {
+	if request.CrdList.CrdExists(tektonClusterTasksCrd) {
 		clusterTasks, err := listDeprecatedClusterTasks(request)
 		if err != nil {
 			return nil, err

--- a/internal/operands/tekton-tasks/tekton-tasks_test.go
+++ b/internal/operands/tekton-tasks/tekton-tasks_test.go
@@ -171,12 +171,12 @@ func getMockedRequest() *common.Request {
 			Kind:       "CustomResourceDefinition",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: tektonCrd,
+			Name: tektonTasksCrd,
 		},
 	}
 	Expect(client.Create(context.Background(), tektonCrdObj)).To(Succeed())
 
-	crdWatch := crd_watch.New(tektonCrd)
+	crdWatch := crd_watch.New(tektonTasksCrd)
 	Expect(crdWatch.Init(context.Background(), client)).To(Succeed())
 
 	return &common.Request{


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: check if ClusterTask CRD exists before listing it

Newest tekton operator dropped ClusterTask CRD. SSP operator was accessing the CRD without checking if it exists. This PR will firstly check if the CRD exists
**Which issue(s) this PR fixes**: 
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

Fixes https://redhat.atlassian.net/browse/CNV-83215

**Special notes for your reviewer**:

**Release note**:
```release-note
fix: check if ClusterTask CRD exists before listing it
```
