### PR TITLE
chore: Update golang version to 1.26

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ARG TARGET_ARCH
 RUN microdnf install -y make tar gzip which && microdnf clean all
 
 RUN ARCH=$(uname -m | sed 's/x86_64/amd64/') && \
-    curl -L https://go.dev/dl/go1.25.7.linux-${ARCH}.tar.gz -o go.tar.gz && \
+    curl -L https://go.dev/dl/go1.26.4.linux-${ARCH}.tar.gz -o go.tar.gz --fail && \
     tar -C /usr/local -xzf go.tar.gz && \
     rm go.tar.gz
 

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module kubevirt.io/ssp-operator/api
 
-go 1.25.7
+go 1.26
 
 require (
 	github.com/openshift/api v0.0.0-20251208101024-c2a41ea924bd // release-4.21

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module kubevirt.io/ssp-operator
 
-go 1.25.7
+go 1.26
 
 require (
 	github.com/blang/semver/v4 v4.0.0

--- a/validator.Dockerfile
+++ b/validator.Dockerfile
@@ -11,7 +11,7 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal as builder
 ARG TARGET_ARCH
 
 RUN microdnf install -y make tar gzip which && microdnf clean all
-RUN export ARCH=$(uname -m | sed 's/x86_64/amd64/'); curl -L https://go.dev/dl/go1.25.7.linux-${ARCH}.tar.gz | tar -C /usr/local -xzf -
+RUN export ARCH=$(uname -m | sed 's/x86_64/amd64/'); curl -L https://go.dev/dl/go1.26.4.linux-${ARCH}.tar.gz --fail | tar -C /usr/local -xzf -
 ENV PATH=$PATH:/usr/local/go/bin
 
 ARG VERSION=latest

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -933,7 +933,7 @@ kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1
 ## explicit; go 1.17
 kubevirt.io/controller-lifecycle-operator-sdk/api
 # kubevirt.io/ssp-operator/api v0.0.0 => ./api
-## explicit; go 1.25.7
+## explicit; go 1.26
 kubevirt.io/ssp-operator/api/v1beta2
 kubevirt.io/ssp-operator/api/v1beta3
 # kubevirt.io/vm-console-proxy/api v0.8.1


### PR DESCRIPTION
**What this PR does / why we need it**:
Updated the golang version to 1.26

**Release note**:
```release-note
None
```
