### PR TITLE
tests: Use Eventually when waiting for metric increase

### DIFF
--- a/tests/commonTemplates_test.go
+++ b/tests/commonTemplates_test.go
@@ -474,7 +474,11 @@ func expectTemplateUpdateToIncreaseTotalRestoredTemplatesCount(testTemplate test
 
 	expectRestoreAfterUpdate(&testTemplate)
 
-	restoredCountAfter, err := totalRestoredTemplatesCount()
-	Expect(err).ToNot(HaveOccurred())
-	Expect(restoredCountAfter - restoredCountBefore).To(Equal(1))
+	// There can be a race when the template has already been updated in API server,
+	// but the metric endpoint was not yet updated.
+	Eventually(func(g Gomega) {
+		restoredCountAfter, err := totalRestoredTemplatesCount()
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(restoredCountAfter).To(BeNumerically(">", restoredCountBefore))
+	}, env.ShortTimeout(), time.Second).Should(Succeed())
 }


### PR DESCRIPTION

**What this PR does / why we need it**:
Using Eventually() to wait for increase of metric `kubevirt_ssp_common_templates_restored_total`.

There is a race, when the template in the API server is restored before the metric is updated.

**Which issue(s) this PR fixes**: 
Jira: https://redhat.atlassian.net/browse/CNV-94083

**Release note**:
```release-note
None
```
