### PR TITLE
[release-v0.22] tests: Use Eventually when waiting for metric increase

### DIFF
--- a/tests/commonTemplates_test.go
+++ b/tests/commonTemplates_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -357,5 +358,9 @@ var _ = Describe("Common templates", func() {
 func expectTemplateUpdateToIncreaseTotalRestoredTemplatesCount(testTemplate testResource) {
 	restoredCountBefore := totalRestoredTemplatesCount()
 	expectRestoreAfterUpdate(&testTemplate)
-	Expect(totalRestoredTemplatesCount() - restoredCountBefore).To(Equal(1))
+
+	// There can be a race when the template has already been updated in API server,
+	// but the metric endpoint was not yet updated.
+	Eventually(totalRestoredTemplatesCount, env.ShortTimeout(), time.Second).
+		Should(BeNumerically(">", restoredCountBefore))
 }


### PR DESCRIPTION
Manual cherry-pick of: https://github.com/kubevirt/ssp-operator/pull/1901

**What this PR does / why we need it**:
Using Eventually() to wait for increase of metric `kubevirt_ssp_common_templates_restored_total`.

There is a race, when the template in the API server is restored before the metric is updated.

**Which issue(s) this PR fixes**: 
Jira: https://redhat.atlassian.net/browse/CNV-94083

**Release note**:
```release-note
None
```
