### PR TITLE
fix: poll SSP status in test_id:6204 to wait for cluster to stabilize

### DIFF
--- a/tests/validator_test.go
+++ b/tests/validator_test.go
@@ -343,20 +343,22 @@ var _ = Describe("Template validator operand", func() {
 	})
 
 	It("[test_id:6204]should set Deployed phase and conditions when validator pods are running", decorators.Conformance, func() {
-		foundSsp := getSsp()
+		Eventually(func(g Gomega) {
+			foundSsp := getSsp()
 
-		Expect(foundSsp.Status.Phase).To(Equal(lifecycleapi.PhaseDeployed), "SSP should be in phase Deployed")
+			g.Expect(foundSsp.Status.Phase).To(Equal(lifecycleapi.PhaseDeployed), "SSP should be in phase Deployed")
 
-		conditions := foundSsp.Status.Conditions
-		Expect(conditionsv1.FindStatusCondition(conditions, conditionsv1.ConditionAvailable).Status).To(Equal(core.ConditionTrue),
-			fmt.Sprintf("Condition '%s' should be '%s'.", conditionsv1.ConditionAvailable, core.ConditionTrue),
-		)
-		Expect(conditionsv1.FindStatusCondition(conditions, conditionsv1.ConditionProgressing).Status).To(Equal(core.ConditionFalse),
-			fmt.Sprintf("Condition '%s' should be '%s'.", conditionsv1.ConditionProgressing, core.ConditionFalse),
-		)
-		Expect(conditionsv1.FindStatusCondition(conditions, conditionsv1.ConditionDegraded).Status).To(Equal(core.ConditionFalse),
-			fmt.Sprintf("Condition '%s' should be '%s'.", conditionsv1.ConditionDegraded, core.ConditionFalse),
-		)
+			conditions := foundSsp.Status.Conditions
+			g.Expect(conditionsv1.FindStatusCondition(conditions, conditionsv1.ConditionAvailable).Status).To(Equal(core.ConditionTrue),
+				fmt.Sprintf("Condition '%s' should be '%s'.", conditionsv1.ConditionAvailable, core.ConditionTrue),
+			)
+			g.Expect(conditionsv1.FindStatusCondition(conditions, conditionsv1.ConditionProgressing).Status).To(Equal(core.ConditionFalse),
+				fmt.Sprintf("Condition '%s' should be '%s'.", conditionsv1.ConditionProgressing, core.ConditionFalse),
+			)
+			g.Expect(conditionsv1.FindStatusCondition(conditions, conditionsv1.ConditionDegraded).Status).To(Equal(core.ConditionFalse),
+				fmt.Sprintf("Condition '%s' should be '%s'.", conditionsv1.ConditionDegraded, core.ConditionFalse),
+			)
+		}, env.Timeout(), time.Second).Should(Succeed())
 
 		deployment := &apps.Deployment{}
 		Expect(apiClient.Get(ctx, deploymentRes.GetKey(), deployment)).ToNot(HaveOccurred())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
[test_id:6204] was doing single check on SSP phase and conditions causing a flaky failure if the operator was still reconciling. Wrap the assertions in Eventually to poll until the cluster stabilizes

**Which issue(s) this PR fixes**: 
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
