### PR TITLE
chore: CI: configure Kubevirt to use emulation

### DIFF
--- a/automation/common/deploy-kubevirt-and-cdi.sh
+++ b/automation/common/deploy-kubevirt-and-cdi.sh
@@ -42,6 +42,14 @@ oc patch -n $NAMESPACE kubevirt kubevirt --type='json' -p '[{
   },
 }]'
 
+if [[ "${USE_EMULATION:-false}" == "true" ]]; then
+  oc patch -n $NAMESPACE kubevirt kubevirt --type='json' -p '[{
+    "op": "add",
+    "path": "/spec/configuration/developerConfiguration/useEmulation",
+    "value": true
+  }]'
+fi
+
 echo "Waiting for Kubevirt to be ready..."
 oc wait --for=condition=Available --timeout=600s -n $NAMESPACE kv/kubevirt
 

--- a/automation/e2e-functests/run.sh
+++ b/automation/e2e-functests/run.sh
@@ -8,7 +8,7 @@ set -e
 # CI_OPERATOR_IMG - path of the operator image in the local repository accessible on the CI
 # CI_VALIDATOR_IMG - path of the validator image in the local repository accessible on the CI
 
-./automation/common/deploy-kubevirt-and-cdi.sh
+USE_EMULATION=true ./automation/common/deploy-kubevirt-and-cdi.sh
 
 # Install network policy to block traffic to/from SSP and its components by default
 KUBECTL=oc ./hack/install-network-policy.sh

--- a/automation/e2e-upgrade-functests/run.sh
+++ b/automation/e2e-upgrade-functests/run.sh
@@ -12,7 +12,7 @@ set -e
 SOURCE_DIR=$(dirname "$0")
 
 # Deploy KubeVirt and CDI
-./automation/common/deploy-kubevirt-and-cdi.sh
+USE_EMULATION=true ./automation/common/deploy-kubevirt-and-cdi.sh
 
 # Deploy latest released SSP operator
 NAMESPACE=${1:-kubevirt}


### PR DESCRIPTION
**What this PR does / why we need it**:
The cluster that runs tests for CI may not have nested virtualization enabled. Our tests only check if a VM is running, and they can be slower.

This change is needed for: https://github.com/openshift/release/pull/77840

**Release note**:
```release-note
None
```
