### PR TITLE
fix: Do not change .status before reconciliation when SSP is unchanged

### DIFF
--- a/internal/controllers/ssp_controller.go
+++ b/internal/controllers/ssp_controller.go
@@ -220,7 +220,6 @@ func (s *sspController) Reconcile(ctx context.Context, req ctrl.Request) (res ct
 		}
 		reqLogger.Info(fmt.Sprintf("Pausing SSP operator on resource: %v/%v", instance.Namespace, instance.Name))
 		instance.Status.Paused = true
-		instance.Status.ObservedGeneration = instance.Generation
 		err := s.client.Status().Update(ctx, instance)
 		return ctrl.Result{}, err
 	}
@@ -230,13 +229,16 @@ func (s *sspController) Reconcile(ctx context.Context, req ctrl.Request) (res ct
 		return ctrl.Result{}, err
 	}
 
-	sspRequest.Logger.V(1).Info("Updating CR status prior to operand reconciliation...")
-	err = preUpdateStatus(sspRequest)
-	if err != nil {
-		return handleError(sspRequest, err, sspRequest.Logger)
+	if sspRequest.Instance.Status.ObservedGeneration == 0 ||
+		sspRequest.Instance.Status.ObservedGeneration != sspRequest.Instance.Generation {
+		// Only set conditions when SSP object was changed.
+		sspRequest.Logger.V(1).Info("Updating CR status prior to operand reconciliation...")
+		err = preUpdateStatus(sspRequest)
+		if err != nil {
+			return handleError(sspRequest, err, sspRequest.Logger)
+		}
+		sspRequest.Logger.V(1).Info("CR status updated")
 	}
-
-	sspRequest.Logger.V(1).Info("CR status updated")
 
 	sspRequest.Logger.Info("Reconciling operands...")
 	reconcileResults, err := s.reconcileOperands(sspRequest)
@@ -427,11 +429,6 @@ func preUpdateStatus(request *common.Request) error {
 	sspStatus.ObservedGeneration = request.Instance.Generation
 	sspStatus.OperatorVersion = operatorVersion
 	sspStatus.TargetVersion = operatorVersion
-
-	if sspStatus.Paused {
-		request.Logger.Info(fmt.Sprintf("Unpausing SSP operator on resource: %v/%v",
-			request.Instance.Namespace, request.Instance.Name))
-	}
 	sspStatus.Paused = false
 
 	if !conditionsv1.IsStatusConditionPresentAndEqual(sspStatus.Conditions, conditionsv1.ConditionAvailable, v1.ConditionFalse) {
@@ -556,6 +553,7 @@ func updateStatus(request *common.Request, reconcileResults []common.ReconcileRe
 		})
 	}
 
+	sspStatus.Paused = false
 	sspStatus.ObservedGeneration = request.Instance.Generation
 	if len(notAvailable) == 0 && len(progressing) == 0 && len(degraded) == 0 {
 		sspStatus.Phase = lifecycleapi.PhaseDeployed

--- a/tests/crypto_policy_test.go
+++ b/tests/crypto_policy_test.go
@@ -289,11 +289,15 @@ func applyTLSConfig(tlsSecurityProfile *ocpv1.TLSSecurityProfile) {
 	Expect(err).ToNot(HaveOccurred())
 	defer watch.Stop()
 
+	var previousGeneration int64
 	updateSsp(func(foundSsp *ssp.SSP) {
+		previousGeneration = foundSsp.Generation
 		foundSsp.Spec.TLSSecurityProfile = tlsSecurityProfile
 	})
-	err = WatchChangesUntil(watch, isStatusDeploying, env.Timeout())
-	Expect(err).ToNot(HaveOccurred(), "SSP status should be deploying.")
-	err = WatchChangesUntil(watch, isStatusDeployed, env.Timeout())
-	Expect(err).ToNot(HaveOccurred(), "SSP status should be deployed.")
+
+	Eventually(func(g Gomega) {
+		sspObj := getSsp()
+		g.Expect(sspObj.Generation).To(BeNumerically(">", previousGeneration))
+		g.Expect(sspObj.Status.ObservedGeneration).To(Equal(sspObj.Generation))
+	}, env.ShortTimeout(), time.Second).Should(Succeed())
 }

--- a/tests/misc_test.go
+++ b/tests/misc_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -98,6 +99,114 @@ var _ = Describe("Observed generation", func() {
 				updatedSsp.Generation == updatedSsp.Status.ObservedGeneration
 		}, env.ShortTimeout())
 		Expect(err).ToNot(HaveOccurred())
+	})
+})
+
+var _ = Describe("Status change before reconciliation", func() {
+	BeforeEach(func() {
+		strategy.SkipSspUpdateTestsIfNeeded()
+		waitUntilDeployed()
+	})
+
+	AfterEach(func() {
+		strategy.RevertToOriginalSspCr()
+		waitUntilDeployed()
+	})
+
+	It("[test_id:TODO] should change .status before reconciliation, when CR was changed", func() {
+		watch, err := StartWatch(sspListerWatcher)
+		Expect(err).ToNot(HaveOccurred())
+		defer watch.Stop()
+
+		var previousGeneration int64
+		var newValidatorReplicas int32 = 0
+		updateSsp(func(foundSsp *ssp.SSP) {
+			previousGeneration = foundSsp.Generation
+			foundSsp.Spec.TemplateValidator = &ssp.TemplateValidator{
+				Replicas: &newValidatorReplicas,
+			}
+		})
+
+		err = WatchChangesUntil(watch, func(updatedSsp *ssp.SSP) bool {
+			return updatedSsp.Generation > previousGeneration &&
+				isStatusDeploying(updatedSsp)
+		}, env.ShortTimeout())
+		Expect(err).ToNot(HaveOccurred(), "SSP status should be deploying after CR change.")
+
+		err = WatchChangesUntil(watch, isStatusDeployed, env.Timeout())
+		Expect(err).ToNot(HaveOccurred(), "SSP status should be deployed.")
+
+		Eventually(func(g Gomega) {
+			sspObj := getSsp()
+			g.Expect(sspObj.Generation).To(BeNumerically(">", previousGeneration))
+			g.Expect(sspObj.Status.ObservedGeneration).To(Equal(sspObj.Generation))
+		}, env.ShortTimeout(), time.Second).Should(Succeed())
+	})
+
+	It("[test_id:TODO] should not change .status before reconciliation, when CR was not changed", func() {
+		serviceRes := testResource{
+			Name:      validator.ServiceName,
+			Namespace: strategy.GetNamespace(),
+			Resource:  &core.Service{},
+			UpdateFunc: func(service *core.Service) {
+				service.Spec.Ports[0].Port = 44331
+				service.Spec.Ports[0].TargetPort = intstr.FromInt32(44331)
+			},
+			EqualsFunc: func(old *core.Service, new *core.Service) bool {
+				return reflect.DeepEqual(old.Spec, new.Spec)
+			},
+		}
+
+		initialSsp := getSsp()
+		Expect(initialSsp.Status.ObservedGeneration).To(Equal(initialSsp.Generation),
+			"ObservedGeneration should equal Generation before test")
+		Expect(isStatusDeployed(initialSsp)).To(BeTrue(),
+			"SSP should be in Deployed state before test")
+
+		watch, err := StartWatch(sspListerWatcher)
+		Expect(err).ToNot(HaveOccurred())
+		defer watch.Stop()
+
+		done := make(chan struct{})
+		statusChanged := make(chan bool, 1)
+		go func() {
+			defer GinkgoRecover()
+			defer close(statusChanged)
+			for {
+				select {
+				case updatedSsp, ok := <-watch.Updates():
+					if !ok {
+						return
+					}
+					if isStatusDeploying(updatedSsp) ||
+						updatedSsp.Status.ObservedGeneration != initialSsp.Generation ||
+						updatedSsp.Generation != initialSsp.Generation {
+						// Found one unexpected event
+						statusChanged <- true
+						return
+					}
+				case <-done:
+					// This case is the last, so all events in the watch channel are processed before exiting.
+					return
+				}
+			}
+		}()
+
+		expectRestoreAfterUpdate(&serviceRes)
+
+		close(done)
+		changed := <-statusChanged
+
+		Expect(changed).To(BeFalse(),
+			"SSP status should not change when CR was not changed")
+
+		finalSsp := getSsp()
+		Expect(finalSsp.Generation).To(Equal(initialSsp.Generation),
+			"Generation should remain unchanged")
+		Expect(finalSsp.Status.ObservedGeneration).To(Equal(initialSsp.Generation),
+			"ObservedGeneration should remain unchanged")
+		Expect(isStatusDeployed(finalSsp)).To(BeTrue(),
+			"SSP should remain in Deployed state")
 	})
 })
 

