### PR TITLE
monitoring: add vm typed resource label to VMStorageClassWarning alert

### DIFF
--- a/pkg/monitoring/rules/alerts/operator.go
+++ b/pkg/monitoring/rules/alerts/operator.go
@@ -1,10 +1,19 @@
 package alerts
 
 import (
+	"fmt"
+
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 )
+
+// withVMLabel wraps a PromQL expression with label_replace to add a "vm"
+// typed resource label derived from the "name" label. This enables the
+// monitoring-plugin to navigate from alerts to the VM resource page.
+func withVMLabel(expr string) string {
+	return fmt.Sprintf(`label_replace(%s, "vm", "$1", "name", "(.+)")`, expr)
+}
 
 const (
 	severityAlertLabelKey     = "severity"
@@ -75,10 +84,12 @@ func operatorAlerts() []promv1.Rule {
 		},
 		{
 			Alert: "VMStorageClassWarning",
-			Expr:  intstr.FromString("(count(kubevirt_ssp_vm_rbd_block_volume_without_rxbounce * on(name, namespace) (kubevirt_vmi_info{guest_os_name=\"Microsoft Windows\"} > 0 or kubevirt_vmi_info{os=~\"windows.*\"} > 0) > 0) or vector(0)) > 0"),
+			Expr: intstr.FromString(withVMLabel(
+				`kubevirt_ssp_vm_rbd_block_volume_without_rxbounce * on(name, namespace) (kubevirt_vmi_info{guest_os_name="Microsoft Windows"} > 0 or kubevirt_vmi_info{os=~"windows.*"} > 0) > 0`,
+			)),
 			Annotations: map[string]string{
-				"summary":     "{{ $value }} Windows Virtual Machines may cause reports of bad crc/signature errors due to certain I/O patterns.",
-				"description": "When running Windows VMs using ODF storage with 'rbd' mounter or 'rbd.csi.ceph.com provisioner', VMs may cause reports of bad crc/signature errors due to certain I/O patterns. Cluster performance can be severely degraded if the number of re-transmissions due to crc errors causes network saturation.",
+				"summary":     "Virtual Machine '{{ $labels.name }}' in namespace '{{ $labels.namespace }}' may cause reports of bad crc/signature errors due to certain I/O patterns.",
+				"description": "When running Windows VMs using ODF storage with 'rbd' mounter or 'rbd.csi.ceph.com provisioner', the VM '{{ $labels.name }}' may cause reports of bad crc/signature errors due to certain I/O patterns. Cluster performance can be severely degraded if the number of re-transmissions due to crc errors causes network saturation.",
 			},
 			Labels: map[string]string{
 				severityAlertLabelKey:     "warning",

--- a/pkg/monitoring/rules/rules-tests.yaml
+++ b/pkg/monitoring/rules/rules-tests.yaml
@@ -190,14 +190,17 @@ tests:
         alertname: "VMStorageClassWarning"
         exp_alerts:
           - exp_annotations:
-              summary: "1 Windows Virtual Machines may cause reports of bad crc/signature errors due to certain I/O patterns."
-              description: "When running Windows VMs using ODF storage with 'rbd' mounter or 'rbd.csi.ceph.com provisioner', VMs may cause reports of bad crc/signature errors due to certain I/O patterns. Cluster performance can be severely degraded if the number of re-transmissions due to crc errors causes network saturation."
+              summary: "Virtual Machine 'vm1' in namespace 'ns1' may cause reports of bad crc/signature errors due to certain I/O patterns."
+              description: "When running Windows VMs using ODF storage with 'rbd' mounter or 'rbd.csi.ceph.com provisioner', the VM 'vm1' may cause reports of bad crc/signature errors due to certain I/O patterns. Cluster performance can be severely degraded if the number of re-transmissions due to crc errors causes network saturation."
               runbook_url: "https://kubevirt.io/monitoring/runbooks/VMStorageClassWarning"
             exp_labels:
               severity: "warning"
               operator_health_impact: "none"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "ssp-operator"
+              name: "vm1"
+              namespace: "ns1"
+              vm: "vm1"
 
       - eval_time: "3m"
         alertname: "VMStorageClassWarning"
@@ -207,14 +210,17 @@ tests:
         alertname: "VMStorageClassWarning"
         exp_alerts:
           - exp_annotations:
-              summary: "1 Windows Virtual Machines may cause reports of bad crc/signature errors due to certain I/O patterns."
-              description: "When running Windows VMs using ODF storage with 'rbd' mounter or 'rbd.csi.ceph.com provisioner', VMs may cause reports of bad crc/signature errors due to certain I/O patterns. Cluster performance can be severely degraded if the number of re-transmissions due to crc errors causes network saturation."
+              summary: "Virtual Machine 'vm1' in namespace 'ns1' may cause reports of bad crc/signature errors due to certain I/O patterns."
+              description: "When running Windows VMs using ODF storage with 'rbd' mounter or 'rbd.csi.ceph.com provisioner', the VM 'vm1' may cause reports of bad crc/signature errors due to certain I/O patterns. Cluster performance can be severely degraded if the number of re-transmissions due to crc errors causes network saturation."
               runbook_url: "https://kubevirt.io/monitoring/runbooks/VMStorageClassWarning"
             exp_labels:
               severity: "warning"
               operator_health_impact: "none"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "ssp-operator"
+              name: "vm1"
+              namespace: "ns1"
+              vm: "vm1"
 
       - eval_time: "5m"
         alertname: "VMStorageClassWarning"
@@ -224,14 +230,17 @@ tests:
         alertname: "VMStorageClassWarning"
         exp_alerts:
           - exp_annotations:
-              summary: "1 Windows Virtual Machines may cause reports of bad crc/signature errors due to certain I/O patterns."
-              description: "When running Windows VMs using ODF storage with 'rbd' mounter or 'rbd.csi.ceph.com provisioner', VMs may cause reports of bad crc/signature errors due to certain I/O patterns. Cluster performance can be severely degraded if the number of re-transmissions due to crc errors causes network saturation."
+              summary: "Virtual Machine 'vm1' in namespace 'ns1' may cause reports of bad crc/signature errors due to certain I/O patterns."
+              description: "When running Windows VMs using ODF storage with 'rbd' mounter or 'rbd.csi.ceph.com provisioner', the VM 'vm1' may cause reports of bad crc/signature errors due to certain I/O patterns. Cluster performance can be severely degraded if the number of re-transmissions due to crc errors causes network saturation."
               runbook_url: "https://kubevirt.io/monitoring/runbooks/VMStorageClassWarning"
             exp_labels:
               severity: "warning"
               operator_health_impact: "none"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "ssp-operator"
+              name: "vm1"
+              namespace: "ns1"
+              vm: "vm1"
 
       - eval_time: "7m"
         alertname: "VMStorageClassWarning"


### PR DESCRIPTION
## Summary

Add a `vm` typed resource label to the VMStorageClassWarning alert defined in the kubevirt/ssp-operator repository. This enables the monitoring-plugin to detect which VirtualMachine resource an alert is about and provide clickable navigation from alerts to the VM resource page.

Jira-url: CNV-92992

## Why `vm` only (not `vmi`)

VM and VMI always share the same name in KubeVirt. Users navigate to the VM page (not VMI). A single `vm` label simplifies correlation, dashboard queries, and console integration.

## Changes

### Alert modified

The VMStorageClassWarning alert expression is restructured to fire per-VM (instead of as a cluster-level count) and wrapped with `label_replace(<expr>, "vm", "$1", "name", "(.+)")` to add the `vm` typed resource label:

| Alert | Severity | Change |
| --- | --- | --- |
| VMStorageClassWarning | warning | Restructured to fire per-VM + added `vm` label |

### Implementation

A `withVMLabel(expr string) string` helper wraps expressions with `label_replace(..., "vm", "$1", "name", "(.+)")`.

The expression is restructured from `(count(...) or vector(0)) > 0` (cluster-aggregate) to the inner per-VM expression, so that the `name` and `namespace` labels are preserved on each alert instance. Annotations are updated to reference the specific VM.

### Files changed

* `pkg/monitoring/rules/alerts/operator.go` — Added `withVMLabel` helper, restructured VMStorageClassWarning to fire per-VM with `vm` label
* `pkg/monitoring/rules/rules-tests.yaml` — Updated test expectations with per-VM labels (`name`, `namespace`, `vm`) and updated annotations

## Note on VirtualMachineInstanceHasEphemeralHotplugVolume

The Jira ticket CNV-92992 also lists a `VirtualMachineInstanceHasEphemeralHotplugVolume` alert. This alert does not currently exist in the ssp-operator codebase — it requires a corresponding metric and alert definition to be created first. This will be addressed in a follow-up PR once the metric is available.

## Test plan

* `promtool check rules` passes (no lint errors)
* `promtool test rules` passes (all existing + updated test cases)
* Existing `name` label preserved (backward compatible)
* Monitoring-plugin can navigate from alert to VM resource page using `vm` label
* No breaking changes to dashboards or korrel8r correlation rules

```release-note
NONE
```

Made with [Cursor](https://cursor.com)