### PR TITLE
[release-v0.21] chore: Improve logging when tests fail to delete SSP

### DIFF
--- a/tests/cleanup_test.go
+++ b/tests/cleanup_test.go
@@ -8,7 +8,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 
-	ssp "kubevirt.io/ssp-operator/api/v1beta2"
 	"kubevirt.io/ssp-operator/internal/common"
 	"kubevirt.io/ssp-operator/internal/operands"
 	common_instancetypes "kubevirt.io/ssp-operator/internal/operands/common-instancetypes"
@@ -48,7 +47,7 @@ var _ = Describe("Cleanup", func() {
 		sspObj := getSsp()
 
 		Expect(apiClient.Delete(ctx, sspObj)).To(Succeed())
-		waitForDeletionOrAbort(client.ObjectKeyFromObject(sspObj), &ssp.SSP{})
+		waitForSspDeletionOrAbort(sspObj)
 
 		// Check that all deployed resources were deleted
 		for _, watchType := range allWatchTypes {

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -479,30 +479,7 @@ func getTemplateValidatorDeployment() *apps.Deployment {
 }
 
 func waitUntilDeployed() {
-	defer func() {
-		// If the below check fails, output the SSP object to log.
-		// Its .status.conditions can be helpful.
-		if rec := recover(); rec != nil {
-			ssp := &sspv1beta2.SSP{}
-			err := apiClient.Get(ctx, client.ObjectKey{
-				Name:      strategy.GetName(),
-				Namespace: strategy.GetNamespace(),
-			}, ssp)
-			if err != nil {
-				_, _ = fmt.Fprintf(GinkgoWriter, "Could not get SSP object: %s\n", err.Error())
-				panic(rec)
-			}
-
-			sspJson, err := json.MarshalIndent(ssp, "", "    ")
-			if err != nil {
-				_, _ = fmt.Fprintf(GinkgoWriter, "Could not convert SSP to JSON: %s\n", err.Error())
-				panic(rec)
-			}
-
-			_, _ = fmt.Fprintf(GinkgoWriter, "SSP object:\n%s\n", sspJson)
-			panic(rec)
-		}
-	}()
+	defer logSSPPanicHandler()
 
 	// If SSP will not be in "deployed" state in 10 minutes, we want to abort the whole test suite.
 	NewGomega(AbortSuite).EventuallyWithOffset(1, func(g Gomega) {
@@ -518,14 +495,18 @@ func waitForDeletion(key client.ObjectKey, obj client.Object) {
 	}, env.Timeout(), time.Second).Should(MatchError(errors.IsNotFound, "errors.IsNotFound"))
 }
 
-// waitForDeletionOrAbort aborts the whole test suite if object is not deleted in env.Timeout time.
-func waitForDeletionOrAbort(key client.ObjectKey, obj client.Object) {
+// waitForSspDeletionOrAbort aborts the whole test suite if object is not deleted in env.Timeout time.
+func waitForSspDeletionOrAbort(sspObj *sspv1beta2.SSP) {
+	defer logSSPPanicHandler()
+
+	key := client.ObjectKey{Name: sspObj.Name, Namespace: sspObj.Namespace}
 	NewGomega(AbortSuite).EventuallyWithOffset(1, func() error {
-		return apiClient.Get(ctx, key, obj)
+		return apiClient.Get(ctx, key, &sspv1beta2.SSP{})
 	}, env.Timeout(), time.Second).Should(MatchError(errors.IsNotFound, "errors.IsNotFound"))
 }
 
 func waitForSspDeletionIfNeeded(sspObj *sspv1beta2.SSP) {
+	defer logSSPPanicHandler()
 	key := client.ObjectKey{Name: sspObj.Name, Namespace: sspObj.Namespace}
 	NewGomega(AbortSuite).Eventually(func() error {
 		foundSsp := &sspv1beta2.SSP{}
@@ -541,6 +522,35 @@ func waitForSspDeletionIfNeeded(sspObj *sspv1beta2.SSP) {
 		}
 		return nil
 	}, env.Timeout(), time.Second).ShouldNot(HaveOccurred())
+}
+
+func logSSPPanicHandler() {
+	// If the below check fails, output the SSP object to log.
+	// Its .status.conditions can be helpful.
+
+	rec := recover()
+	if rec == nil {
+		return
+	}
+
+	ssp := &sspv1beta2.SSP{}
+	err := apiClient.Get(ctx, client.ObjectKey{
+		Name:      strategy.GetName(),
+		Namespace: strategy.GetNamespace(),
+	}, ssp)
+	if err != nil {
+		_, _ = fmt.Fprintf(GinkgoWriter, "Could not get SSP object: %s\n", err.Error())
+		panic(rec)
+	}
+
+	sspJson, err := json.MarshalIndent(ssp, "", "    ")
+	if err != nil {
+		_, _ = fmt.Fprintf(GinkgoWriter, "Could not convert SSP to JSON: %s\n", err.Error())
+		panic(rec)
+	}
+
+	_, _ = fmt.Fprintf(GinkgoWriter, "SSP object:\n%s\n", sspJson)
+	panic(rec)
 }
 
 func validateDeploymentExists() {


### PR DESCRIPTION
This is a manual backport of: https://github.com/kubevirt/ssp-operator/pull/1845

**What this PR does / why we need it**:
Sometimes a test fails when waiting for SSP to be deleted, but then before the test lane exists, the SSP deletion succeeds, and we don't see the failure reason in the must-gather archive.

This changes prints the SSP object into the log in this case.

**Which issue(s) this PR fixes**: 
Jira: https://redhat.atlassian.net/issues?selectedIssue=CNV-89022


**Release note**:
```release-note
None
```
