### PR TITLE
tests: fix flaky network policy restore-with-pause tests

### DIFF
--- a/tests/validator_test.go
+++ b/tests/validator_test.go
@@ -59,7 +59,10 @@ func testNetworkPolicyResource(name, namespace string, expectedLabels map[string
 		Resource:       &networkv1.NetworkPolicy{},
 		ExpectedLabels: expectedLabels,
 		UpdateFunc: func(policy *networkv1.NetworkPolicy) {
-			policy.Spec.PodSelector = metav1.LabelSelector{}
+			if policy.Spec.PodSelector.MatchLabels == nil {
+				policy.Spec.PodSelector.MatchLabels = map[string]string{}
+			}
+			policy.Spec.PodSelector.MatchLabels["ssp.kubevirt.io/test-mutated"] = "true"
 		},
 		EqualsFunc: func(old *networkv1.NetworkPolicy, new *networkv1.NetworkPolicy) bool {
 			return reflect.DeepEqual(old.Spec, new.Spec)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The `testNetworkPolicyResource` helper used in the functional test suite had an `UpdateFunc` that replaced the `NetworkPolicy` `PodSelector` with an empty `metav1.LabelSelector{}`. An empty `PodSelector` matches all pods in the namespace, including the ssp-operator pod itself.

Since that policy only permitted port 8768, the ssp-operator's validating webhook on port 9443 became unreachable while the SSP CR was paused for the test

Because unpausing requires an Update on the SSP CR, which must pass through that very webhook, a deadlock occurred

This fix changes the mutation to add an extra MatchLabels requirement of `ssp.kubevirt.io/test-mutated`, and since no real pod in the cluster has that label, the modified selector now matches zero pods instead of all pods.

**Which issue(s) this PR fixes**: 
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

Fixes #

**Special notes for your reviewer**:
The test's purpose is to verify the SSP operator detects and restores drift on a managed resource. For that to work, the EqualsFunc just needs to see a difference between the original spec and the mutated spec, the selection of pods has no effect on this test.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
