### PR TITLE
chore: Update golang version in ci-builder to 1.26

### DIFF
--- a/ci-builder/Dockerfile
+++ b/ci-builder/Dockerfile
@@ -1,7 +1,7 @@
 # This Dockerfile is used in openshift CI
-FROM quay.io/fedora/fedora:43
+FROM quay.io/fedora/fedora:44
 
-RUN curl -L https://go.dev/dl/go1.25.7.linux-amd64.tar.gz | tar -C /usr/local -xzf -
+RUN curl -L https://go.dev/dl/go1.26.4.linux-amd64.tar.gz | tar -C /usr/local -xzf -
 ENV PATH=$PATH:/usr/local/go/bin
 
 # Install dependencies and tools


### PR DESCRIPTION
**What this PR does / why we need it**:
This needs to be merged before other version updates in: https://github.com/kubevirt/ssp-operator/pull/1837

**Release note**:
```release-note
None
```
