### PR TITLE
tests: Retry VM creation if template validator webhook is not reachable

### DIFF
--- a/tests/misc_test.go
+++ b/tests/misc_test.go
@@ -446,7 +446,7 @@ var _ = Describe("RHEL VM creation", func() {
 			},
 		}
 
-		Expect(apiClient.Create(ctx, vm)).To(Succeed())
+		createVmWithWebhookRetry(vm)
 
 		// Wait for DataVolume to finish importing
 		dvName := vm.Spec.DataVolumeTemplates[0].Name

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -506,6 +506,22 @@ func waitUntilDeployed() {
 	}, env.Timeout(), time.Second).Should(Succeed())
 }
 
+// createVmWithWebhookRetry tries to create the VM, and retires if the webhook is not reachable.
+// Webhook may not be reachable for a short time during running tests, when template-validator pods
+// are recreated.
+func createVmWithWebhookRetry(vm *kubevirtv1.VirtualMachine, createOpts ...client.CreateOption) {
+	EventuallyWithOffset(1, func() error {
+		err := apiClient.Create(ctx, vm, createOpts...)
+		// When the API server can't reach a webhook, it returns InternalError.
+		if errors.IsInternalError(err) {
+			return err
+		}
+		// Intentionally using Expect() in Eventually() to fail the whole loop.
+		Expect(err).ToNot(HaveOccurred(), "Failed to create VM: %s", vm.Name)
+		return nil
+	}, env.ShortTimeout(), time.Second).Should(Succeed())
+}
+
 func waitForDeletion(key client.ObjectKey, obj client.Object) {
 	EventuallyWithOffset(1, func() error {
 		return apiClient.Get(ctx, key, obj)

--- a/tests/validator_test.go
+++ b/tests/validator_test.go
@@ -515,7 +515,7 @@ var _ = Describe("Template validator webhooks", func() {
 	Context("Validation defined on template", func() {
 		It("[test_id:5584]should create VM without template", func() {
 			vm = NewVirtualMachine(vmi)
-			Expect(apiClient.Create(ctx, vm)).ToNot(HaveOccurred(), "Failed to create VM")
+			createVmWithWebhookRetry(vm)
 		})
 
 		It("[test_id:TODO] should create VM if template does not exist", func() {
@@ -524,7 +524,7 @@ var _ = Describe("Template validator webhooks", func() {
 				TemplateNameAnnotation:      "non-existing-template",
 				TemplateNamespaceAnnotation: strategy.GetNamespace(),
 			}
-			Expect(apiClient.Create(ctx, vm, client.DryRunAll)).To(Succeed())
+			createVmWithWebhookRetry(vm, client.DryRunAll)
 		})
 
 		It("[test_id:5585]be created from template with no rules", decorators.Conformance, func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
Sometimes during test runs, the webhook may be unreachable for a short time. This can happen when a previous test has recreated the validator pods.


**Which issue(s) this PR fixes**: 
Jira: https://redhat.atlassian.net/browse/CNV-94356

**Release note**:
```release-note
None
```
