### PR TITLE
fix: Removed the "cleanup" label from DataSource that is owned by SSP

### DIFF
--- a/internal/operands/data-sources/reconcile.go
+++ b/internal/operands/data-sources/reconcile.go
@@ -505,6 +505,7 @@ func getDataSourceInfosMultiArch(sourceCollection template_bundle.DataSourceColl
 }
 
 const dataImportCronLabel = "cdi.kubevirt.io/dataImportCron"
+const dataImportCronCleanupLabel = "cdi.kubevirt.io/dataImportCron.cleanup"
 
 func dataSourceAutoUpdateEnabled(dataSource *cdiv1beta1.DataSource, cronByDataSource map[client.ObjectKey]*cdiv1beta1.DataImportCron, request *common.Request) (bool, error) {
 	objectKey := client.ObjectKeyFromObject(dataSource)
@@ -688,6 +689,7 @@ func reconcileDataSource(dsInfo dataSourceInfo, request *common.Request) (common
 			// Only set app labels if DIC does not exist
 			common.AddAppLabels(request.Instance, operandName, operandComponent, foundRes)
 			delete(foundRes.GetLabels(), dataImportCronLabel)
+			delete(foundRes.GetLabels(), dataImportCronCleanupLabel)
 
 			foundRes.(*cdiv1beta1.DataSource).Spec = newRes.(*cdiv1beta1.DataSource).Spec
 		}).

--- a/internal/operands/data-sources/reconcile_test.go
+++ b/internal/operands/data-sources/reconcile_test.go
@@ -368,6 +368,34 @@ var _ = Describe("Data-Sources operand", func() {
 
 				ExpectResourceExists(&cron, request)
 			})
+
+			It("should remove the cleanup label from DataSource that is not using auto-update", func() {
+				_, err := operand.Reconcile(&request)
+				Expect(err).ToNot(HaveOccurred())
+
+				cron := cronTemplate.AsDataImportCron()
+				cron.Namespace = internal.GoldenImagesNamespace
+				ExpectResourceNotExists(&cron, request)
+
+				// Simulate CDI adding the cleanup label to the DataSource,
+				// after the owning DataImportCron with retentionPolicy "None" was deleted.
+				foundDs := &cdiv1beta1.DataSource{}
+				dsKey := client.ObjectKeyFromObject(testDataSource(centos8))
+				Expect(request.Client.Get(request.Context, dsKey, foundDs)).To(Succeed())
+
+				if foundDs.GetLabels() == nil {
+					foundDs.SetLabels(map[string]string{})
+				}
+				foundDs.GetLabels()[dataImportCronCleanupLabel] = "true"
+
+				Expect(request.Client.Update(request.Context, foundDs)).To(Succeed())
+
+				_, err = operand.Reconcile(&request)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(request.Client.Get(request.Context, dsKey, foundDs)).To(Succeed())
+				Expect(foundDs.GetLabels()).ToNot(HaveKey(dataImportCronCleanupLabel))
+			})
 		})
 
 		It("should keep DataImportCron, if not owned by SSP CR", func() {

--- a/tests/dataSources_test.go
+++ b/tests/dataSources_test.go
@@ -1103,6 +1103,102 @@ var _ = Describe("DataSources", func() {
 				})
 			})
 