--- a/tests/tests_common_test.go
+++ b/tests/tests_common_test.go
@@ -95,23 +95,13 @@ func expectRecreateAfterDelete(res *testResource) {
 	resource.SetName(res.Name)
 	resource.SetNamespace(res.Namespace)
 
-	// Watch status of the SSP resource
-	watch, err := StartWatch(sspListerWatcher)
-	Expect(err).ToNot(HaveOccurred())
-	defer watch.Stop()
-
 	Expect(apiClient.Delete(ctx, resource)).ToNot(HaveOccurred())
 
-	err = WatchChangesUntil(watch, isStatusDeploying, env.ShortTimeout())
-	Expect(err).ToNot(HaveOccurred(), "SSP status should be deploying.")
-
-	err = WatchChangesUntil(watch, isStatusDeployed, env.Timeout())
-	Expect(err).ToNot(HaveOccurred(), "SSP status should be deployed.")
-
-	Eventually(func() error {
-		return apiClient.Get(ctx, client.ObjectKey{
+	Eventually(func(g Gomega) {
+		g.Expect(apiClient.Get(ctx, client.ObjectKey{
 			Name: res.Name, Namespace: res.Namespace,
-		}, resource)
+		}, resource)).To(Succeed())
+		g.Expect(resource.GetDeletionTimestamp().IsZero()).To(BeTrue())
 	}, env.ShortTimeout(), time.Second).Should(Succeed())
 }
 
@@ -178,23 +168,12 @@ func expectRestoreAfterUpdate(res *testResource) {
 	original := res.NewResource()
 	Expect(apiClient.Get(ctx, res.GetKey(), original)).ToNot(HaveOccurred())
 
-	// Watch status of the SSP resource
-	watch, err := StartWatch(sspListerWatcher)
-	Expect(err).ToNot(HaveOccurred())
-	defer watch.Stop()
-
 	Eventually(func(g Gomega) {
 		found := res.NewResource()
 		g.Expect(apiClient.Get(ctx, res.GetKey(), found)).To(Succeed())
 		res.Update(found)
 		g.Expect(apiClient.Update(ctx, found)).ToNot(HaveOccurred())
 	}, env.ShortTimeout(), time.Second).Should(Succeed())
-
-	err = WatchChangesUntil(watch, isStatusDeploying, env.ShortTimeout())
-	Expect(err).ToNot(HaveOccurred(), "SSP status should be deploying.")
-
-	err = WatchChangesUntil(watch, isStatusDeployed, env.Timeout())
-	Expect(err).ToNot(HaveOccurred(), "SSP status should be deployed.")
 
 	Eventually(func(g Gomega) {
 		found := res.NewResource()

--- a/tests/validator_test.go
+++ b/tests/validator_test.go
@@ -80,8 +80,6 @@ var _ = Describe("Template validator operand", func() {
 		networkPolicyKubeAPIAndDNSRes     testResource
 		networkPolicyWebhookAndMetricsRes testResource
 		podDisruptionBudgetRes            testResource
-
-		replicas int32 = 2
 	)
 
 	BeforeEach(func() {
@@ -473,37 +471,6 @@ var _ = Describe("Template validator operand", func() {
 					podSpec.NodeSelector == nil &&
 					podSpec.Tolerations == nil
 			}, env.Timeout(), 1*time.Second).Should(BeTrue(), "placement should be nil")
-		})
-
-		// TODO - This test is currently pending, because it can be flaky.
-		//        If the operator is too slow and does not notice Deployment
-		//        state when not all pods are running, the test would fail.
-		PIt("[test_id:5830]should set available condition when at least one validator pod is running", decorators.Conformance, func() {
-			watch, err := StartWatch(sspListerWatcher)
-			Expect(err).ToNot(HaveOccurred())
-			defer watch.Stop()
-
-			updateSsp(func(foundSsp *ssp.SSP) {
-				foundSsp.Spec.TemplateValidator = &ssp.TemplateValidator{
-					Replicas: ptr.To(replicas),
-				}
-			})
-
-			err = WatchChangesUntil(watch, isStatusDeploying, env.Timeout())
-			Expect(err).ToNot(HaveOccurred(), "SSP status should be deploying.")
-
-			err = WatchChangesUntil(watch, func(obj *ssp.SSP) bool {
-				available := conditionsv1.FindStatusCondition(obj.Status.Conditions, conditionsv1.ConditionAvailable)
-				progressing := conditionsv1.FindStatusCondition(obj.Status.Conditions, conditionsv1.ConditionProgressing)
-
-				return obj.Status.Phase == lifecycleapi.PhaseDeploying &&
-					available.Status == core.ConditionTrue &&
-					progressing.Status == core.ConditionTrue
-			}, env.Timeout())
-			Expect(err).ToNot(HaveOccurred(), "SSP should be available, but progressing.")
-
-			err = WatchChangesUntil(watch, isStatusDeployed, env.Timeout())
-			Expect(err).ToNot(HaveOccurred(), "SSP status should be deployed.")
 		})
 	})
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
Changing the `.status` to `Deploying` and then to `Deployed` on every reconciliation loop caused warnings in the event logs.

**Which issue(s) this PR fixes**: 
Jira: https://redhat.atlassian.net/browse/CNV-82471

**Release note**:
```release-note
None
```
