### PR TITLE
tests: print logs from vm-console-proxy when TLS test fails

### DIFF
--- a/tests/crypto_policy_test.go
+++ b/tests/crypto_policy_test.go
@@ -12,6 +12,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"k8s.io/utils/ptr"
 
 	ocpv1 "github.com/openshift/api/config/v1"
 	openshiftcrypto "github.com/openshift/library-go/pkg/crypto"
@@ -100,6 +101,8 @@ var _ = Describe("Crypto Policy", func() {
 				},
 			},
 		}
+
+		lastVmProxyPod *core.Pod
 	)
 
 	BeforeEach(func() {
@@ -112,9 +115,24 @@ var _ = Describe("Crypto Policy", func() {
 			}
 		})
 		waitUntilDeployed()
+
+		lastVmProxyPod = nil
 	})
 
 	AfterEach(func() {
+		// Print logs from vm-console-proxy, so we know why the tests failed.
+		if CurrentSpecReport().Failed() && lastVmProxyPod != nil {
+			const tailLines int64 = 64
+			logs, err := GetPodLogs(lastVmProxyPod.Name, lastVmProxyPod.Namespace, core.PodLogOptions{
+				TailLines: ptr.To(tailLines),
+			})
+			if err != nil {
+				GinkgoWriter.Printf("Failed to get vm-console-proxy logs: %v\n", err)
+			} else {
+				GinkgoWriter.Printf("Last %d lines of vm-console-proxy pod %q logs:\n%s\n", tailLines, lastVmProxyPod.Name, logs)
+			}
+		}
+
 		strategy.RevertToOriginalSspCr()
 	})
 
@@ -141,6 +159,7 @@ var _ = Describe("Crypto Policy", func() {
 				vmProxyPod, err := vmConsoleProxyPod()
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(vmProxyPod).ToNot(BeNil())
+				lastVmProxyPod = vmProxyPod
 				g.Expect(testVmConsoleProxyEndpoint(*vmProxyPod, tlsConfigTestPermutation, clientCert)).To(Succeed())
 			}, env.Timeout(), time.Second).Should(Succeed())
 		},

--- a/tests/tests_common_test.go
+++ b/tests/tests_common_test.go
@@ -303,9 +303,8 @@ func expectUserCannot(sars *authv1.SubjectAccessReviewSpec) {
 			sars.ResourceAttributes.Version, sars.ResourceAttributes.Namespace))
 }
 
-func GetPodLogs(name, namespace string) (string, error) {
-	RawLogs, err := coreClient.CoreV1().Pods(namespace).
-		GetLogs(name, &core.PodLogOptions{}).DoRaw(ctx)
+func GetPodLogs(name, namespace string, params core.PodLogOptions) (string, error) {
+	RawLogs, err := coreClient.CoreV1().Pods(namespace).GetLogs(name, &params).DoRaw(ctx)
 	return string(RawLogs), err
 }
 

--- a/tests/validator_test.go
+++ b/tests/validator_test.go
@@ -638,7 +638,7 @@ var _ = Describe("Template validator webhooks", func() {
 			Expect(err).ToNot(HaveOccurred(), "Could not find the validator pods")
 			Eventually(func() bool {
 				for _, pod := range pods.Items {
-					logs, err := GetPodLogs(pod.Name, pod.Namespace)
+					logs, err := GetPodLogs(pod.Name, pod.Namespace, core.PodLogOptions{})
 					Expect(err).ToNot(HaveOccurred())
 					if strings.Contains(logs, "Memory size not within range") {
 						return true


### PR DESCRIPTION
**What this PR does / why we need it**:
When cleaning up after the TLS test, the `vm-console-proxy` `Deployment` is removed, so we cannot see the logs in `must-gather`.

This PR adds those logs to the main test log.

**Release note**:
```release-note
None
```