+			Context("with DataVolume created after DataImportCron is removed", func() {
+				var dataVolume *cdiv1beta1.DataVolume
+
+				AfterEach(func() {
+					if dataVolume != nil {
+						pvc := &core.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: dataVolume.Name, Namespace: dataVolume.Namespace}}
+						Expect(apiClient.Delete(ctx, dataVolume)).To(Or(Succeed(), MatchError(errors.IsNotFound, "errors.IsNotFound")))
+						Expect(apiClient.Delete(ctx, pvc)).To(Or(Succeed(), MatchError(errors.IsNotFound, "errors.IsNotFound")))
+						waitForDeletion(client.ObjectKeyFromObject(dataVolume), &cdiv1beta1.DataVolume{})
+						waitForDeletion(client.ObjectKeyFromObject(pvc), &core.PersistentVolumeClaim{})
+						dataVolume = nil
+					}
+				})
+
+				It("[test_id:TODO] should create DataImportCron after user enables auto-update on DataSource with cleanup label", func() {
+					// Remove the template. SSP deletes the DataImportCron, but keeps the DataSource it was managing.
+					updateSsp(func(foundSsp *ssp.SSP) {
+						foundSsp.Spec.CommonTemplates.DataImportCronTemplates = nil
+					})
+					waitUntilDeployed()
+
+					// Make sure the DataImportCron is deleted, and DataSource remains.
+					waitForDeletion(dataImportCron.GetKey(), &cdiv1beta1.DataImportCron{})
+					Expect(apiClient.Get(ctx, dataSource.GetKey(), dataSource.NewResource())).To(Succeed(), "DataSource should not have been removed.")
+
+					// Create a new DataVolume, that will be referenced by the DataSource.
+					dataVolume = &cdiv1beta1.DataVolume{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:        dataSourceName,
+							Namespace:   internal.GoldenImagesNamespace,
+							Annotations: commonAnnotations,
+						},
+						Spec: cdiv1beta1.DataVolumeSpec{
+							Source: &cdiv1beta1.DataVolumeSource{
+								Registry: &cdiv1beta1.DataVolumeSourceRegistry{
+									URL:        ptr.To(registryURL),
+									PullMethod: ptr.To(cdiv1beta1.RegistryPullNode),
+								},
+							},
+							Storage: &cdiv1beta1.StorageSpec{
+								Resources: core.VolumeResourceRequirements{
+									Requests: core.ResourceList{
+										core.ResourceStorage: resource.MustParse("128Mi"),
+									},
+								},
+							},
+						},
+					}
+					Expect(apiClient.Create(ctx, dataVolume)).To(Succeed())
+
+					// Wait until DataVolume import is done.
+					Eventually(func(g Gomega) {
+						foundDv := &cdiv1beta1.DataVolume{}
+						getErr := apiClient.Get(ctx, client.ObjectKeyFromObject(dataVolume), foundDv)
+
+						// When DataVolume succeeds importing, CDI may remove it and leave only PVC.
+						if errors.IsNotFound(getErr) {
+							g.Expect(apiClient.Get(ctx, client.ObjectKeyFromObject(dataVolume), &core.PersistentVolumeClaim{})).To(Succeed())
+							return
+						}
+
+						g.Expect(getErr).ToNot(HaveOccurred())
+						g.Expect(foundDv.Status.Phase).To(Equal(cdiv1beta1.Succeeded))
+					}, env.Timeout(), time.Second).Should(Succeed(), "DataVolume should successfully import.")
+
+					// Add DataImportCron template back to SSP.
+					updateSsp(func(foundSsp *ssp.SSP) {
+						foundSsp.Spec.CommonTemplates.DataImportCronTemplates = append(foundSsp.Spec.CommonTemplates.DataImportCronTemplates,
+							cronTemplate,
+						)
+					})
+					waitUntilDeployed()
+
+					// DataImportCron should not be created.
+					err := apiClient.Get(ctx, dataImportCron.GetKey(), dataImportCron.NewResource())
+					Expect(err).To(MatchError(errors.IsNotFound, "errors.IsNotFound"), "DataImportCron should not exist.")
+
+					// Enable auto-update by adding the "cdi.kubevirt.io/dataImportCron=true" label to the DataSource.
+					Eventually(func(g Gomega) error {
+						ds := &cdiv1beta1.DataSource{}
+						g.Expect(apiClient.Get(ctx, dataSource.GetKey(), ds)).To(Succeed())
+
+						if ds.GetLabels() == nil {
+							ds.SetLabels(map[string]string{})
+						}
+						ds.GetLabels()[cdiLabel] = "true"
+
+						return apiClient.Update(ctx, ds)
+					}, env.ShortTimeout(), time.Second).Should(Succeed())
+
+					Eventually(func() error {
+						return apiClient.Get(ctx, dataImportCron.GetKey(), dataImportCron.NewResource())
+					}, env.ShortTimeout(), time.Second).Should(Succeed())
+				})
+			})
+
 			It("[test_id:8296] should restore CDI label on DataSource, if user removes it", decorators.Conformance, func() {
 				Eventually(func(g Gomega) error {
 					ds := &cdiv1beta1.DataSource{}


### PR DESCRIPTION
**What this PR does / why we need it**:
This fixes the following flow:
1. A DataImportCron template with `retentionPolicy` `None` exists in SSP, and SSP has created the DataImportCron.
2. User removes this DataImportCron template, and SSP removes the DataImportCron, but DataSource is not removed.
3. A DataVolume is created for the DataSource created by SSP.
4. Then a DataImportCron template with "retentionPolicy" "None" is added again to the SSP CR. But now DataImportCron is not created, because DataSource points to existing PVC.
5. User wants to enable auto-update for the DataSource, by adding the label "cdi.kubevirt.io/dataImportCron=true" to the DataSource.
6. Then SSP creates the DataImportCron.

Previously, when the "cleanup" label was not removed from the DataSource, step 5. would remove the DataSource, and recreate it. The new object would point to the exiting PVC, and SSP would not create DataImportCron.

**Which issue(s) this PR fixes**: 
Jira: https://redhat.atlassian.net/browse/CNV-86273

**Release note**:
```release-note
None
```
